### PR TITLE
ci: restore hacs and hassfest as separate required workflow files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,9 +79,14 @@ jobs:
       needs.test.result == 'success'
     runs-on: ubuntu-latest
     permissions:
+      actions: read
       contents: write
       pull-requests: read
     steps:
+      - name: Wait for HACS and Hassfest workflows
+        uses: int128/wait-for-workflows-action@v1
+        with:
+          filter-workflow-name: "HACS,Hassfest"
       - uses: release-drafter/release-drafter@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,22 +66,8 @@ jobs:
       - name: Run tests with coverage
         run: PYTHONPATH=. pytest --cov --cov-report=term-missing -v
 
-  hacs:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: hacs/action@main
-        with:
-          category: integration
-
-  hassfest:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: home-assistant/actions/hassfest@master
-
   release-draft:
-    needs: [go, docker, test, hacs, hassfest]
+    needs: [go, docker, test]
     # Runs exactly once on push to main, only when all quality gates pass.
     # Go and docker may be skipped (no Go files changed) — that is acceptable.
     if: |
@@ -90,9 +76,7 @@ jobs:
       github.ref == 'refs/heads/main' &&
       (needs.go.result == 'success' || needs.go.result == 'skipped') &&
       (needs.docker.result == 'success' || needs.docker.result == 'skipped') &&
-      needs.test.result == 'success' &&
-      needs.hacs.result == 'success' &&
-      needs.hassfest.result == 'success'
+      needs.test.result == 'success'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/hacs.yml
+++ b/.github/workflows/hacs.yml
@@ -1,0 +1,16 @@
+name: HACS
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  hacs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: hacs/action@main
+        with:
+          category: integration

--- a/.github/workflows/hassfest.yml
+++ b/.github/workflows/hassfest.yml
@@ -1,0 +1,14 @@
+name: Hassfest
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  hassfest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: home-assistant/actions/hassfest@master


### PR DESCRIPTION
## Summary
- Extract `hacs` and `hassfest` jobs from `ci.yml` back into separate `hacs.yml` and `hassfest.yml` workflow files, as prescribed by HACS/HA contribution guidelines
- `release-draft` in `ci.yml` now depends only on `go`, `docker`, and `test`