### PR TITLE
feat: port bug fixes and energy sensors from community forks

### DIFF
--- a/custom_components/eebus/binary_sensor.py
+++ b/custom_components/eebus/binary_sensor.py
@@ -77,5 +77,8 @@ class EebusHeartbeatOkSensor(EebusEntity, BinarySensorEntity):
         hb = self.coordinator.data.get("heartbeat_status")
         if hb is None:
             return None
+        within_duration = hb.get("within_duration")
+        if within_duration is None:
+            return None
         # PROBLEM class: is_on=True means there's a problem
-        return not hb.get("within_duration", True)
+        return not within_duration

--- a/custom_components/eebus/config_flow.py
+++ b/custom_components/eebus/config_flow.py
@@ -56,15 +56,21 @@ class EebusConfigFlow(ConfigFlow, domain=DOMAIN):
             self._host = user_input[CONF_GRPC_HOST]
             self._port = user_input[CONF_GRPC_PORT]
 
+            channel = grpc.aio.insecure_channel(f"{self._host}:{self._port}")
             try:
-                channel = grpc.aio.insecure_channel(f"{self._host}:{self._port}")
                 from . import proto_stubs
                 stub = proto_stubs.DeviceServiceStub(channel)
                 await stub.GetStatus(proto_stubs.Empty())
-                await channel.close()
                 return await self.async_step_device()
             except Exception:
+                _LOGGER.exception(
+                    "Failed to connect to EEBUS bridge at %s:%s",
+                    self._host,
+                    self._port,
+                )
                 errors["base"] = "cannot_connect"
