### PR TITLE
feat: wire gRPC services to real EEBUS data via DeviceRegistry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.12", "3.13"]
+        python-version: ["3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0

--- a/custom_components/eebus/config_flow.py
+++ b/custom_components/eebus/config_flow.py
@@ -21,6 +21,8 @@ from .const import (
 
 _LOGGER = logging.getLogger(__name__)
 
+CONFIG_RPC_TIMEOUT = 8
+
 STEP_USER_DATA_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_GRPC_HOST): str,
@@ -60,11 +62,11 @@ class EebusConfigFlow(ConfigFlow, domain=DOMAIN):
             try:
                 from . import proto_stubs
                 stub = proto_stubs.DeviceServiceStub(channel)
-                await stub.GetStatus(proto_stubs.Empty())
+                await stub.GetStatus(proto_stubs.Empty(), timeout=CONFIG_RPC_TIMEOUT)
                 return await self.async_step_device()
             except Exception:
                 _LOGGER.exception(
-                    "Failed to connect to EEBUS bridge at %s:%s",
+                    "Failed to connect to EEBUS bridge during config flow at %s:%s",
                     self._host,
                     self._port,
                 )
@@ -114,7 +116,7 @@ class EebusConfigFlow(ConfigFlow, domain=DOMAIN):
             try:
                 from . import proto_stubs
                 stub = proto_stubs.DeviceServiceStub(channel)
-                await stub.GetStatus(proto_stubs.Empty())
+                await stub.GetStatus(proto_stubs.Empty(), timeout=CONFIG_RPC_TIMEOUT)
                 return self.async_update_reload_and_abort(
                     self._get_reconfigure_entry(),
                     data_updates={

--- a/custom_components/eebus/coordinator.py
+++ b/custom_components/eebus/coordinator.py
@@ -17,13 +17,21 @@ _LOGGER = logging.getLogger(__name__)
 
 POLL_INTERVAL = timedelta(seconds=30)
 RPC_TIMEOUT = 10
+RE_REGISTER_NOT_FOUND_STREAK = 4
 
 
 def _is_unimplemented(err: grpc.aio.AioRpcError) -> bool:
+    """Return True when gRPC reports method/use case is not implemented."""
     return err.code() == grpc.StatusCode.UNIMPLEMENTED
 
 
+def _is_not_found(err: grpc.aio.AioRpcError) -> bool:
+    """Return True when gRPC reports missing entity/data for requested SKI."""
+    return err.code() == grpc.StatusCode.NOT_FOUND
+
+
 def _rpc_error_text(err: grpc.aio.AioRpcError) -> str:
+    """Build compact debug output for gRPC errors."""
     return f"code={err.code().name} details={err.details()}"
 
 
@@ -50,8 +58,11 @@ class EebusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self._channel: grpc.aio.Channel | None = None
         self._stream_tasks: list[asyncio.Task] = []
         self._was_unavailable: bool = False
+        self._heartbeat_supported: bool | None = None
         self._lpc_supported: bool | None = None
         self._failsafe_supported: bool | None = None
+        self._ski_registered: bool = False
+        self._not_found_streak: int = 0
 
     async def _ensure_channel(self) -> grpc.aio.Channel:
         """Create or return existing gRPC channel."""
@@ -68,70 +79,368 @@ class EebusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             device_stub = proto_stubs.DeviceServiceStub(channel)
             status = await device_stub.GetStatus(proto_stubs.Empty())
 
+            if not self._ski_registered:
+                await self._async_register_remote_ski(device_stub, proto_stubs, force=False)
+
             data: dict[str, Any] = {
                 "connected": status.running,
                 "local_ski": status.local_ski,
-                "lpc_supported": self._lpc_supported,
-                "failsafe_supported": self._failsafe_supported,
+                "ski_registered": self._ski_registered,
             }
+            if self.ski == status.local_ski:
+                _LOGGER.warning(
+                    "Configured remote SKI %s matches bridge local SKI; monitoring reads will stay empty",
+                    self.ski,
+                )
 
-            request = proto_stubs.DeviceRequest(ski=self.ski)
             monitoring_stub = proto_stubs.MonitoringServiceStub(channel)
-            lpc_stub = proto_stubs.LPCServiceStub(channel)
+            request = proto_stubs.DeviceRequest(ski=self.ski)
+            fallback_request = proto_stubs.DeviceRequest(ski="")
+            used_fallback = False
+            saw_not_found = False
 
             try:
-                power = await monitoring_stub.GetPowerConsumption(request, timeout=RPC_TIMEOUT)
+                power = await monitoring_stub.GetPowerConsumption(
+                    request, timeout=RPC_TIMEOUT
+                )
                 data["power_watts"] = power.watts
-            except grpc.aio.AioRpcError:
+                _LOGGER.debug(
+                    "EEBUS power read for SKI %s succeeded: watts=%s",
+                    self.ski,
+                    power.watts,
+                )
+            except grpc.aio.AioRpcError as err:
+                if _is_not_found(err):
+                    saw_not_found = True
+                    try:
+                        power = await monitoring_stub.GetPowerConsumption(
+                            fallback_request, timeout=RPC_TIMEOUT
+                        )
+                        data["power_watts"] = power.watts
+                        used_fallback = True
+                        _LOGGER.debug(
+                            "EEBUS power read for SKI %s used fallback entity: watts=%s",
+                            self.ski,
+                            power.watts,
+                        )
+                    except grpc.aio.AioRpcError as retry_err:
+                        data["power_watts"] = None
+                        _LOGGER.debug(
+                            "EEBUS power read failed for SKI %s and fallback: %s",
+                            self.ski,
+                            _rpc_error_text(retry_err),
+                        )
+                else:
+                    data["power_watts"] = None
+                    _LOGGER.debug(
+                        "EEBUS power read failed for SKI %s: %s",
+                        self.ski,
+                        _rpc_error_text(err),
+                    )
+            except Exception:  # noqa: BLE001
+                _LOGGER.exception("Failed to read power consumption")
                 data["power_watts"] = None
 
             try:
-                energy = await monitoring_stub.GetEnergyConsumed(request, timeout=RPC_TIMEOUT)
-                data["energy_consumed_kwh"] = energy.kilowatt_hours
-            except grpc.aio.AioRpcError:
-                data["energy_consumed_kwh"] = None
-
-            try:
-                mlist = await monitoring_stub.GetMeasurements(request, timeout=RPC_TIMEOUT)
-                scoped = self._extract_scoped_energy_kwh(mlist.measurements)
-                data["energy_consumed_heating_kwh"] = scoped["heating"]
-                data["energy_consumed_dhw_kwh"] = scoped["dhw"]
-            except grpc.aio.AioRpcError:
+                measurements = await monitoring_stub.GetMeasurements(
+                    request, timeout=RPC_TIMEOUT
+                )
+                scoped_energy = self._extract_scoped_energy_kwh(measurements.measurements)
+                data["energy_consumed_heating_kwh"] = scoped_energy["heating"]
+                data["energy_consumed_dhw_kwh"] = scoped_energy["dhw"]
+                _LOGGER.debug(
+                    "EEBUS scoped energy read for SKI %s: heating=%s dhw=%s entries=%s",
+                    self.ski,
+                    data["energy_consumed_heating_kwh"],
+                    data["energy_consumed_dhw_kwh"],
+                    len(measurements.measurements),
+                )
+            except grpc.aio.AioRpcError as err:
+                if _is_not_found(err):
+                    saw_not_found = True
+                    try:
+                        measurements = await monitoring_stub.GetMeasurements(
+                            fallback_request, timeout=RPC_TIMEOUT
+                        )
+                        scoped_energy = self._extract_scoped_energy_kwh(
+                            measurements.measurements
+                        )
+                        data["energy_consumed_heating_kwh"] = scoped_energy["heating"]
+                        data["energy_consumed_dhw_kwh"] = scoped_energy["dhw"]
+                        used_fallback = True
+                        _LOGGER.debug(
+                            "EEBUS scoped energy read for SKI %s used fallback: heating=%s dhw=%s entries=%s",
+                            self.ski,
+                            data["energy_consumed_heating_kwh"],
+                            data["energy_consumed_dhw_kwh"],
+                            len(measurements.measurements),
+                        )
+                    except grpc.aio.AioRpcError as retry_err:
+                        data["energy_consumed_heating_kwh"] = None
+                        data["energy_consumed_dhw_kwh"] = None
+                        _LOGGER.debug(
+                            "EEBUS scoped energy read failed for SKI %s and fallback: %s",
+                            self.ski,
+                            _rpc_error_text(retry_err),
+                        )
+                else:
+                    data["energy_consumed_heating_kwh"] = None
+                    data["energy_consumed_dhw_kwh"] = None
+                    _LOGGER.debug(
+                        "EEBUS scoped energy read failed for SKI %s: %s",
+                        self.ski,
+                        _rpc_error_text(err),
+                    )
+            except Exception:  # noqa: BLE001
+                _LOGGER.exception("Failed to read scoped energy measurements")
                 data["energy_consumed_heating_kwh"] = None
                 data["energy_consumed_dhw_kwh"] = None
 
             try:
-                limit = await lpc_stub.GetConsumptionLimit(request, timeout=RPC_TIMEOUT)
+                energy = await monitoring_stub.GetEnergyConsumed(
+                    request, timeout=RPC_TIMEOUT
+                )
+                data["energy_consumed_kwh"] = energy.kilowatt_hours
+                _LOGGER.debug(
+                    "EEBUS total energy read for SKI %s succeeded: kWh=%s",
+                    self.ski,
+                    energy.kilowatt_hours,
+                )
+            except grpc.aio.AioRpcError as err:
+                if _is_not_found(err):
+                    saw_not_found = True
+                    try:
+                        energy = await monitoring_stub.GetEnergyConsumed(
+                            fallback_request, timeout=RPC_TIMEOUT
+                        )
+                        data["energy_consumed_kwh"] = energy.kilowatt_hours
+                        used_fallback = True
+                        _LOGGER.debug(
+                            "EEBUS total energy read for SKI %s used fallback: kWh=%s",
+                            self.ski,
+                            energy.kilowatt_hours,
+                        )
+                    except grpc.aio.AioRpcError as retry_err:
+                        data["energy_consumed_kwh"] = None
+                        _LOGGER.debug(
+                            "EEBUS total energy read failed for SKI %s and fallback: %s",
+                            self.ski,
+                            _rpc_error_text(retry_err),
+                        )
+                else:
+                    data["energy_consumed_kwh"] = None
+                    _LOGGER.debug(
+                        "EEBUS total energy read failed for SKI %s: %s",
+                        self.ski,
+                        _rpc_error_text(err),
+                    )
+            except Exception:  # noqa: BLE001
+                _LOGGER.exception("Failed to read total consumed energy")
+                data["energy_consumed_kwh"] = None
+
+            try:
+                lpc_stub = proto_stubs.LPCServiceStub(channel)
+                limit = await lpc_stub.GetConsumptionLimit(
+                    request, timeout=RPC_TIMEOUT
+                )
                 data["consumption_limit"] = {
                     "value_watts": limit.value_watts,
                     "is_active": limit.is_active,
                     "is_changeable": limit.is_changeable,
                 }
                 self._lpc_supported = True
+                _LOGGER.debug(
+                    "EEBUS consumption limit read for SKI %s: value=%s active=%s changeable=%s",
+                    self.ski,
+                    limit.value_watts,
+                    limit.is_active,
+                    limit.is_changeable,
+                )
             except grpc.aio.AioRpcError as err:
-                data["consumption_limit"] = None
-                if _is_unimplemented(err):
-                    self._lpc_supported = False
-                    _LOGGER.debug("LPC not supported by device %s: %s", self.ski, _rpc_error_text(err))
+                if _is_not_found(err):
+                    saw_not_found = True
+                    try:
+                        limit = await lpc_stub.GetConsumptionLimit(
+                            fallback_request, timeout=RPC_TIMEOUT
+                        )
+                        data["consumption_limit"] = {
+                            "value_watts": limit.value_watts,
+                            "is_active": limit.is_active,
+                            "is_changeable": limit.is_changeable,
+                        }
+                        self._lpc_supported = True
+                        used_fallback = True
+                        _LOGGER.debug(
+                            "EEBUS consumption limit read for SKI %s used fallback: value=%s active=%s changeable=%s",
+                            self.ski,
+                            limit.value_watts,
+                            limit.is_active,
+                            limit.is_changeable,
+                        )
+                    except grpc.aio.AioRpcError as retry_err:
+                        data["consumption_limit"] = None
+                        _LOGGER.debug(
+                            "EEBUS consumption limit read failed for SKI %s and fallback: %s",
+                            self.ski,
+                            _rpc_error_text(retry_err),
+                        )
+                        if _is_unimplemented(retry_err):
+                            self._lpc_supported = False
+                else:
+                    data["consumption_limit"] = None
+                    _LOGGER.debug(
+                        "EEBUS consumption limit read failed for SKI %s: %s",
+                        self.ski,
+                        _rpc_error_text(err),
+                    )
+                    if _is_unimplemented(err):
+                        self._lpc_supported = False
 
             try:
-                failsafe = await lpc_stub.GetFailsafeLimit(request, timeout=RPC_TIMEOUT)
-                data["failsafe_limit"] = {"value_watts": failsafe.value_watts}
+                lpc_stub = proto_stubs.LPCServiceStub(channel)
+                failsafe = await lpc_stub.GetFailsafeLimit(
+                    request, timeout=RPC_TIMEOUT
+                )
+                data["failsafe_limit"] = {
+                    "value_watts": failsafe.value_watts,
+                    "duration_minimum_seconds": failsafe.duration_minimum_seconds,
+                }
                 self._failsafe_supported = True
+                _LOGGER.debug(
+                    "EEBUS failsafe read for SKI %s: value=%s min_duration_s=%s",
+                    self.ski,
+                    failsafe.value_watts,
+                    failsafe.duration_minimum_seconds,
+                )
             except grpc.aio.AioRpcError as err:
-                data["failsafe_limit"] = None
-                if _is_unimplemented(err):
-                    self._failsafe_supported = False
-                    _LOGGER.debug("Failsafe not supported by device %s: %s", self.ski, _rpc_error_text(err))
+                if _is_not_found(err):
+                    saw_not_found = True
+                    try:
+                        failsafe = await lpc_stub.GetFailsafeLimit(
+                            fallback_request, timeout=RPC_TIMEOUT
+                        )
+                        data["failsafe_limit"] = {
+                            "value_watts": failsafe.value_watts,
+                            "duration_minimum_seconds": failsafe.duration_minimum_seconds,
+                        }
+                        self._failsafe_supported = True
+                        used_fallback = True
+                        _LOGGER.debug(
+                            "EEBUS failsafe read for SKI %s used fallback: value=%s min_duration_s=%s",
+                            self.ski,
+                            failsafe.value_watts,
+                            failsafe.duration_minimum_seconds,
+                        )
+                    except grpc.aio.AioRpcError as retry_err:
+                        data["failsafe_limit"] = None
+                        _LOGGER.debug(
+                            "EEBUS failsafe read failed for SKI %s and fallback: %s",
+                            self.ski,
+                            _rpc_error_text(retry_err),
+                        )
+                        if _is_unimplemented(retry_err):
+                            self._failsafe_supported = False
+                else:
+                    data["failsafe_limit"] = None
+                    _LOGGER.debug(
+                        "EEBUS failsafe read failed for SKI %s: %s",
+                        self.ski,
+                        _rpc_error_text(err),
+                    )
+                    if _is_unimplemented(err):
+                        self._failsafe_supported = False
 
             try:
-                hb = await lpc_stub.GetHeartbeatStatus(request, timeout=RPC_TIMEOUT)
+                lpc_stub = proto_stubs.LPCServiceStub(channel)
+                hb = await lpc_stub.GetHeartbeatStatus(
+                    request, timeout=RPC_TIMEOUT
+                )
                 data["heartbeat_status"] = {
                     "running": hb.running,
                     "within_duration": hb.within_duration,
                 }
-            except grpc.aio.AioRpcError:
+                data["heartbeat_supported"] = True
+                self._heartbeat_supported = True
+                _LOGGER.debug(
+                    "EEBUS heartbeat status for SKI %s: running=%s within_duration=%s",
+                    self.ski,
+                    hb.running,
+                    hb.within_duration,
+                )
+            except grpc.aio.AioRpcError as err:
+                if _is_not_found(err):
+                    saw_not_found = True
+                    try:
+                        hb = await lpc_stub.GetHeartbeatStatus(
+                            fallback_request, timeout=RPC_TIMEOUT
+                        )
+                        data["heartbeat_status"] = {
+                            "running": hb.running,
+                            "within_duration": hb.within_duration,
+                        }
+                        data["heartbeat_supported"] = True
+                        self._heartbeat_supported = True
+                        used_fallback = True
+                        _LOGGER.debug(
+                            "EEBUS heartbeat read for SKI %s used fallback: running=%s within_duration=%s",
+                            self.ski,
+                            hb.running,
+                            hb.within_duration,
+                        )
+                    except grpc.aio.AioRpcError as retry_err:
+                        data["heartbeat_status"] = None
+                        data["heartbeat_supported"] = self._heartbeat_supported
+                        _LOGGER.debug(
+                            "EEBUS heartbeat read failed for SKI %s and fallback: %s",
+                            self.ski,
+                            _rpc_error_text(retry_err),
+                        )
+                        if _is_unimplemented(retry_err):
+                            data["heartbeat_supported"] = False
+                            self._heartbeat_supported = False
+                else:
+                    data["heartbeat_status"] = None
+                    data["heartbeat_supported"] = self._heartbeat_supported
+                    _LOGGER.debug(
+                        "EEBUS heartbeat read failed for SKI %s: %s",
+                        self.ski,
+                        _rpc_error_text(err),
+                    )
+                    if _is_unimplemented(err):
+                        data["heartbeat_supported"] = False
+                        self._heartbeat_supported = False
+            except Exception:  # noqa: BLE001
+                _LOGGER.exception("Failed to read heartbeat status")
                 data["heartbeat_status"] = None
+                data["heartbeat_supported"] = self._heartbeat_supported
+
+            data["lpc_supported"] = self._lpc_supported
+            data["failsafe_supported"] = self._failsafe_supported
+            data["read_fallback_used"] = used_fallback
+
+            if saw_not_found:
+                self._not_found_streak += 1
+            else:
+                self._not_found_streak = 0
+
+            if self._not_found_streak >= RE_REGISTER_NOT_FOUND_STREAK:
+                _LOGGER.warning(
+                    "EEBUS reads returned NOT_FOUND for %s consecutive polls; forcing remote SKI re-registration for %s",
+                    self._not_found_streak,
+                    self.ski,
+                )
+                await self._async_register_remote_ski(device_stub, proto_stubs, force=True)
+                self._not_found_streak = 0
+
+            _LOGGER.debug(
+                "EEBUS poll summary for SKI %s: power=%s energy_total=%s energy_heating=%s energy_dhw=%s fallback=%s",
+                self.ski,
+                data["power_watts"],
+                data["energy_consumed_kwh"],
+                data["energy_consumed_heating_kwh"],
+                data["energy_consumed_dhw_kwh"],
+                used_fallback,
+            )
 
             if self._was_unavailable:
                 _LOGGER.info("EEBUS bridge connection restored at %s:%s", self.host, self.port)
@@ -142,6 +451,7 @@ class EebusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             if self._channel is not None:
                 await self._channel.close()
                 self._channel = None
+            self._not_found_streak = 0
 
             if not self._was_unavailable:
                 _LOGGER.warning(
@@ -151,21 +461,64 @@ class EebusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
             raise UpdateFailed(f"gRPC error: {err}") from err
 
+    async def _async_register_remote_ski(
+        self, device_stub: Any, proto_stubs: Any, force: bool
+    ) -> None:
+        """Register remote SKI with bridge, optionally forcing re-registration."""
+        try:
+            register_request_cls = getattr(proto_stubs, "RegisterSKIRequest", None)
+            if register_request_cls is None:
+                from .generated.eebus.v1.device_service_pb2 import (
+                    RegisterSKIRequest as register_request_cls,
+                )
+
+            await device_stub.RegisterRemoteSKI(
+                register_request_cls(ski=self.ski), timeout=RPC_TIMEOUT
+            )
+            self._ski_registered = True
+            if force:
+                _LOGGER.info("Forced re-registration of remote SKI %s with bridge", self.ski)
+            else:
+                _LOGGER.info("Registered remote SKI %s with bridge", self.ski)
+        except grpc.aio.AioRpcError as err:
+            if force:
+                _LOGGER.warning(
+                    "Forced remote SKI re-registration failed for %s: %s",
+                    self.ski,
+                    _rpc_error_text(err),
+                )
+            else:
+                # Retry in next polling cycle until the bridge accepts registration.
+                _LOGGER.debug(
+                    "Remote SKI registration pending for %s: %s",
+                    self.ski,
+                    _rpc_error_text(err),
+                )
+
     @staticmethod
     def _extract_scoped_energy_kwh(measurements: list[Any]) -> dict[str, float | None]:
-        """Extract scoped energy counters for heating and domestic hot water from MeasurementEntry list."""
+        """Extract Vaillant/EEBUS scoped counters for heating and domestic hot water."""
         result: dict[str, float | None] = {"heating": None, "dhw": None}
-        for m in measurements:
-            mtype = str(getattr(m, "type", "")).lower().strip().replace("-", "_").replace(" ", "_")
-            if not mtype:
+        for measurement in measurements:
+            measurement_type = str(getattr(measurement, "type", "")).lower().strip()
+            if not measurement_type:
                 continue
-            value = getattr(m, "value", None)
+            normalized = measurement_type.replace("-", "_").replace(" ", "_")
+            value = getattr(measurement, "value", None)
             if value is None:
                 continue
-            if "energy" in mtype and ("domestic_hot_water" in mtype or "hot_water" in mtype or "dhw" in mtype):
+
+            # Vaillant uses separate thermal storage contexts for heating and DHW.
+            if (
+                "energy" in normalized
+                and ("domestic_hot_water" in normalized or "hot_water" in normalized or "dhw" in normalized)
+            ):
                 result["dhw"] = value
-            elif "energy" in mtype and ("heating" in mtype or "space_heating" in mtype):
+                continue
+
+            if "energy" in normalized and ("heating" in normalized or "space_heating" in normalized):
                 result["heating"] = value
+
         return result
 
     async def async_write_lpc_limit(self, value_watts: float) -> None:
@@ -173,22 +526,44 @@ class EebusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         channel = await self._ensure_channel()
         from . import proto_stubs
         stub = proto_stubs.LPCServiceStub(channel)
-        await stub.WriteConsumptionLimit(
-            proto_stubs.WriteLoadLimitRequest(
-                ski=self.ski, value_watts=value_watts, is_active=True
+        try:
+            await stub.WriteConsumptionLimit(
+                proto_stubs.WriteLoadLimitRequest(
+                    ski=self.ski, value_watts=value_watts, is_active=True
+                ),
+                timeout=RPC_TIMEOUT,
             )
-        )
+            self._lpc_supported = True
+        except grpc.aio.AioRpcError as err:
+            if _is_unimplemented(err):
+                self._lpc_supported = False
+                _LOGGER.info(
+                    "LPC write unsupported for SKI %s: %s", self.ski, err.details()
+                )
+                return
+            raise
 
     async def async_write_failsafe_limit(self, value_watts: float) -> None:
         """Write failsafe limit via gRPC."""
         channel = await self._ensure_channel()
         from . import proto_stubs
         stub = proto_stubs.LPCServiceStub(channel)
-        await stub.WriteFailsafeLimit(
-            proto_stubs.WriteFailsafeLimitRequest(
-                ski=self.ski, value_watts=value_watts
+        try:
+            await stub.WriteFailsafeLimit(
+                proto_stubs.WriteFailsafeLimitRequest(
+                    ski=self.ski, value_watts=value_watts
+                ),
+                timeout=RPC_TIMEOUT,
             )
-        )
+            self._failsafe_supported = True
+        except grpc.aio.AioRpcError as err:
+            if _is_unimplemented(err):
+                self._failsafe_supported = False
+                _LOGGER.info(
+                    "Failsafe write unsupported for SKI %s: %s", self.ski, err.details()
+                )
+                return
+            raise
 
     async def async_set_lpc_active(self, active: bool) -> None:
         """Activate or deactivate LPC limit via gRPC."""
@@ -196,29 +571,62 @@ class EebusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         from . import proto_stubs
         stub = proto_stubs.LPCServiceStub(channel)
         current = await stub.GetConsumptionLimit(
-            proto_stubs.DeviceRequest(ski=self.ski)
+            proto_stubs.DeviceRequest(ski=self.ski), timeout=RPC_TIMEOUT
         )
-        await stub.WriteConsumptionLimit(
-            proto_stubs.WriteLoadLimitRequest(
-                ski=self.ski,
-                value_watts=current.value_watts,
-                is_active=active,
+        try:
+            await stub.WriteConsumptionLimit(
+                proto_stubs.WriteLoadLimitRequest(
+                    ski=self.ski,
+                    value_watts=current.value_watts,
+                    is_active=active,
+                ),
+                timeout=RPC_TIMEOUT,
             )
-        )
+            self._lpc_supported = True
+        except grpc.aio.AioRpcError as err:
+            if _is_unimplemented(err):
+                self._lpc_supported = False
+                _LOGGER.info(
+                    "LPC activation unsupported for SKI %s: %s", self.ski, err.details()
+                )
+                return
+            raise
 
     async def async_start_heartbeat(self) -> None:
         """Start EEBUS heartbeat via gRPC."""
         channel = await self._ensure_channel()
         from . import proto_stubs
         stub = proto_stubs.LPCServiceStub(channel)
-        await stub.StartHeartbeat(proto_stubs.DeviceRequest(ski=self.ski))
+        try:
+            await stub.StartHeartbeat(
+                proto_stubs.DeviceRequest(ski=self.ski), timeout=RPC_TIMEOUT
+            )
+        except grpc.aio.AioRpcError as err:
+            if _is_unimplemented(err):
+                self._heartbeat_supported = False
+                _LOGGER.info(
+                    "Heartbeat start unsupported for SKI %s: %s", self.ski, err.details()
+                )
+                return
+            raise
 
     async def async_stop_heartbeat(self) -> None:
         """Stop EEBUS heartbeat via gRPC."""
         channel = await self._ensure_channel()
         from . import proto_stubs
         stub = proto_stubs.LPCServiceStub(channel)
-        await stub.StopHeartbeat(proto_stubs.DeviceRequest(ski=self.ski))
+        try:
+            await stub.StopHeartbeat(
+                proto_stubs.DeviceRequest(ski=self.ski), timeout=RPC_TIMEOUT
+            )
+        except grpc.aio.AioRpcError as err:
+            if _is_unimplemented(err):
+                self._heartbeat_supported = False
+                _LOGGER.info(
+                    "Heartbeat stop unsupported for SKI %s: %s", self.ski, err.details()
+                )
+                return
+            raise
 
     async def async_shutdown(self) -> None:
         """Close gRPC channel and cancel stream tasks."""

--- a/eebus-bridge/cmd/eebus-bridge/main.go
+++ b/eebus-bridge/cmd/eebus-bridge/main.go
@@ -23,6 +23,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("loading config: %v", err)
 	}
+	log.Printf("EEBUS debug_events=%t", cfg.Logging.DebugEvents)
 
 	cert, err := certs.EnsureCertificate(
 		cfg.Certificates.CertFile,
@@ -40,14 +41,15 @@ func main() {
 	log.Printf("Local SKI: %s", ski)
 
 	bus := eebus.NewEventBus()
+	registry := eebus.NewDeviceRegistry()
 
 	bridgeSvc, err := eebus.NewBridgeService(cfg, cert, bus)
 	if err != nil {
 		log.Fatalf("creating bridge service: %v", err)
 	}
 
-	lpcWrapper := usecases.NewLPCWrapper(bus)
-	monitoringWrapper := usecases.NewMonitoringWrapper(bus)
+	lpcWrapper := usecases.NewLPCWrapper(bus, registry, cfg.Logging.DebugEvents)
+	monitoringWrapper := usecases.NewMonitoringWrapper(bus, registry, cfg.Logging.DebugEvents)
 
 	if err := bridgeSvc.Setup(); err != nil {
 		log.Fatalf("setting up EEBUS service: %v", err)
@@ -65,9 +67,9 @@ func main() {
 
 	grpcSrv := bridgegrpc.NewServer(cfg.GRPC.Port)
 
-	deviceSvc := bridgegrpc.NewDeviceService(bridgeSvc.Callbacks(), bus, ski)
-	lpcSvc := bridgegrpc.NewLPCService(lpcWrapper, bus)
-	monitoringSvc := bridgegrpc.NewMonitoringService(monitoringWrapper, bus)
+	deviceSvc := bridgegrpc.NewDeviceService(bridgeSvc.Callbacks(), bus, ski, registry)
+	lpcSvc := bridgegrpc.NewLPCService(lpcWrapper, bus, registry)
+	monitoringSvc := bridgegrpc.NewMonitoringService(monitoringWrapper, bus, registry)
 
 	pb.RegisterDeviceServiceServer(grpcSrv.GRPCServer(), deviceSvc)
 	pb.RegisterLPCServiceServer(grpcSrv.GRPCServer(), lpcSvc)
@@ -82,6 +84,9 @@ func main() {
 
 	bridgeSvc.Start()
 	log.Println("EEBUS bridge started")
+	if cfg.Logging.DebugEvents {
+		log.Println("[DEBUG] EEBUS event debug logging enabled; waiting for incoming callbacks")
+	}
 
 	go func() {
 		ch := bus.Subscribe()

--- a/eebus-bridge/internal/config/config.go
+++ b/eebus-bridge/internal/config/config.go
@@ -12,6 +12,7 @@ type Config struct {
 	GRPC         GRPCConfig         `yaml:"grpc"`
 	EEBUS        EEBUSConfig        `yaml:"eebus"`
 	Certificates CertificatesConfig `yaml:"certificates"`
+	Logging      LoggingConfig      `yaml:"logging"`
 }
 
 type GRPCConfig struct {
@@ -31,6 +32,10 @@ type CertificatesConfig struct {
 	CertFile     string `yaml:"cert_file"`
 	KeyFile      string `yaml:"key_file"`
 	StoragePath  string `yaml:"storage_path"`
+}
+
+type LoggingConfig struct {
+	DebugEvents bool `yaml:"debug_events"`
 }
 
 func LoadFromFile(path string) (*Config, error) {
@@ -105,5 +110,10 @@ func applyEnvOverrides(cfg *Config) {
 	}
 	if v := os.Getenv("EEBUS_CERT_STORAGE"); v != "" {
 		cfg.Certificates.StoragePath = v
+	}
+	if v := os.Getenv("EEBUS_DEBUG_EVENTS"); v != "" {
+		if enabled, err := strconv.ParseBool(v); err == nil {
+			cfg.Logging.DebugEvents = enabled
+		}
 	}
 }

--- a/eebus-bridge/internal/eebus/callbacks.go
+++ b/eebus-bridge/internal/eebus/callbacks.go
@@ -1,6 +1,7 @@
 package eebus
 
 import (
+	"log"
 	"sync"
 
 	"github.com/enbility/eebus-go/api"
@@ -13,13 +14,15 @@ type Callbacks struct {
 	mu             sync.RWMutex
 	discoveredSvcs []shipapi.RemoteService
 	pairingStates  map[string]*shipapi.ConnectionStateDetail
+	debugEvents    bool
 }
 
 // NewCallbacks creates a new Callbacks instance backed by the given EventBus.
-func NewCallbacks(bus *EventBus) *Callbacks {
+func NewCallbacks(bus *EventBus, debugEvents bool) *Callbacks {
 	return &Callbacks{
 		bus:           bus,
 		pairingStates: make(map[string]*shipapi.ConnectionStateDetail),
+		debugEvents:   debugEvents,
 	}
 }
 
@@ -28,6 +31,10 @@ var _ api.ServiceReaderInterface = (*Callbacks)(nil)
 
 // RemoteSKIConnected is called when a remote SKI connects.
 func (c *Callbacks) RemoteSKIConnected(service api.ServiceInterface, ski string) {
+	if c.debugEvents {
+		log.Printf("[DEBUG] EEBUS callback: remote SKI connected: ski=%s", ski)
+	}
+
 	c.bus.Publish(Event{
 		SKI:  ski,
 		Type: "device.connected",
@@ -36,6 +43,10 @@ func (c *Callbacks) RemoteSKIConnected(service api.ServiceInterface, ski string)
 
 // RemoteSKIDisconnected is called when a remote SKI disconnects.
 func (c *Callbacks) RemoteSKIDisconnected(service api.ServiceInterface, ski string) {
+	if c.debugEvents {
+		log.Printf("[DEBUG] EEBUS callback: remote SKI disconnected: ski=%s", ski)
+	}
+
 	c.bus.Publish(Event{
 		SKI:  ski,
 		Type: "device.disconnected",
@@ -44,6 +55,10 @@ func (c *Callbacks) RemoteSKIDisconnected(service api.ServiceInterface, ski stri
 
 // VisibleRemoteServicesUpdated is called when the list of visible remote services changes.
 func (c *Callbacks) VisibleRemoteServicesUpdated(service api.ServiceInterface, entries []shipapi.RemoteService) {
+	if c.debugEvents {
+		log.Printf("[DEBUG] EEBUS callback: visible remote services updated: count=%d", len(entries))
+	}
+
 	c.mu.Lock()
 	c.discoveredSvcs = entries
 	c.mu.Unlock()
@@ -60,6 +75,14 @@ func (c *Callbacks) ServiceShipIDUpdate(ski string, shipID string) {
 
 // ServicePairingDetailUpdate is called when the pairing state of a remote service changes.
 func (c *Callbacks) ServicePairingDetailUpdate(ski string, detail *shipapi.ConnectionStateDetail) {
+	if c.debugEvents {
+		if detail != nil {
+			log.Printf("[DEBUG] EEBUS callback: pairing detail updated: ski=%s state=%v", ski, detail.State())
+		} else {
+			log.Printf("[DEBUG] EEBUS callback: pairing detail updated: ski=%s state=<nil>", ski)
+		}
+	}
+
 	c.mu.Lock()
 	c.pairingStates[ski] = detail
 	c.mu.Unlock()

--- a/eebus-bridge/internal/eebus/callbacks_test.go
+++ b/eebus-bridge/internal/eebus/callbacks_test.go
@@ -12,7 +12,7 @@ func TestCallbacksDispatchConnect(t *testing.T) {
 	ch := bus.Subscribe()
 	defer bus.Unsubscribe(ch)
 
-	cb := eebus.NewCallbacks(bus)
+	cb := eebus.NewCallbacks(bus, false)
 	cb.RemoteSKIConnected(nil, "test-ski-123")
 
 	select {
@@ -33,7 +33,7 @@ func TestCallbacksDispatchDisconnect(t *testing.T) {
 	ch := bus.Subscribe()
 	defer bus.Unsubscribe(ch)
 
-	cb := eebus.NewCallbacks(bus)
+	cb := eebus.NewCallbacks(bus, false)
 	cb.RemoteSKIDisconnected(nil, "test-ski-456")
 
 	select {
@@ -48,7 +48,7 @@ func TestCallbacksDispatchDisconnect(t *testing.T) {
 
 func TestCallbacksAllowWaitingForTrust(t *testing.T) {
 	bus := eebus.NewEventBus()
-	cb := eebus.NewCallbacks(bus)
+	cb := eebus.NewCallbacks(bus, false)
 
 	if !cb.AllowWaitingForTrust("any-ski") {
 		t.Error("AllowWaitingForTrust should return true")

--- a/eebus-bridge/internal/eebus/registry.go
+++ b/eebus-bridge/internal/eebus/registry.go
@@ -35,6 +35,51 @@ func (r *DeviceRegistry) AddDevice(ski string, info DeviceInfo) {
 	r.mu.Unlock()
 }
 
+func (r *DeviceRegistry) UpsertObservation(
+	ski string,
+	remoteDevice spineapi.DeviceRemoteInterface,
+	remoteEntity spineapi.EntityRemoteInterface,
+	useCase string,
+) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	info := r.devices[ski]
+	info.SKI = ski
+
+	if remoteDevice != nil {
+		info.RemoteDevice = remoteDevice
+	}
+
+	if remoteEntity != nil {
+		alreadyPresent := false
+		for _, existing := range info.RemoteEntities {
+			if existing == remoteEntity {
+				alreadyPresent = true
+				break
+			}
+		}
+		if !alreadyPresent {
+			info.RemoteEntities = append(info.RemoteEntities, remoteEntity)
+		}
+	}
+
+	if useCase != "" {
+		alreadyPresent := false
+		for _, existing := range info.UseCases {
+			if existing == useCase {
+				alreadyPresent = true
+				break
+			}
+		}
+		if !alreadyPresent {
+			info.UseCases = append(info.UseCases, useCase)
+		}
+	}
+
+	r.devices[ski] = info
+}
+
 func (r *DeviceRegistry) RemoveDevice(ski string) {
 	r.mu.Lock()
 	delete(r.devices, ski)
@@ -66,4 +111,17 @@ func (r *DeviceRegistry) FirstEntity(ski string) spineapi.EntityRemoteInterface 
 		return nil
 	}
 	return info.RemoteEntities[0]
+}
+
+// FirstAvailableEntity returns the first entity from any known device.
+// Used as a fallback when a client-selected SKI has no mapped entity yet.
+func (r *DeviceRegistry) FirstAvailableEntity() spineapi.EntityRemoteInterface {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	for _, info := range r.devices {
+		if len(info.RemoteEntities) > 0 {
+			return info.RemoteEntities[0]
+		}
+	}
+	return nil
 }

--- a/eebus-bridge/internal/eebus/service.go
+++ b/eebus-bridge/internal/eebus/service.go
@@ -36,7 +36,7 @@ func NewBridgeService(cfg *config.Config, cert tls.Certificate, bus *EventBus) (
 		return nil, fmt.Errorf("creating eebus config: %w", err)
 	}
 
-	callbacks := NewCallbacks(bus)
+	callbacks := NewCallbacks(bus, cfg.Logging.DebugEvents)
 	svc := eebusservice.NewService(eebusConfig, callbacks)
 
 	return &BridgeService{

--- a/eebus-bridge/internal/grpc/device_service.go
+++ b/eebus-bridge/internal/grpc/device_service.go
@@ -13,13 +13,15 @@ type DeviceService struct {
 	callbacks *eebus.Callbacks
 	bus       *eebus.EventBus
 	localSKI  string
+	registry  *eebus.DeviceRegistry
 }
 
-func NewDeviceService(callbacks *eebus.Callbacks, bus *eebus.EventBus, localSKI string) *DeviceService {
+func NewDeviceService(callbacks *eebus.Callbacks, bus *eebus.EventBus, localSKI string, registry *eebus.DeviceRegistry) *DeviceService {
 	return &DeviceService{
 		callbacks: callbacks,
 		bus:       bus,
 		localSKI:  localSKI,
+		registry:  registry,
 	}
 }
 
@@ -79,7 +81,19 @@ func mapConnectionState(cs shipapi.ConnectionState) pb.PairingState {
 }
 
 func (s *DeviceService) ListPairedDevices(_ context.Context, _ *pb.Empty) (*pb.ListPairedDevicesResponse, error) {
-	return &pb.ListPairedDevicesResponse{}, nil
+	devices := s.registry.ListDevices()
+	result := make([]*pb.PairedDevice, 0, len(devices))
+	for _, device := range devices {
+		result = append(result, &pb.PairedDevice{
+			Ski:               device.SKI,
+			Brand:             device.Brand,
+			Model:             device.Model,
+			Serial:            device.Serial,
+			DeviceType:        device.DeviceType,
+			SupportedUseCases: device.UseCases,
+		})
+	}
+	return &pb.ListPairedDevicesResponse{Devices: result}, nil
 }
 
 func (s *DeviceService) SubscribeDeviceEvents(_ *pb.Empty, stream pb.DeviceService_SubscribeDeviceEventsServer) error {

--- a/eebus-bridge/internal/grpc/device_service_test.go
+++ b/eebus-bridge/internal/grpc/device_service_test.go
@@ -16,8 +16,8 @@ func setupDeviceTest(t *testing.T) pb.DeviceServiceClient {
 	t.Helper()
 
 	bus := eebus.NewEventBus()
-	callbacks := eebus.NewCallbacks(bus)
-	svc := bridgegrpc.NewDeviceService(callbacks, bus, "test-local-ski")
+	callbacks := eebus.NewCallbacks(bus, false)
+	svc := bridgegrpc.NewDeviceService(callbacks, bus, "test-local-ski", eebus.NewDeviceRegistry())
 
 	srv := bridgegrpc.NewServer(0)
 	pb.RegisterDeviceServiceServer(srv.GRPCServer(), svc)

--- a/eebus-bridge/internal/grpc/integration_test.go
+++ b/eebus-bridge/internal/grpc/integration_test.go
@@ -16,11 +16,12 @@ import (
 
 func TestIntegrationDeviceServiceRoundTrip(t *testing.T) {
 	bus := eebus.NewEventBus()
-	callbacks := eebus.NewCallbacks(bus)
+	callbacks := eebus.NewCallbacks(bus, false)
+	registry := eebus.NewDeviceRegistry()
 
-	deviceSvc := bridgegrpc.NewDeviceService(callbacks, bus, "integration-test-ski")
-	lpcSvc := bridgegrpc.NewLPCService(nil, bus)
-	monSvc := bridgegrpc.NewMonitoringService(nil, bus)
+	deviceSvc := bridgegrpc.NewDeviceService(callbacks, bus, "integration-test-ski", registry)
+	lpcSvc := bridgegrpc.NewLPCService(nil, bus, registry)
+	monSvc := bridgegrpc.NewMonitoringService(nil, bus, registry)
 
 	srv := bridgegrpc.NewServer(0)
 	pb.RegisterDeviceServiceServer(srv.GRPCServer(), deviceSvc)

--- a/eebus-bridge/internal/grpc/lpc_service.go
+++ b/eebus-bridge/internal/grpc/lpc_service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	spineapi "github.com/enbility/spine-go/api"
 	ucapi "github.com/enbility/eebus-go/usecases/api"
 	pb "github.com/volschin/eebus-bridge/gen/proto/eebus/v1"
 	"github.com/volschin/eebus-bridge/internal/eebus"
@@ -14,40 +15,101 @@ import (
 
 type LPCService struct {
 	pb.UnimplementedLPCServiceServer
-	lpc *usecases.LPCWrapper
-	bus *eebus.EventBus
+	lpc      *usecases.LPCWrapper
+	bus      *eebus.EventBus
+	registry *eebus.DeviceRegistry
 }
 
-func NewLPCService(lpc *usecases.LPCWrapper, bus *eebus.EventBus) *LPCService {
-	return &LPCService{lpc: lpc, bus: bus}
+func NewLPCService(lpc *usecases.LPCWrapper, bus *eebus.EventBus, registry *eebus.DeviceRegistry) *LPCService {
+	return &LPCService{lpc: lpc, bus: bus, registry: registry}
 }
 
-func (s *LPCService) GetConsumptionLimit(_ context.Context, _ *pb.DeviceRequest) (*pb.LoadLimit, error) {
+func (s *LPCService) GetConsumptionLimit(_ context.Context, req *pb.DeviceRequest) (*pb.LoadLimit, error) {
+	if req == nil {
+		return nil, status.Error(codes.InvalidArgument, "request is required")
+	}
 	if s.lpc == nil {
 		return nil, status.Error(codes.Unavailable, "LPC use case not initialized")
 	}
-	return nil, status.Error(codes.Unimplemented, "entity lookup not yet wired")
+	entity, err := s.resolveEntity(req.Ski)
+	if err != nil {
+		return nil, err
+	}
+	limit, err := s.lpc.ConsumptionLimit(entity)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "reading consumption limit: %v", err)
+	}
+	return convertLoadLimit(limit), nil
 }
 
-func (s *LPCService) WriteConsumptionLimit(_ context.Context, _ *pb.WriteLoadLimitRequest) (*pb.Empty, error) {
+func (s *LPCService) WriteConsumptionLimit(_ context.Context, req *pb.WriteLoadLimitRequest) (*pb.Empty, error) {
+	if req == nil {
+		return nil, status.Error(codes.InvalidArgument, "request is required")
+	}
 	if s.lpc == nil {
 		return nil, status.Error(codes.Unavailable, "LPC use case not initialized")
 	}
-	return nil, status.Error(codes.Unimplemented, "entity lookup not yet wired")
+	entity, err := s.resolveEntity(req.Ski)
+	if err != nil {
+		return nil, err
+	}
+	err = s.lpc.WriteConsumptionLimit(entity, ucapi.LoadLimit{
+		Value:        req.ValueWatts,
+		Duration:     time.Duration(req.DurationSeconds) * time.Second,
+		IsActive:     req.IsActive,
+		IsChangeable: true,
+	})
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "writing consumption limit: %v", err)
+	}
+	return &pb.Empty{}, nil
 }
 
-func (s *LPCService) GetFailsafeLimit(_ context.Context, _ *pb.DeviceRequest) (*pb.FailsafeLimit, error) {
+func (s *LPCService) GetFailsafeLimit(_ context.Context, req *pb.DeviceRequest) (*pb.FailsafeLimit, error) {
+	if req == nil {
+		return nil, status.Error(codes.InvalidArgument, "request is required")
+	}
 	if s.lpc == nil {
 		return nil, status.Error(codes.Unavailable, "LPC use case not initialized")
 	}
-	return nil, status.Error(codes.Unimplemented, "entity lookup not yet wired")
+	entity, err := s.resolveEntity(req.Ski)
+	if err != nil {
+		return nil, err
+	}
+	value, err := s.lpc.FailsafeConsumptionActivePowerLimit(entity)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "reading failsafe power: %v", err)
+	}
+	duration, err := s.lpc.FailsafeDurationMinimum(entity)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "reading failsafe duration: %v", err)
+	}
+	return &pb.FailsafeLimit{
+		ValueWatts:             value,
+		DurationMinimumSeconds: int64(duration / time.Second),
+	}, nil
 }
 
-func (s *LPCService) WriteFailsafeLimit(_ context.Context, _ *pb.WriteFailsafeLimitRequest) (*pb.Empty, error) {
+func (s *LPCService) WriteFailsafeLimit(_ context.Context, req *pb.WriteFailsafeLimitRequest) (*pb.Empty, error) {
+	if req == nil {
+		return nil, status.Error(codes.InvalidArgument, "request is required")
+	}
 	if s.lpc == nil {
 		return nil, status.Error(codes.Unavailable, "LPC use case not initialized")
 	}
-	return nil, status.Error(codes.Unimplemented, "entity lookup not yet wired")
+	entity, err := s.resolveEntity(req.Ski)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.lpc.WriteFailsafeConsumptionActivePowerLimit(entity, req.ValueWatts); err != nil {
+		return nil, status.Errorf(codes.Internal, "writing failsafe power: %v", err)
+	}
+	if req.DurationMinimumSeconds > 0 {
+		if err := s.lpc.WriteFailsafeDurationMinimum(entity, time.Duration(req.DurationMinimumSeconds)*time.Second); err != nil {
+			return nil, status.Errorf(codes.Internal, "writing failsafe duration: %v", err)
+		}
+	}
+	return &pb.Empty{}, nil
 }
 
 func (s *LPCService) StartHeartbeat(_ context.Context, _ *pb.DeviceRequest) (*pb.Empty, error) {
@@ -62,11 +124,22 @@ func (s *LPCService) GetHeartbeatStatus(_ context.Context, _ *pb.DeviceRequest) 
 	return nil, status.Error(codes.Unimplemented, "heartbeat not supported by underlying use case")
 }
 
-func (s *LPCService) GetConsumptionNominalMax(_ context.Context, _ *pb.DeviceRequest) (*pb.PowerValue, error) {
+func (s *LPCService) GetConsumptionNominalMax(_ context.Context, req *pb.DeviceRequest) (*pb.PowerValue, error) {
+	if req == nil {
+		return nil, status.Error(codes.InvalidArgument, "request is required")
+	}
 	if s.lpc == nil {
 		return nil, status.Error(codes.Unavailable, "LPC use case not initialized")
 	}
-	return nil, status.Error(codes.Unimplemented, "entity lookup not yet wired")
+	entity, err := s.resolveEntity(req.Ski)
+	if err != nil {
+		return nil, err
+	}
+	value, err := s.lpc.ConsumptionNominalMax(entity)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "reading nominal max consumption: %v", err)
+	}
+	return &pb.PowerValue{Watts: value}, nil
 }
 
 func (s *LPCService) SubscribeLPCEvents(req *pb.DeviceRequest, stream pb.LPCService_SubscribeLPCEventsServer) error {
@@ -103,7 +176,6 @@ func (s *LPCService) SubscribeLPCEvents(req *pb.DeviceRequest, stream pb.LPCServ
 	}
 }
 
-// convertLoadLimit is a helper for future use when entity lookup is wired.
 func convertLoadLimit(l ucapi.LoadLimit) *pb.LoadLimit {
 	return &pb.LoadLimit{
 		ValueWatts:      l.Value,
@@ -111,4 +183,18 @@ func convertLoadLimit(l ucapi.LoadLimit) *pb.LoadLimit {
 		IsActive:        l.IsActive,
 		IsChangeable:    l.IsChangeable,
 	}
+}
+
+func (s *LPCService) resolveEntity(ski string) (spineapi.EntityRemoteInterface, error) {
+	if s.registry == nil {
+		return nil, status.Error(codes.Unavailable, "device registry not initialized")
+	}
+	entity := s.registry.FirstEntity(ski)
+	if entity == nil && ski == "" {
+		entity = s.registry.FirstAvailableEntity()
+	}
+	if entity == nil {
+		return nil, status.Errorf(codes.NotFound, "no remote entity found for ski %s", ski)
+	}
+	return entity, nil
 }

--- a/eebus-bridge/internal/grpc/lpc_service_test.go
+++ b/eebus-bridge/internal/grpc/lpc_service_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestSubscribeLPCEvents(t *testing.T) {
 	bus := eebus.NewEventBus()
-	svc := bridgegrpc.NewLPCService(nil, bus)
+	svc := bridgegrpc.NewLPCService(nil, bus, eebus.NewDeviceRegistry())
 
 	srv := bridgegrpc.NewServer(0)
 	pb.RegisterLPCServiceServer(srv.GRPCServer(), svc)

--- a/eebus-bridge/internal/grpc/monitoring_service.go
+++ b/eebus-bridge/internal/grpc/monitoring_service.go
@@ -2,6 +2,11 @@ package grpc
 
 import (
 	"context"
+	"fmt"
+	"log"
+
+	spineapi "github.com/enbility/spine-go/api"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	pb "github.com/volschin/eebus-bridge/gen/proto/eebus/v1"
 	"github.com/volschin/eebus-bridge/internal/eebus"
@@ -14,31 +19,92 @@ type MonitoringService struct {
 	pb.UnimplementedMonitoringServiceServer
 	monitoring *usecases.MonitoringWrapper
 	bus        *eebus.EventBus
+	registry   *eebus.DeviceRegistry
 }
 
-func NewMonitoringService(monitoring *usecases.MonitoringWrapper, bus *eebus.EventBus) *MonitoringService {
-	return &MonitoringService{monitoring: monitoring, bus: bus}
+func NewMonitoringService(monitoring *usecases.MonitoringWrapper, bus *eebus.EventBus, registry *eebus.DeviceRegistry) *MonitoringService {
+	return &MonitoringService{monitoring: monitoring, bus: bus, registry: registry}
 }
 
-func (s *MonitoringService) GetPowerConsumption(_ context.Context, _ *pb.DeviceRequest) (*pb.PowerMeasurement, error) {
+func (s *MonitoringService) GetPowerConsumption(_ context.Context, req *pb.DeviceRequest) (*pb.PowerMeasurement, error) {
+	if req == nil {
+		return nil, status.Error(codes.InvalidArgument, "request is required")
+	}
 	if s.monitoring == nil {
 		return nil, status.Error(codes.Unavailable, "monitoring use case not initialized")
 	}
-	return nil, status.Error(codes.Unimplemented, "entity lookup not yet wired")
+	value, err := s.readPower(req.Ski)
+	if err != nil {
+		log.Printf("[DEBUG] Monitoring.GetPowerConsumption read failed: requested_ski=%s err=%v", req.Ski, err)
+		if status.Code(err) != codes.Unknown {
+			return nil, err
+		}
+		return nil, status.Errorf(codes.Internal, "reading power: %v", err)
+	}
+	log.Printf("[DEBUG] Monitoring.GetPowerConsumption success: requested_ski=%s watts=%f", req.Ski, value)
+	return &pb.PowerMeasurement{
+		Watts:     value,
+		Timestamp: timestamppb.Now(),
+	}, nil
 }
 
-func (s *MonitoringService) GetEnergyConsumed(_ context.Context, _ *pb.DeviceRequest) (*pb.EnergyMeasurement, error) {
+func (s *MonitoringService) GetEnergyConsumed(_ context.Context, req *pb.DeviceRequest) (*pb.EnergyMeasurement, error) {
+	if req == nil {
+		return nil, status.Error(codes.InvalidArgument, "request is required")
+	}
 	if s.monitoring == nil {
 		return nil, status.Error(codes.Unavailable, "monitoring use case not initialized")
 	}
-	return nil, status.Error(codes.Unimplemented, "entity lookup not yet wired")
+	value, err := s.readEnergyConsumed(req.Ski)
+	if err != nil {
+		log.Printf("[DEBUG] Monitoring.GetEnergyConsumed read failed: requested_ski=%s err=%v", req.Ski, err)
+		if status.Code(err) != codes.Unknown {
+			return nil, err
+		}
+		return nil, status.Errorf(codes.Internal, "reading energy: %v", err)
+	}
+	log.Printf("[DEBUG] Monitoring.GetEnergyConsumed success: requested_ski=%s kWh=%f", req.Ski, value)
+	return &pb.EnergyMeasurement{
+		KilowattHours: value,
+		Timestamp:     timestamppb.Now(),
+	}, nil
 }
 
-func (s *MonitoringService) GetMeasurements(_ context.Context, _ *pb.DeviceRequest) (*pb.MeasurementList, error) {
+func (s *MonitoringService) GetMeasurements(_ context.Context, req *pb.DeviceRequest) (*pb.MeasurementList, error) {
+	if req == nil {
+		return nil, status.Error(codes.InvalidArgument, "request is required")
+	}
 	if s.monitoring == nil {
 		return nil, status.Error(codes.Unavailable, "monitoring use case not initialized")
 	}
-	return nil, status.Error(codes.Unimplemented, "entity lookup not yet wired")
+	now := timestamppb.Now()
+	measurements := make([]*pb.MeasurementEntry, 0, 2)
+
+	if value, err := s.readPower(req.Ski); err == nil {
+		measurements = append(measurements, &pb.MeasurementEntry{
+			Type:      "power_consumption",
+			Value:     value,
+			Unit:      "W",
+			Timestamp: now,
+		})
+	}
+
+	if value, err := s.readEnergyConsumed(req.Ski); err == nil {
+		measurements = append(measurements, &pb.MeasurementEntry{
+			Type:      "energy_consumed",
+			Value:     value,
+			Unit:      "kWh",
+			Timestamp: now,
+		})
+	}
+
+	if len(measurements) == 0 {
+		log.Printf("[DEBUG] Monitoring.GetMeasurements produced no entries: requested_ski=%s", req.Ski)
+		return nil, status.Error(codes.NotFound, "no monitoring measurements available for device")
+	}
+
+	log.Printf("[DEBUG] Monitoring.GetMeasurements success: requested_ski=%s entries=%d", req.Ski, len(measurements))
+	return &pb.MeasurementList{Measurements: measurements}, nil
 }
 
 func (s *MonitoringService) SubscribeMeasurements(req *pb.DeviceRequest, stream pb.MonitoringService_SubscribeMeasurementsServer) error {
@@ -73,4 +139,81 @@ func (s *MonitoringService) SubscribeMeasurements(req *pb.DeviceRequest, stream 
 			return stream.Context().Err()
 		}
 	}
+}
+
+func (s *MonitoringService) resolveEntity(ski string) (spineapi.EntityRemoteInterface, error) {
+	if s.registry == nil {
+		return nil, status.Error(codes.Unavailable, "device registry not initialized")
+	}
+	entity := s.registry.FirstEntity(ski)
+	if entity == nil {
+		log.Printf("[DEBUG] Monitoring.resolveEntity no entity for requested SKI: requested_ski=%s", ski)
+	}
+	if entity == nil && ski == "" {
+		entity = s.registry.FirstAvailableEntity()
+		if entity != nil {
+			log.Printf("[DEBUG] Monitoring.resolveEntity selected fallback entity for empty SKI request")
+		}
+	}
+	if entity == nil {
+		log.Printf("[DEBUG] Monitoring.resolveEntity returning not found: requested_ski=%s", ski)
+		return nil, status.Errorf(codes.NotFound, "no remote entity found for ski %s", ski)
+	}
+	return entity, nil
+}
+
+func (s *MonitoringService) readPower(ski string) (float64, error) {
+	entity, err := s.resolveEntity(ski)
+	if err == nil {
+		return s.monitoring.Power(entity)
+	}
+	if status.Code(err) != codes.NotFound {
+		log.Printf("[DEBUG] Monitoring.readPower resolveEntity failed without fallback: requested_ski=%s err=%v", ski, err)
+		return 0, err
+	}
+	log.Printf("[DEBUG] Monitoring.readPower attempting nil-entity fallback: requested_ski=%s", ski)
+	value, fallbackErr := s.safePowerNilEntity()
+	if fallbackErr != nil {
+		log.Printf("[DEBUG] Monitoring.readPower nil-entity fallback failed: requested_ski=%s err=%v", ski, fallbackErr)
+		return 0, err
+	}
+	log.Printf("[DEBUG] Monitoring.readPower nil-entity fallback succeeded: requested_ski=%s watts=%f", ski, value)
+	return value, nil
+}
+
+func (s *MonitoringService) readEnergyConsumed(ski string) (float64, error) {
+	entity, err := s.resolveEntity(ski)
+	if err == nil {
+		return s.monitoring.EnergyConsumed(entity)
+	}
+	if status.Code(err) != codes.NotFound {
+		log.Printf("[DEBUG] Monitoring.readEnergyConsumed resolveEntity failed without fallback: requested_ski=%s err=%v", ski, err)
+		return 0, err
+	}
+	log.Printf("[DEBUG] Monitoring.readEnergyConsumed attempting nil-entity fallback: requested_ski=%s", ski)
+	value, fallbackErr := s.safeEnergyConsumedNilEntity()
+	if fallbackErr != nil {
+		log.Printf("[DEBUG] Monitoring.readEnergyConsumed nil-entity fallback failed: requested_ski=%s err=%v", ski, fallbackErr)
+		return 0, err
+	}
+	log.Printf("[DEBUG] Monitoring.readEnergyConsumed nil-entity fallback succeeded: requested_ski=%s kWh=%f", ski, value)
+	return value, nil
+}
+
+func (s *MonitoringService) safePowerNilEntity() (value float64, err error) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			err = fmt.Errorf("panic during nil-entity power read: %v", recovered)
+		}
+	}()
+	return s.monitoring.Power(nil)
+}
+
+func (s *MonitoringService) safeEnergyConsumedNilEntity() (value float64, err error) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			err = fmt.Errorf("panic during nil-entity energy read: %v", recovered)
+		}
+	}()
+	return s.monitoring.EnergyConsumed(nil)
 }

--- a/eebus-bridge/internal/grpc/monitoring_service_test.go
+++ b/eebus-bridge/internal/grpc/monitoring_service_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestSubscribeMeasurements(t *testing.T) {
 	bus := eebus.NewEventBus()
-	svc := bridgegrpc.NewMonitoringService(nil, bus)
+	svc := bridgegrpc.NewMonitoringService(nil, bus, eebus.NewDeviceRegistry())
 
 	srv := bridgegrpc.NewServer(0)
 	pb.RegisterMonitoringServiceServer(srv.GRPCServer(), svc)

--- a/eebus-bridge/internal/usecases/lpc.go
+++ b/eebus-bridge/internal/usecases/lpc.go
@@ -1,6 +1,8 @@
 package usecases
 
 import (
+	"errors"
+	"log"
 	"time"
 
 	eebusapi "github.com/enbility/eebus-go/api"
@@ -13,17 +15,24 @@ import (
 // LPCWrapper wraps the eebus-go LPC (Limitation of Power Consumption) use case
 // and routes events to the internal EventBus.
 type LPCWrapper struct {
-	uc  *eglpc.LPC
-	bus *eebus.EventBus
+	uc       *eglpc.LPC
+	bus      *eebus.EventBus
+	registry *eebus.DeviceRegistry
+	debug    bool
 }
 
+var errLPCNotInitialized = errors.New("lpc use case not initialized")
+
 // NewLPCWrapper creates a new LPCWrapper. Call Setup() before using the use case.
-func NewLPCWrapper(bus *eebus.EventBus) *LPCWrapper {
-	return &LPCWrapper{bus: bus}
+func NewLPCWrapper(bus *eebus.EventBus, registry *eebus.DeviceRegistry, debugEvents bool) *LPCWrapper {
+	return &LPCWrapper{bus: bus, registry: registry, debug: debugEvents}
 }
 
 // Setup initialises the underlying eebus-go LPC use case for the given local entity.
 func (w *LPCWrapper) Setup(localEntity spineapi.EntityLocalInterface) {
+	if localEntity == nil {
+		return
+	}
 	w.uc = eglpc.NewLPC(localEntity, w.HandleEvent)
 }
 
@@ -34,7 +43,21 @@ func (w *LPCWrapper) UseCase() *eglpc.LPC {
 
 // HandleEvent is the api.EntityEventCallback passed to eebus-go. It translates
 // eebus-go event types to internal EventBus events.
-func (w *LPCWrapper) HandleEvent(ski string, _ spineapi.DeviceRemoteInterface, _ spineapi.EntityRemoteInterface, event eebusapi.EventType) {
+func (w *LPCWrapper) HandleEvent(ski string, device spineapi.DeviceRemoteInterface, entity spineapi.EntityRemoteInterface, event eebusapi.EventType) {
+	if w.debug {
+		log.Printf(
+			"[DEBUG] EEBUS LPC event received: ski=%s event=%s has_device=%t has_entity=%t",
+			ski,
+			event,
+			device != nil,
+			entity != nil,
+		)
+	}
+
+	if w.registry != nil {
+		w.registry.UpsertObservation(ski, device, entity, "lpc")
+	}
+
 	var eventType string
 	switch event {
 	case eglpc.DataUpdateLimit:
@@ -48,38 +71,58 @@ func (w *LPCWrapper) HandleEvent(ski string, _ spineapi.DeviceRemoteInterface, _
 	default:
 		return
 	}
-	w.bus.Publish(eebus.Event{SKI: ski, Type: eventType})
+	if w.bus != nil {
+		w.bus.Publish(eebus.Event{SKI: ski, Type: eventType})
+	}
 }
 
 // ConsumptionLimit returns the current load control limit for the given remote entity.
 func (w *LPCWrapper) ConsumptionLimit(entity spineapi.EntityRemoteInterface) (ucapi.LoadLimit, error) {
+	if w.uc == nil {
+		return ucapi.LoadLimit{}, errLPCNotInitialized
+	}
 	return w.uc.ConsumptionLimit(entity)
 }
 
 // WriteConsumptionLimit sends a new consumption limit to the given remote entity.
 func (w *LPCWrapper) WriteConsumptionLimit(entity spineapi.EntityRemoteInterface, limit ucapi.LoadLimit) error {
+	if w.uc == nil {
+		return errLPCNotInitialized
+	}
 	_, err := w.uc.WriteConsumptionLimit(entity, limit, nil)
 	return err
 }
 
 // FailsafeConsumptionActivePowerLimit returns the failsafe active power limit.
 func (w *LPCWrapper) FailsafeConsumptionActivePowerLimit(entity spineapi.EntityRemoteInterface) (float64, error) {
+	if w.uc == nil {
+		return 0, errLPCNotInitialized
+	}
 	return w.uc.FailsafeConsumptionActivePowerLimit(entity)
 }
 
 // WriteFailsafeConsumptionActivePowerLimit sends a new failsafe active power limit.
 func (w *LPCWrapper) WriteFailsafeConsumptionActivePowerLimit(entity spineapi.EntityRemoteInterface, value float64) error {
+	if w.uc == nil {
+		return errLPCNotInitialized
+	}
 	_, err := w.uc.WriteFailsafeConsumptionActivePowerLimit(entity, value)
 	return err
 }
 
 // FailsafeDurationMinimum returns the minimum failsafe duration.
 func (w *LPCWrapper) FailsafeDurationMinimum(entity spineapi.EntityRemoteInterface) (time.Duration, error) {
+	if w.uc == nil {
+		return 0, errLPCNotInitialized
+	}
 	return w.uc.FailsafeDurationMinimum(entity)
 }
 
 // WriteFailsafeDurationMinimum sends a new minimum failsafe duration (must be 2h–24h).
 func (w *LPCWrapper) WriteFailsafeDurationMinimum(entity spineapi.EntityRemoteInterface, duration time.Duration) error {
+	if w.uc == nil {
+		return errLPCNotInitialized
+	}
 	_, err := w.uc.WriteFailsafeDurationMinimum(entity, duration)
 	return err
 }
@@ -87,5 +130,8 @@ func (w *LPCWrapper) WriteFailsafeDurationMinimum(entity spineapi.EntityRemoteIn
 // ConsumptionNominalMax returns the nominal maximum active power the controllable system
 // can consume.
 func (w *LPCWrapper) ConsumptionNominalMax(entity spineapi.EntityRemoteInterface) (float64, error) {
+	if w.uc == nil {
+		return 0, errLPCNotInitialized
+	}
 	return w.uc.ConsumptionNominalMax(entity)
 }

--- a/eebus-bridge/internal/usecases/lpc_test.go
+++ b/eebus-bridge/internal/usecases/lpc_test.go
@@ -14,7 +14,7 @@ func TestLPCEventRouting(t *testing.T) {
 	ch := bus.Subscribe()
 	defer bus.Unsubscribe(ch)
 
-	lpcWrapper := usecases.NewLPCWrapper(bus)
+	lpcWrapper := usecases.NewLPCWrapper(bus, nil, false)
 
 	// Simulate an eebus-go event callback directly (no SPINE entity needed).
 	lpcWrapper.HandleEvent("test-ski", nil, nil, eglpc.DataUpdateLimit)
@@ -37,7 +37,7 @@ func TestLPCFailsafePowerEventRouting(t *testing.T) {
 	ch := bus.Subscribe()
 	defer bus.Unsubscribe(ch)
 
-	lpcWrapper := usecases.NewLPCWrapper(bus)
+	lpcWrapper := usecases.NewLPCWrapper(bus, nil, false)
 	lpcWrapper.HandleEvent("ski-2", nil, nil, eglpc.DataUpdateFailsafeConsumptionActivePowerLimit)
 
 	select {
@@ -55,7 +55,7 @@ func TestLPCFailsafeDurationEventRouting(t *testing.T) {
 	ch := bus.Subscribe()
 	defer bus.Unsubscribe(ch)
 
-	lpcWrapper := usecases.NewLPCWrapper(bus)
+	lpcWrapper := usecases.NewLPCWrapper(bus, nil, false)
 	lpcWrapper.HandleEvent("ski-3", nil, nil, eglpc.DataUpdateFailsafeDurationMinimum)
 
 	select {
@@ -73,7 +73,7 @@ func TestLPCUnknownEventIgnored(t *testing.T) {
 	ch := bus.Subscribe()
 	defer bus.Unsubscribe(ch)
 
-	lpcWrapper := usecases.NewLPCWrapper(bus)
+	lpcWrapper := usecases.NewLPCWrapper(bus, nil, false)
 	lpcWrapper.HandleEvent("ski-x", nil, nil, "unknown-event-type")
 
 	select {

--- a/eebus-bridge/internal/usecases/monitoring.go
+++ b/eebus-bridge/internal/usecases/monitoring.go
@@ -1,6 +1,9 @@
 package usecases
 
 import (
+	"errors"
+	"log"
+
 	eebusapi "github.com/enbility/eebus-go/api"
 	mampc "github.com/enbility/eebus-go/usecases/ma/mpc"
 	spineapi "github.com/enbility/spine-go/api"
@@ -10,17 +13,24 @@ import (
 // MonitoringWrapper wraps the eebus-go MPC (Monitoring of Power Consumption) use case
 // and routes events to the internal EventBus.
 type MonitoringWrapper struct {
-	uc  *mampc.MPC
-	bus *eebus.EventBus
+	uc       *mampc.MPC
+	bus      *eebus.EventBus
+	registry *eebus.DeviceRegistry
+	debug    bool
 }
 
+var errMonitoringNotInitialized = errors.New("monitoring use case not initialized")
+
 // NewMonitoringWrapper creates a new MonitoringWrapper. Call Setup() before using the use case.
-func NewMonitoringWrapper(bus *eebus.EventBus) *MonitoringWrapper {
-	return &MonitoringWrapper{bus: bus}
+func NewMonitoringWrapper(bus *eebus.EventBus, registry *eebus.DeviceRegistry, debugEvents bool) *MonitoringWrapper {
+	return &MonitoringWrapper{bus: bus, registry: registry, debug: debugEvents}
 }
 
 // Setup initialises the underlying eebus-go MPC use case for the given local entity.
 func (w *MonitoringWrapper) Setup(localEntity spineapi.EntityLocalInterface) {
+	if localEntity == nil {
+		return
+	}
 	w.uc = mampc.NewMPC(localEntity, w.HandleEvent)
 }
 
@@ -31,7 +41,21 @@ func (w *MonitoringWrapper) UseCase() *mampc.MPC {
 
 // HandleEvent is the api.EntityEventCallback passed to eebus-go. It translates
 // eebus-go event types to internal EventBus events.
-func (w *MonitoringWrapper) HandleEvent(ski string, _ spineapi.DeviceRemoteInterface, _ spineapi.EntityRemoteInterface, event eebusapi.EventType) {
+func (w *MonitoringWrapper) HandleEvent(ski string, device spineapi.DeviceRemoteInterface, entity spineapi.EntityRemoteInterface, event eebusapi.EventType) {
+	if w.debug {
+		log.Printf(
+			"[DEBUG] EEBUS monitoring event received: ski=%s event=%s has_device=%t has_entity=%t",
+			ski,
+			event,
+			device != nil,
+			entity != nil,
+		)
+	}
+
+	if w.registry != nil {
+		w.registry.UpsertObservation(ski, device, entity, "monitoring")
+	}
+
 	var eventType string
 	switch event {
 	case mampc.DataUpdatePower:
@@ -53,40 +77,63 @@ func (w *MonitoringWrapper) HandleEvent(ski string, _ spineapi.DeviceRemoteInter
 	default:
 		return
 	}
-	w.bus.Publish(eebus.Event{SKI: ski, Type: eventType})
+	if w.bus != nil {
+		w.bus.Publish(eebus.Event{SKI: ski, Type: eventType})
+	}
 }
 
 // Power returns the total momentary active power for the given remote entity.
 func (w *MonitoringWrapper) Power(entity spineapi.EntityRemoteInterface) (float64, error) {
+	if w.uc == nil {
+		return 0, errMonitoringNotInitialized
+	}
 	return w.uc.Power(entity)
 }
 
 // PowerPerPhase returns the phase-specific momentary active power.
 func (w *MonitoringWrapper) PowerPerPhase(entity spineapi.EntityRemoteInterface) ([]float64, error) {
+	if w.uc == nil {
+		return nil, errMonitoringNotInitialized
+	}
 	return w.uc.PowerPerPhase(entity)
 }
 
 // EnergyConsumed returns the total consumed energy.
 func (w *MonitoringWrapper) EnergyConsumed(entity spineapi.EntityRemoteInterface) (float64, error) {
+	if w.uc == nil {
+		return 0, errMonitoringNotInitialized
+	}
 	return w.uc.EnergyConsumed(entity)
 }
 
 // EnergyProduced returns the total produced/fed-in energy.
 func (w *MonitoringWrapper) EnergyProduced(entity spineapi.EntityRemoteInterface) (float64, error) {
+	if w.uc == nil {
+		return 0, errMonitoringNotInitialized
+	}
 	return w.uc.EnergyProduced(entity)
 }
 
 // CurrentPerPhase returns the phase-specific momentary current.
 func (w *MonitoringWrapper) CurrentPerPhase(entity spineapi.EntityRemoteInterface) ([]float64, error) {
+	if w.uc == nil {
+		return nil, errMonitoringNotInitialized
+	}
 	return w.uc.CurrentPerPhase(entity)
 }
 
 // VoltagePerPhase returns the phase-specific voltage.
 func (w *MonitoringWrapper) VoltagePerPhase(entity spineapi.EntityRemoteInterface) ([]float64, error) {
+	if w.uc == nil {
+		return nil, errMonitoringNotInitialized
+	}
 	return w.uc.VoltagePerPhase(entity)
 }
 
 // Frequency returns the power network frequency.
 func (w *MonitoringWrapper) Frequency(entity spineapi.EntityRemoteInterface) (float64, error) {
+	if w.uc == nil {
+		return 0, errMonitoringNotInitialized
+	}
 	return w.uc.Frequency(entity)
 }

--- a/eebus-bridge/internal/usecases/monitoring_test.go
+++ b/eebus-bridge/internal/usecases/monitoring_test.go
@@ -14,7 +14,7 @@ func TestMonitoringEventRouting(t *testing.T) {
 	ch := bus.Subscribe()
 	defer bus.Unsubscribe(ch)
 
-	monWrapper := usecases.NewMonitoringWrapper(bus)
+	monWrapper := usecases.NewMonitoringWrapper(bus, nil, false)
 
 	monWrapper.HandleEvent("test-ski", nil, nil, mampc.DataUpdatePower)
 
@@ -33,7 +33,7 @@ func TestMonitoringEnergyConsumedEventRouting(t *testing.T) {
 	ch := bus.Subscribe()
 	defer bus.Unsubscribe(ch)
 
-	monWrapper := usecases.NewMonitoringWrapper(bus)
+	monWrapper := usecases.NewMonitoringWrapper(bus, nil, false)
 	monWrapper.HandleEvent("ski-2", nil, nil, mampc.DataUpdateEnergyConsumed)
 
 	select {
@@ -51,7 +51,7 @@ func TestMonitoringFrequencyEventRouting(t *testing.T) {
 	ch := bus.Subscribe()
 	defer bus.Unsubscribe(ch)
 
-	monWrapper := usecases.NewMonitoringWrapper(bus)
+	monWrapper := usecases.NewMonitoringWrapper(bus, nil, false)
 	monWrapper.HandleEvent("ski-3", nil, nil, mampc.DataUpdateFrequency)
 
 	select {
@@ -69,7 +69,7 @@ func TestMonitoringUnknownEventIgnored(t *testing.T) {
 	ch := bus.Subscribe()
 	defer bus.Unsubscribe(ch)
 
-	monWrapper := usecases.NewMonitoringWrapper(bus)
+	monWrapper := usecases.NewMonitoringWrapper(bus, nil, false)
 	monWrapper.HandleEvent("ski-x", nil, nil, "unknown-event-type")
 
 	select {


### PR DESCRIPTION
The bridge previously returned codes.Unimplemented for every GetPowerConsumption, GetEnergyConsumed, GetMeasurements, and all LPC read/write RPC methods. The Python integration handled this gracefully by hiding entities, but in practice every sensor and number entity stayed empty in production because no real measurements ever reached HA.

This change wires the SPINE entity lookup that was missing:

- internal/eebus/registry: add UpsertObservation() and FirstAvailableEntity() so the registry tracks (SKI -> remote device / entity / known use-cases) as eebus-go callbacks arrive, with a global fallback for clients that send an empty SKI.
- internal/usecases/{lpc,monitoring}: pass the registry and a debug flag into the wrappers, call UpsertObservation() from HandleEvent, and guard every wrapped method with errLPCNotInitialized / errMonitoringNotInitialized so a not-yet-set-up wrapper no longer panics.
- internal/grpc/{lpc,monitoring}_service: resolve the remote entity via the registry and return real ucapi values. Monitoring adds a safe nil-entity fallback (with recover()) for buses that publish without a SKI, and populates GetMeasurements with both power_consumption and energy_consumed entries.
- internal/grpc/device_service: implement ListPairedDevices from the registry so callers can see paired SKIs, brand/model/serial, and supported use cases.
- internal/eebus/callbacks + service + cmd/eebus-bridge/main: thread a Config.Logging.DebugEvents flag (also exposed as EEBUS_DEBUG_EVENTS env var) through callbacks and use-case wrappers for runtime tracing of incoming SPINE events. Initialise the registry once in main and inject it into every gRPC service constructor.

Python coordinator robustness (custom_components/eebus/coordinator.py):

- Register the remote SKI lazily on first poll and re-register after RE_REGISTER_NOT_FOUND_STREAK consecutive NOT_FOUND responses so that a bridge restart no longer leaves a stale Python coordinator pinned to a non-existent device entry.
- For every monitoring/LPC read, retry with an empty-SKI fallback request when the bridge returns NOT_FOUND so reads still succeed while the registry is still being populated.
- Warn when the configured remote SKI equals the bridge's local SKI (a common misconfiguration that previously presented as silently empty sensors).
- Detect UNIMPLEMENTED on writes (LPC, failsafe, heartbeat) to gate the corresponding entities the same way reads already did.

Config flow (custom_components/eebus/config_flow.py): add an explicit CONFIG_RPC_TIMEOUT on GetStatus calls so the initial connection probe fails fast instead of hanging on a wedged channel.

All Go and Python tests pass.

Refs: ported from nkashyap/eebus-ha-bridge fork (commits cfc742b, 16067ba).