### PR TITLE
feat: add Home Assistant add-on packaging for the Go bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,20 @@ Home Assistant                    eebus-bridge (Go)         Vaillant VR940f
 
 ### Bridge-Setup
 
-Der Go-basierte Bridge-Dienst muss separat laufen (Docker empfohlen):
+Der Go-basierte Bridge-Dienst muss separat laufen. Je nach HA-Installationsart unterschiedlich:
+
+#### Home Assistant OS / Supervised -- Add-on (empfohlen)
+
+1. **Settings** > **Add-ons** > **Add-on Store** > Drei-Punkte-Menue > **Repositories**
+2. Repository-URL einfuegen: `https://github.com/volschin/eebus-ha-bridge`
+3. **Add** > Store schliessen und neu oeffnen
+4. **EEBUS Bridge** im Store waehlen > **Install**
+5. **Configuration** pruefen (Defaults reichen meist) > **Start**
+6. Im Bridge-Log den **SKI** notieren (fuer Pairing).
+
+In der Integration anschliessend `localhost:50051` als Bridge eintragen.
+
+#### Home Assistant Core / Container -- Docker Compose
 
 ```bash
 docker-compose up -d eebus-bridge

--- a/eebus-bridge-addon/CHANGELOG.md
+++ b/eebus-bridge-addon/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 0.2.1
+
+- Initial release as Home Assistant add-on.
+- Bundles `volschin/eebus-ha-bridge` v0.2.1 Go bridge binary.
+- Persists SHIP certificates under `/data/certs`.
+- Configurable via add-on options (gRPC port, EEBUS port, vendor/brand/model/serial).

--- a/eebus-bridge-addon/DOCS.md
+++ b/eebus-bridge-addon/DOCS.md
@@ -1,0 +1,54 @@
+# EEBUS Bridge Add-on
+
+## Overview
+
+This add-on runs the Go-based EEBUS bridge inside Home Assistant OS. It
+exposes a local gRPC API consumed by the `eebus` custom integration and
+speaks the EEBUS SHIP/SPINE protocol on the LAN to heat pumps and other
+EEBUS-capable devices.
+
+Host networking is required so the bridge can discover devices via mDNS
+and accept incoming SHIP connections on TCP/4712.
+
+## Prerequisites
+
+- Home Assistant OS or Supervised (this add-on does not apply to Core or
+  Container installations).
+- The `eebus` custom integration installed via HACS.
+
+## Configuration
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `GRPC_PORT` | `50051` | Port for the gRPC API |
+| `EEBUS_PORT` | `4712` | Port for EEBUS SHIP protocol |
+| `EEBUS_VENDOR` | `HomeAssistant` | Vendor name announced via EEBUS |
+| `EEBUS_BRAND` | `eebus-bridge` | Brand name announced via EEBUS |
+| `EEBUS_MODEL` | `eebus-bridge` | Model name announced via EEBUS |
+| `EEBUS_SERIAL` | *(auto)* | Serial number (leave empty for default) |
+
+## Integration setup
+
+When configuring the EEBUS integration, use:
+
+- **Host:** `localhost`
+- **Port:** `50051` (or whatever you set `GRPC_PORT` to)
+
+## Certificate persistence
+
+The bridge persists its SHIP certificate and private key under `/data/certs`
+inside the add-on. This directory survives add-on restarts and upgrades but
+is removed if the add-on is uninstalled. Re-pairing with the heat pump may
+be required after uninstall/reinstall.
+
+## Troubleshooting
+
+Check the add-on logs in **Settings → Add-ons → EEBUS Bridge → Log**.
+The bridge logs the local SKI at startup — use this for pairing with the
+heat pump.
+
+If devices are not discovered:
+
+- Confirm `host_network: true` was not disabled.
+- Verify the heat pump and HA host are on the same VLAN/subnet.
+- Check port 4712/tcp is not blocked by a firewall.

--- a/eebus-bridge-addon/Dockerfile
+++ b/eebus-bridge-addon/Dockerfile
@@ -1,8 +1,8 @@
 ARG BUILD_FROM=ghcr.io/home-assistant/amd64-base:3.20
-ARG EEBUS_BRIDGE_VERSION=v0.2.1
+ARG EEBUS_BRIDGE_VERSION=v0.5.3
 
 # --- Build stage ---
-FROM golang:1.26-alpine AS builder
+FROM golang:1.25-alpine AS builder
 
 ARG EEBUS_BRIDGE_VERSION
 RUN apk add --no-cache git

--- a/eebus-bridge-addon/Dockerfile
+++ b/eebus-bridge-addon/Dockerfile
@@ -1,0 +1,27 @@
+ARG BUILD_FROM=ghcr.io/home-assistant/amd64-base:3.20
+ARG EEBUS_BRIDGE_VERSION=v0.2.1
+
+# --- Build stage ---
+FROM golang:1.26-alpine AS builder
+
+ARG EEBUS_BRIDGE_VERSION
+RUN apk add --no-cache git
+
+RUN git clone https://github.com/volschin/eebus-ha-bridge.git /src && \
+    cd /src && \
+    git switch --detach ${EEBUS_BRIDGE_VERSION}
+
+WORKDIR /src/eebus-bridge
+RUN go mod download
+RUN CGO_ENABLED=0 go build -o /eebus-bridge ./cmd/eebus-bridge
+
+# --- Runtime stage ---
+FROM $BUILD_FROM
+
+RUN apk add --no-cache ca-certificates
+
+COPY --from=builder /eebus-bridge /usr/local/bin/eebus-bridge
+COPY run.sh /
+RUN chmod a+x /run.sh
+
+CMD [ "/run.sh" ]

--- a/eebus-bridge-addon/README.md
+++ b/eebus-bridge-addon/README.md
@@ -1,0 +1,11 @@
+# EEBUS Bridge Add-on for Home Assistant
+
+Runs the EEBUS Bridge (Go) as a Home Assistant add-on, enabling EEBUS
+SHIP/SPINE protocol communication with heat pumps directly from your HA
+instance. Pairs with the `eebus` custom integration.
+
+See [DOCS.md](DOCS.md) for configuration and pairing details.
+
+This add-on is only required for Home Assistant OS (and Supervised) users.
+HA Core or HA Container deployments should run the bridge as a standalone
+Docker container via `docker-compose` — see the project root `README.md`.

--- a/eebus-bridge-addon/build.yaml
+++ b/eebus-bridge-addon/build.yaml
@@ -1,0 +1,5 @@
+build_from:
+  amd64: ghcr.io/home-assistant/amd64-base:3.20
+  aarch64: ghcr.io/home-assistant/aarch64-base:3.20
+args:
+  EEBUS_BRIDGE_VERSION: v0.2.1

--- a/eebus-bridge-addon/build.yaml
+++ b/eebus-bridge-addon/build.yaml
@@ -2,4 +2,4 @@ build_from:
   amd64: ghcr.io/home-assistant/amd64-base:3.20
   aarch64: ghcr.io/home-assistant/aarch64-base:3.20
 args:
-  EEBUS_BRIDGE_VERSION: v0.2.1
+  EEBUS_BRIDGE_VERSION: v0.5.3

--- a/eebus-bridge-addon/config.yaml
+++ b/eebus-bridge-addon/config.yaml
@@ -2,7 +2,7 @@ name: EEBUS Bridge
 description: >-
   EEBUS SHIP/SPINE bridge for heat pump communication.
   Provides gRPC interface for the EEBUS custom integration.
-version: 0.2.1
+version: 0.5.3
 slug: eebus_bridge
 init: false
 arch:

--- a/eebus-bridge-addon/config.yaml
+++ b/eebus-bridge-addon/config.yaml
@@ -1,0 +1,33 @@
+name: EEBUS Bridge
+description: >-
+  EEBUS SHIP/SPINE bridge for heat pump communication.
+  Provides gRPC interface for the EEBUS custom integration.
+version: 0.2.1
+slug: eebus_bridge
+init: false
+arch:
+  - amd64
+  - aarch64
+host_network: true
+ports:
+  50051/tcp: null
+  4712/tcp: null
+ports_description:
+  50051/tcp: gRPC API (used by the HA integration)
+  4712/tcp: EEBUS SHIP protocol
+map:
+  - addon_config:rw
+options:
+  GRPC_PORT: 50051
+  EEBUS_PORT: 4712
+  EEBUS_VENDOR: HomeAssistant
+  EEBUS_BRAND: eebus-bridge
+  EEBUS_MODEL: eebus-bridge
+  EEBUS_SERIAL: ""
+schema:
+  GRPC_PORT: port
+  EEBUS_PORT: port
+  EEBUS_VENDOR: str
+  EEBUS_BRAND: str
+  EEBUS_MODEL: str
+  EEBUS_SERIAL: str?

--- a/eebus-bridge-addon/config.yaml
+++ b/eebus-bridge-addon/config.yaml
@@ -21,7 +21,7 @@ options:
   GRPC_PORT: 50051
   EEBUS_PORT: 4712
   EEBUS_VENDOR: HomeAssistant
-  EEBUS_BRAND: eebus-bridge
+  EEBUS_BRAND: "Home Assistant"
   EEBUS_MODEL: eebus-bridge
   EEBUS_SERIAL: ""
 schema:

--- a/eebus-bridge-addon/run.sh
+++ b/eebus-bridge-addon/run.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/with-contenv bashio
+
+export EEBUS_GRPC_PORT=$(bashio::config "GRPC_PORT")
+export EEBUS_PORT=$(bashio::config "EEBUS_PORT")
+export EEBUS_VENDOR=$(bashio::config "EEBUS_VENDOR")
+export EEBUS_BRAND=$(bashio::config "EEBUS_BRAND")
+export EEBUS_MODEL=$(bashio::config "EEBUS_MODEL")
+
+SERIAL=$(bashio::config "EEBUS_SERIAL")
+if bashio::var.has_value "${SERIAL}"; then
+    export EEBUS_SERIAL="${SERIAL}"
+fi
+
+export EEBUS_CERT_STORAGE="/data/certs"
+mkdir -p "${EEBUS_CERT_STORAGE}"
+
+CONFIG_FILE="/etc/eebus-bridge/config.yaml"
+mkdir -p "$(dirname "${CONFIG_FILE}")"
+cat > "${CONFIG_FILE}" <<EOF
+grpc:
+  port: ${EEBUS_GRPC_PORT}
+eebus:
+  port: ${EEBUS_PORT}
+certificates:
+  auto_generate: true
+  storage_path: "${EEBUS_CERT_STORAGE}"
+EOF
+
+bashio::log.info "Starting EEBUS Bridge"
+bashio::log.info "  gRPC port:  ${EEBUS_GRPC_PORT}"
+bashio::log.info "  EEBUS port: ${EEBUS_PORT}"
+bashio::log.info "  Cert store: ${EEBUS_CERT_STORAGE}"
+
+exec /usr/local/bin/eebus-bridge --config "${CONFIG_FILE}"

--- a/eebus-bridge-addon/run.sh
+++ b/eebus-bridge-addon/run.sh
@@ -7,9 +7,16 @@ export EEBUS_BRAND=$(bashio::config "EEBUS_BRAND")
 export EEBUS_MODEL=$(bashio::config "EEBUS_MODEL")
 
 SERIAL=$(bashio::config "EEBUS_SERIAL")
-if bashio::var.has_value "${SERIAL}"; then
-    export EEBUS_SERIAL="${SERIAL}"
+if ! bashio::var.has_value "${SERIAL}"; then
+    # Bridge requires a serial; generate and persist a stable one in /data
+    SERIAL_FILE="/data/serial"
+    if [ ! -s "${SERIAL_FILE}" ]; then
+        head -c 8 /dev/urandom | od -An -tx1 | tr -d ' \n' > "${SERIAL_FILE}"
+    fi
+    SERIAL=$(cat "${SERIAL_FILE}")
+    bashio::log.info "No serial configured; using generated serial ${SERIAL}"
 fi
+export EEBUS_SERIAL="${SERIAL}"
 
 export EEBUS_CERT_STORAGE="/data/certs"
 mkdir -p "${EEBUS_CERT_STORAGE}"

--- a/repository.yaml
+++ b/repository.yaml
@@ -1,0 +1,3 @@
+name: EEBUS HA Bridge Add-ons
+url: https://github.com/volschin/eebus-ha-bridge
+maintainer: volschin <veit@olschinski.de>


### PR DESCRIPTION
Adds eebus-bridge-addon/ with config.yaml, build.yaml, Dockerfile, run.sh, DOCS.md, README.md, CHANGELOG.md plus a top-level repository.yaml so Home Assistant OS / Supervised users can install the bridge through the HA add-on store.

The add-on builder clones volschin/eebus-ha-bridge at the pinned EEBUS_BRIDGE_VERSION (v0.2.1) and builds the existing Go bridge against golang:1.26-alpine. The bridge already supports EEBUS_* env overrides via applyEnvOverrides() in internal/config, so the bashio-based run.sh maps add-on options 1:1 to env vars and writes a minimal config.yaml. SHIP certificates are persisted under /data/certs.

HA Core / Container deployments are unaffected and keep using docker-compose as before; the README documents both installation paths.

Refs: ported from mathiasbl/eebus-ha-bridge fork.