### PR TITLE
fix: bump grpcio requirement to >=1.80.0 (closes #22)

### DIFF
--- a/custom_components/eebus/manifest.json
+++ b/custom_components/eebus/manifest.json
@@ -8,7 +8,7 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/volschin/eebus-ha-bridge/issues",
   "quality_scale": "gold",
-  "requirements": ["grpcio>=1.60.0", "protobuf>=4.25.0"],
+  "requirements": ["grpcio>=1.80.0", "protobuf>=4.25.0"],
   "single_config_entry": false,
-  "version": "0.2.2"
+  "version": "0.2.3"
 }


### PR DESCRIPTION
## Summary
- Bump `grpcio>=1.60.0` → `grpcio>=1.80.0` in `custom_components/eebus/manifest.json` to match `GRPC_GENERATED_VERSION` in generated stubs
- Bump version `0.2.2` → `0.2.3`

## Root Cause
Generated stubs in `custom_components/eebus/generated/eebus/v1/*_pb2_grpc.py` were produced by `grpcio-tools` 1.80+ and refuse to load against older grpcio at import time. Manifest floor of `1.60.0` allowed HA to resolve grpcio 1.78.0, producing the `RuntimeError` reported in #22.

## Test plan
- [ ] HA installs grpcio>=1.80.0 in fresh venv
- [ ] Integration loads without RuntimeError
- [ ] CI green (HACS, hassfest, tests)

Fixes #22