### PR TITLE
ci: release drafter only runs when all CI workflows pass

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,10 @@
 name: Release Drafter
 
 on:
-  push:
+  workflow_run:
+    workflows: ["Go", "Test & Lint", "HACS Validation", "Hassfest"]
     branches: [main]
+    types: [completed]
 
 permissions:
   contents: read
@@ -15,6 +17,31 @@ jobs:
       contents: write
       pull-requests: read
     steps:
-      - uses: release-drafter/release-drafter@v6
+      - name: Check all required workflows passed
+        id: check
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const required = ['Go', 'Test & Lint', 'HACS Validation', 'Hassfest'];
+            const sha = context.payload.workflow_run.head_sha;
+            const { data } = await github.rest.actions.listWorkflowRunsForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              head_sha: sha,
+              per_page: 100,
+            });
+            const allPassed = required.every(name => {
+              const runs = data.workflow_runs
+                .filter(r => r.name === name)
+                .sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
+              return runs.length > 0 && runs[0].conclusion === 'success';
+            });
+            core.info(`SHA ${sha}: all required workflows passed = ${allPassed}`);
+            return allPassed;
+          result-encoding: string
+
+      - name: Draft release
+        if: steps.check.outputs.result == 'true'
+        uses: release-drafter/release-drafter@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Ändert den Trigger von `push: branches: [main]` auf `workflow_run`.

**Vorher:** Release Drafter lief bei jedem Push auf main — unabhängig vom CI-Ergebnis.

**Nachher:** Wird durch den Abschluss von Go, Test & Lint, HACS Validation oder Hassfest ausgelöst. Ein `github-script`-Schritt prüft via API, ob **alle vier** Workflows für denselben Commit-SHA erfolgreich waren. Nur dann läuft `release-drafter/release-drafter`.