### PR TITLE
fix: regenerate stubs with grpcio-tools 1.78.0 to match HA constraint

### DIFF
--- a/custom_components/eebus/generated/eebus/v1/common_pb2_grpc.py
+++ b/custom_components/eebus/generated/eebus/v1/common_pb2_grpc.py
@@ -4,7 +4,7 @@ import grpc
 import warnings
 
 
-GRPC_GENERATED_VERSION = '1.80.0'
+GRPC_GENERATED_VERSION = '1.78.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/custom_components/eebus/generated/eebus/v1/device_service_pb2_grpc.py
+++ b/custom_components/eebus/generated/eebus/v1/device_service_pb2_grpc.py
@@ -6,7 +6,7 @@ import warnings
 from . import common_pb2 as eebus_dot_v1_dot_common__pb2
 from . import device_service_pb2 as eebus_dot_v1_dot_device__service__pb2
 
-GRPC_GENERATED_VERSION = '1.80.0'
+GRPC_GENERATED_VERSION = '1.78.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/custom_components/eebus/generated/eebus/v1/lpc_service_pb2_grpc.py
+++ b/custom_components/eebus/generated/eebus/v1/lpc_service_pb2_grpc.py
@@ -6,7 +6,7 @@ import warnings
 from . import common_pb2 as eebus_dot_v1_dot_common__pb2
 from . import lpc_service_pb2 as eebus_dot_v1_dot_lpc__service__pb2
 
-GRPC_GENERATED_VERSION = '1.80.0'
+GRPC_GENERATED_VERSION = '1.78.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/custom_components/eebus/generated/eebus/v1/monitoring_service_pb2_grpc.py
+++ b/custom_components/eebus/generated/eebus/v1/monitoring_service_pb2_grpc.py
@@ -6,7 +6,7 @@ import warnings
 from . import common_pb2 as eebus_dot_v1_dot_common__pb2
 from . import monitoring_service_pb2 as eebus_dot_v1_dot_monitoring__service__pb2
 
-GRPC_GENERATED_VERSION = '1.80.0'
+GRPC_GENERATED_VERSION = '1.78.0'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 

--- a/custom_components/eebus/manifest.json
+++ b/custom_components/eebus/manifest.json
@@ -8,7 +8,7 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/volschin/eebus-ha-bridge/issues",
   "quality_scale": "gold",
-  "requirements": ["grpcio>=1.80.0", "protobuf>=4.25.0"],
+  "requirements": ["grpcio>=1.78.0", "protobuf>=4.25.0"],
   "single_config_entry": false,
-  "version": "0.2.3"
+  "version": "0.2.4"
 }

--- a/generate_proto.sh
+++ b/generate_proto.sh
@@ -2,10 +2,17 @@
 # Generate Python gRPC stubs from protobuf definitions
 set -euo pipefail
 
+# Home Assistant Core pins grpcio==1.78.0 in package_constraints.txt.
+# Stubs must be generated with a matching grpcio-tools so the embedded
+# GRPC_GENERATED_VERSION does not exceed HA's runtime grpcio (see issue #22).
+GRPCIO_TOOLS_VERSION="${GRPCIO_TOOLS_VERSION:-1.78.0}"
+
 PROTO_DIR="eebus-bridge/proto"
 OUT_DIR="custom_components/eebus/generated"
 
 mkdir -p "$OUT_DIR"
+
+pip install --quiet "grpcio-tools==${GRPCIO_TOOLS_VERSION}"
 
 python -m grpc_tools.protoc \
   -I "$PROTO_DIR" \


### PR DESCRIPTION
## Summary
- Home Assistant Core pins `grpcio==1.78.0` in [`package_constraints.txt`](https://github.com/home-assistant/core/blob/dev/homeassistant/package_constraints.txt). The previous fix in #25 bumped the manifest floor to `grpcio>=1.80.0`, which makes the dependency set unsatisfiable: HA refuses to install the integration with `Because you require grpcio>=1.80.0 and grpcio==1.78.0, we can conclude that your requirements are unsatisfiable`.
- Regenerate gRPC stubs with `grpcio-tools==1.78.0` so `GRPC_GENERATED_VERSION` is `'1.78.0'` and matches HA's runtime.
- Pin `grpcio-tools==1.78.0` in `generate_proto.sh` (overridable via `GRPCIO_TOOLS_VERSION`) so future regens stay aligned with HA.
- Relax manifest requirement to `grpcio>=1.78.0`; bump version `0.2.3` → `0.2.4`.

Closes follow-up report on #22.

## Test plan
- [x] `grep GRPC_GENERATED_VERSION custom_components/eebus/generated/eebus/v1/*_grpc.py` → all `'1.78.0'`
- [x] Stubs import cleanly under Python with `grpcio==1.78.0` installed
- [x] Relative imports preserved (`from . import common_pb2 ...`)
- [ ] CI green (hacs, hassfest, tests on Python 3.12/3.13/3.14)