+            finally:
+                await channel.close()
 
         return self.async_show_form(
             step_id="user",
@@ -102,15 +108,13 @@ class EebusConfigFlow(ConfigFlow, domain=DOMAIN):
         errors: dict[str, str] = {}
 
         if user_input is not None:
+            channel = grpc.aio.insecure_channel(
+                f"{user_input[CONF_GRPC_HOST]}:{user_input[CONF_GRPC_PORT]}"
+            )
             try:
-                channel = grpc.aio.insecure_channel(
-                    f"{user_input[CONF_GRPC_HOST]}:{user_input[CONF_GRPC_PORT]}"
-                )
                 from . import proto_stubs
                 stub = proto_stubs.DeviceServiceStub(channel)
                 await stub.GetStatus(proto_stubs.Empty())
-                await channel.close()
-
                 return self.async_update_reload_and_abort(
                     self._get_reconfigure_entry(),
                     data_updates={
@@ -119,7 +123,14 @@ class EebusConfigFlow(ConfigFlow, domain=DOMAIN):
                     },
                 )
             except Exception:
+                _LOGGER.exception(
+                    "Failed to connect to EEBUS bridge during reconfigure at %s:%s",
+                    user_input[CONF_GRPC_HOST],
+                    user_input[CONF_GRPC_PORT],
+                )
                 errors["base"] = "cannot_connect"
+            finally:
+                await channel.close()
 
         entry = self._get_reconfigure_entry()
         return self.async_show_form(

--- a/custom_components/eebus/coordinator.py
+++ b/custom_components/eebus/coordinator.py
@@ -16,6 +16,15 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 _LOGGER = logging.getLogger(__name__)
 
 POLL_INTERVAL = timedelta(seconds=30)
+RPC_TIMEOUT = 10
+
+
+def _is_unimplemented(err: grpc.aio.AioRpcError) -> bool:
+    return err.code() == grpc.StatusCode.UNIMPLEMENTED
+
+
+def _rpc_error_text(err: grpc.aio.AioRpcError) -> str:
+    return f"code={err.code().name} details={err.details()}"
 
 
 class EebusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
@@ -41,6 +50,8 @@ class EebusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self._channel: grpc.aio.Channel | None = None
         self._stream_tasks: list[asyncio.Task] = []
         self._was_unavailable: bool = False
+        self._lpc_supported: bool | None = None
+        self._failsafe_supported: bool | None = None
 
     async def _ensure_channel(self) -> grpc.aio.Channel:
         """Create or return existing gRPC channel."""
@@ -60,35 +71,61 @@ class EebusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             data: dict[str, Any] = {
                 "connected": status.running,
                 "local_ski": status.local_ski,
+                "lpc_supported": self._lpc_supported,
+                "failsafe_supported": self._failsafe_supported,
             }
 
+            request = proto_stubs.DeviceRequest(ski=self.ski)
+            monitoring_stub = proto_stubs.MonitoringServiceStub(channel)
+            lpc_stub = proto_stubs.LPCServiceStub(channel)
+
             try:
-                monitoring_stub = proto_stubs.MonitoringServiceStub(channel)
-                power = await monitoring_stub.GetPowerConsumption(
-                    proto_stubs.DeviceRequest(ski=self.ski)
-                )
+                power = await monitoring_stub.GetPowerConsumption(request, timeout=RPC_TIMEOUT)
                 data["power_watts"] = power.watts
             except grpc.aio.AioRpcError:
                 data["power_watts"] = None
 
             try:
-                lpc_stub = proto_stubs.LPCServiceStub(channel)
-                limit = await lpc_stub.GetConsumptionLimit(
-                    proto_stubs.DeviceRequest(ski=self.ski)
-                )
+                energy = await monitoring_stub.GetEnergyConsumed(request, timeout=RPC_TIMEOUT)
+                data["energy_consumed_kwh"] = energy.kilowatt_hours
+            except grpc.aio.AioRpcError:
+                data["energy_consumed_kwh"] = None
+
+            try:
+                mlist = await monitoring_stub.GetMeasurements(request, timeout=RPC_TIMEOUT)
+                scoped = self._extract_scoped_energy_kwh(mlist.measurements)
+                data["energy_consumed_heating_kwh"] = scoped["heating"]
+                data["energy_consumed_dhw_kwh"] = scoped["dhw"]
+            except grpc.aio.AioRpcError:
+                data["energy_consumed_heating_kwh"] = None
+                data["energy_consumed_dhw_kwh"] = None
+
+            try:
+                limit = await lpc_stub.GetConsumptionLimit(request, timeout=RPC_TIMEOUT)
                 data["consumption_limit"] = {
                     "value_watts": limit.value_watts,
                     "is_active": limit.is_active,
                     "is_changeable": limit.is_changeable,
                 }
-            except grpc.aio.AioRpcError:
+                self._lpc_supported = True
+            except grpc.aio.AioRpcError as err:
                 data["consumption_limit"] = None
+                if _is_unimplemented(err):
+                    self._lpc_supported = False
+                    _LOGGER.debug("LPC not supported by device %s: %s", self.ski, _rpc_error_text(err))
 
             try:
-                lpc_stub = proto_stubs.LPCServiceStub(channel)
-                hb = await lpc_stub.GetHeartbeatStatus(
-                    proto_stubs.DeviceRequest(ski=self.ski)
-                )
+                failsafe = await lpc_stub.GetFailsafeLimit(request, timeout=RPC_TIMEOUT)
+                data["failsafe_limit"] = {"value_watts": failsafe.value_watts}
+                self._failsafe_supported = True
+            except grpc.aio.AioRpcError as err:
+                data["failsafe_limit"] = None
+                if _is_unimplemented(err):
+                    self._failsafe_supported = False
+                    _LOGGER.debug("Failsafe not supported by device %s: %s", self.ski, _rpc_error_text(err))
+
+            try:
+                hb = await lpc_stub.GetHeartbeatStatus(request, timeout=RPC_TIMEOUT)
                 data["heartbeat_status"] = {
                     "running": hb.running,
                     "within_duration": hb.within_duration,
@@ -113,6 +150,23 @@ class EebusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 self._was_unavailable = True
 
             raise UpdateFailed(f"gRPC error: {err}") from err
+
+    @staticmethod
+    def _extract_scoped_energy_kwh(measurements: list[Any]) -> dict[str, float | None]:
+        """Extract scoped energy counters for heating and domestic hot water from MeasurementEntry list."""
+        result: dict[str, float | None] = {"heating": None, "dhw": None}
+        for m in measurements:
+            mtype = str(getattr(m, "type", "")).lower().strip().replace("-", "_").replace(" ", "_")
+            if not mtype:
+                continue
+            value = getattr(m, "value", None)
+            if value is None:
+                continue
+            if "energy" in mtype and ("domestic_hot_water" in mtype or "hot_water" in mtype or "dhw" in mtype):
+                result["dhw"] = value
+            elif "energy" in mtype and ("heating" in mtype or "space_heating" in mtype):
+                result["heating"] = value
+        return result
 
     async def async_write_lpc_limit(self, value_watts: float) -> None:
         """Write LPC consumption limit via gRPC."""

--- a/custom_components/eebus/icons.json
+++ b/custom_components/eebus/icons.json
@@ -2,6 +2,9 @@
   "entity": {
     "sensor": {
       "power_consumption": { "default": "mdi:flash" },
+      "energy_consumed": { "default": "mdi:lightning-bolt" },
+      "energy_consumed_heating": { "default": "mdi:radiator" },
+      "energy_consumed_dhw": { "default": "mdi:water-boiler" },
       "consumption_limit": { "default": "mdi:speedometer" }
     },
     "number": {

--- a/custom_components/eebus/number.py
+++ b/custom_components/eebus/number.py
@@ -57,6 +57,15 @@ class EebusLPCLimitNumber(EebusEntity, NumberEntity):
             return None
         return limit.get("value_watts")
 
+    @property
+    def available(self) -> bool:
+        """Disable entity when LPC is known to be unsupported."""
+        if not super().available:
+            return False
+        if self.coordinator.data is None:
+            return False
+        return self.coordinator.data.get("lpc_supported") is not False
+
     async def async_set_native_value(self, value: float) -> None:
         """Set new LPC limit via gRPC."""
         await self.coordinator.async_write_lpc_limit(value)
@@ -93,6 +102,15 @@ class EebusFailsafeLimitNumber(EebusEntity, NumberEntity):
         if failsafe is None:
             return None
         return failsafe.get("value_watts")
+
+    @property
+    def available(self) -> bool:
+        """Disable entity when failsafe is known to be unsupported."""
+        if not super().available:
+            return False
+        if self.coordinator.data is None:
+            return False
+        return self.coordinator.data.get("failsafe_supported") is not False
 
     async def async_set_native_value(self, value: float) -> None:
         """Set new failsafe limit via gRPC."""

--- a/custom_components/eebus/sensor.py
+++ b/custom_components/eebus/sensor.py
@@ -8,7 +8,7 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import EntityCategory, UnitOfPower
+from homeassistant.const import EntityCategory, UnitOfEnergy, UnitOfPower
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -25,6 +25,9 @@ async def async_setup_entry(
     coordinator: EebusCoordinator = entry.runtime_data
     async_add_entities([
         EebusPowerSensor(coordinator),
+        EebusEnergyConsumedSensor(coordinator),
+        EebusEnergyConsumedHeatingSensor(coordinator),
+        EebusEnergyConsumedDhwSensor(coordinator),
         EebusConsumptionLimitSensor(coordinator),
     ])
 
@@ -48,6 +51,69 @@ class EebusPowerSensor(EebusEntity, SensorEntity):
         if self.coordinator.data is None:
             return None
         return self.coordinator.data.get("power_watts")
+
+
+class EebusEnergyConsumedSensor(EebusEntity, SensorEntity):
+    """Sensor for cumulative consumed energy."""
+
+    _attr_device_class = SensorDeviceClass.ENERGY
+    _attr_native_unit_of_measurement = UnitOfEnergy.KILO_WATT_HOUR
+    _attr_state_class = SensorStateClass.TOTAL_INCREASING
+    _attr_translation_key = "energy_consumed"
+
+    def __init__(self, coordinator: EebusCoordinator) -> None:
+        """Initialize."""
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{coordinator.ski}_energy_consumed"
+
+    @property
+    def native_value(self) -> float | None:
+        """Return consumed energy in kWh."""
+        if self.coordinator.data is None:
+            return None
+        return self.coordinator.data.get("energy_consumed_kwh")
+
+
+class EebusEnergyConsumedHeatingSensor(EebusEntity, SensorEntity):
+    """Sensor for cumulative consumed energy for space heating."""
+
+    _attr_device_class = SensorDeviceClass.ENERGY
+    _attr_native_unit_of_measurement = UnitOfEnergy.KILO_WATT_HOUR
+    _attr_state_class = SensorStateClass.TOTAL_INCREASING
+    _attr_translation_key = "energy_consumed_heating"
+
+    def __init__(self, coordinator: EebusCoordinator) -> None:
+        """Initialize."""
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{coordinator.ski}_energy_consumed_heating"
+
+    @property
+    def native_value(self) -> float | None:
+        """Return consumed heating energy in kWh."""
+        if self.coordinator.data is None:
+            return None
+        return self.coordinator.data.get("energy_consumed_heating_kwh")
+
+
+class EebusEnergyConsumedDhwSensor(EebusEntity, SensorEntity):
+    """Sensor for cumulative consumed energy for domestic hot water."""
+
+    _attr_device_class = SensorDeviceClass.ENERGY
+    _attr_native_unit_of_measurement = UnitOfEnergy.KILO_WATT_HOUR
+    _attr_state_class = SensorStateClass.TOTAL_INCREASING
+    _attr_translation_key = "energy_consumed_dhw"
+
+    def __init__(self, coordinator: EebusCoordinator) -> None:
+        """Initialize."""
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{coordinator.ski}_energy_consumed_dhw"
+
+    @property
+    def native_value(self) -> float | None:
+        """Return consumed DHW energy in kWh."""
+        if self.coordinator.data is None:
+            return None
+        return self.coordinator.data.get("energy_consumed_dhw_kwh")
 
 
 class EebusConsumptionLimitSensor(EebusEntity, SensorEntity):

--- a/custom_components/eebus/strings.json
+++ b/custom_components/eebus/strings.json
@@ -43,6 +43,9 @@
   "entity": {
     "sensor": {
       "power_consumption": { "name": "Power Consumption" },
+      "energy_consumed": { "name": "Energy Consumed" },
+      "energy_consumed_heating": { "name": "Energy Consumed Heating" },
+      "energy_consumed_dhw": { "name": "Energy Consumed Domestic Hot Water" },
       "consumption_limit": { "name": "Consumption Limit" }
     },
     "number": {

--- a/custom_components/eebus/translations/de.json
+++ b/custom_components/eebus/translations/de.json
@@ -43,6 +43,9 @@
   "entity": {
     "sensor": {
       "power_consumption": { "name": "Leistungsaufnahme" },
+      "energy_consumed": { "name": "Energieverbrauch" },
+      "energy_consumed_heating": { "name": "Energieverbrauch Heizung" },
+      "energy_consumed_dhw": { "name": "Energieverbrauch Warmwasser" },
       "consumption_limit": { "name": "Leistungslimit" }
     },
     "number": {

--- a/custom_components/eebus/translations/en.json
+++ b/custom_components/eebus/translations/en.json
@@ -43,6 +43,9 @@
   "entity": {
     "sensor": {
       "power_consumption": { "name": "Power Consumption" },
+      "energy_consumed": { "name": "Energy Consumed" },
+      "energy_consumed_heating": { "name": "Energy Consumed Heating" },
+      "energy_consumed_dhw": { "name": "Energy Consumed Domestic Hot Water" },
       "consumption_limit": { "name": "Consumption Limit" }
     },
     "number": {

--- a/eebus-bridge/cmd/eebus-bridge/main.go
+++ b/eebus-bridge/cmd/eebus-bridge/main.go
@@ -54,8 +54,14 @@ func main() {
 	}
 
 	localEntity := bridgeSvc.LocalEntity()
+	if localEntity == nil {
+		log.Fatal("local CEM entity is not available")
+	}
 	lpcWrapper.Setup(localEntity)
 	monitoringWrapper.Setup(localEntity)
+	bridgeSvc.Service().AddUseCase(lpcWrapper.UseCase())
+	bridgeSvc.Service().AddUseCase(monitoringWrapper.UseCase())
+	log.Println("Registered EEBUS use cases: LPC, Monitoring")
 
 	grpcSrv := bridgegrpc.NewServer(cfg.GRPC.Port)
 


### PR DESCRIPTION
## Summary

Reviewed two community forks ([nkashyap](https://github.com/nkashyap/eebus-ha-bridge) and [mathiasbl](https://github.com/mathiasbl/eebus-ha-bridge)) and ported all non-Vaillant-specific improvements.

### Critical fix — Go bridge
- **`AddUseCase()` missing for LPC and Monitoring** (`eebus-bridge/cmd/eebus-bridge/main.go`): SPINE features (LoadControl, DeviceDiagnosis client/server) were never registered on the local entity, and use cases were never announced in node management. Remote devices could not negotiate LPC/MPC, so no consumption or monitoring data was ever exchanged. Added `Service().AddUseCase()` calls after `Setup()`. Added nil guard on `LocalEntity()`.

### Bug fixes — Python integration
- **gRPC channel leak on connect failure** (`config_flow.py`): `channel.close()` was only called on the success path in both `async_step_user` and `async_step_reconfigure`. Moved to `finally` block. Added `_LOGGER.exception` so failures appear in HA logs.
- **Heartbeat sensor wrong state when `within_duration` absent** (`binary_sensor.py`): `hb.get("within_duration", True)` returned `False` (no problem) when the field was missing. Changed to explicit `None` check → returns `None` (unavailable).
- **Failsafe limit entity always `None`** (`coordinator.py`): `EebusFailsafeLimitNumber` read `data["failsafe_limit"]` but the coordinator never fetched it. Added `GetFailsafeLimit` gRPC call.

### New feature — Energy sensors
- **Three new `TOTAL_INCREASING` kWh sensors** (`sensor.py`): Energy Consumed (total), Energy Consumed Heating, Energy Consumed Domestic Hot Water — populated via `GetEnergyConsumed` and `GetMeasurements` + scope-type string matching.
- **LPC/failsafe entities hide on unsupported devices** (`number.py`): `available` property checks `lpc_supported` / `failsafe_supported` flags set by the coordinator when the bridge returns `UNIMPLEMENTED`.
- Translations (en/de), icons, and strings updated for all new sensors.

## Test plan

- [ ] CI passes (HACS, Hassfest, pytest, Go tests)
- [ ] Energy sensors appear in HA after install (may show unavailable until bridge confirms support)
- [ ] LPC/failsafe number entities hide correctly on devices that return UNIMPLEMENTED
- [ ] Config flow connect failure no longer leaks gRPC channel (check HA logs for exception lines)
- [ ] Heartbeat sensor shows unavailable (not "no problem") when `within_duration` not yet reported