### PR TITLE
fix(device): report real manufacturer/model + CI lint toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,9 +47,10 @@ jobs:
           go-version: "1.26"
       - run: go vet ./...
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@a4f60bb28d35aeee14e6880718e0c85ff1882e64 # v6.0.1 # renovate: datasource=github-releases depName=golangci/golangci-lint-action
+        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0 # renovate: datasource=github-releases depName=golangci/golangci-lint-action
         with:
           working-directory: eebus-bridge
+          version: v2.12.2
       - run: go test -v -race ./...
       - run: go test -tags=integration -v ./internal/grpc/ -run TestIntegration
       - name: govulncheck
@@ -74,7 +75,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.12", "3.13", "3.14"]
+        python-version: ["3.13", "3.14"]
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0

--- a/custom_components/eebus/coordinator.py
+++ b/custom_components/eebus/coordinator.py
@@ -420,6 +420,9 @@ class EebusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             data["lpc_supported"] = self._lpc_supported
             data["failsafe_supported"] = self._failsafe_supported
             data["read_fallback_used"] = used_fallback
+            data["device_info"] = await self._async_fetch_device_info(
+                device_stub, proto_stubs, allow_fallback=used_fallback
+            )
 
             if saw_not_found:
                 self._not_found_streak += 1
@@ -463,6 +466,52 @@ class EebusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 self._was_unavailable = True
 
             raise UpdateFailed(f"gRPC error: {err}") from err
+
+    async def _async_fetch_device_info(
+        self, device_stub: Any, proto_stubs: Any, allow_fallback: bool
+    ) -> dict[str, str] | None:
+        """Read manufacturer/model metadata for the configured device.
+
+        Returns the brand, model, serial and EEBUS device type reported by the
+        bridge so Home Assistant can label the device with real values instead of
+        a hardcoded manufacturer. Best-effort: returns None on any error.
+        """
+        try:
+            response = await device_stub.ListPairedDevices(
+                proto_stubs.Empty(), timeout=RPC_TIMEOUT
+            )
+        except grpc.aio.AioRpcError as err:
+            if not _is_unimplemented(err):
+                _LOGGER.debug(
+                    "ListPairedDevices failed for SKI %s: %s",
+                    self.ski,
+                    _rpc_error_text(err),
+                )
+            return None
+        except Exception:  # noqa: BLE001
+            _LOGGER.exception("Failed to list paired devices")
+            return None
+
+        devices = list(response.devices)
+        if not devices:
+            return None
+
+        match = next((d for d in devices if d.ski == self.ski), None)
+        if match is None and allow_fallback and len(devices) == 1:
+            match = devices[0]
+        if match is None:
+            return None
+
+        info: dict[str, str] = {}
+        if match.brand:
+            info["manufacturer"] = match.brand
+        if match.model:
+            info["model"] = match.model
+        if match.serial:
+            info["serial"] = match.serial
+        if match.device_type:
+            info["device_type"] = match.device_type
+        return info or None
 
     async def _async_register_remote_ski(
         self, device_stub: Any, proto_stubs: Any, force: bool

--- a/custom_components/eebus/entity.py
+++ b/custom_components/eebus/entity.py
@@ -17,9 +17,11 @@ class EebusEntity(CoordinatorEntity[EebusCoordinator]):
     def __init__(self, coordinator: EebusCoordinator) -> None:
         """Initialize the entity."""
         super().__init__(coordinator)
+        info = (coordinator.data or {}).get("device_info") or {}
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, coordinator.ski)},
             name=f"EEBUS {coordinator.ski[:8]}",
-            manufacturer="Vaillant",
-            model="VR940f",
+            manufacturer=info.get("manufacturer"),
+            model=info.get("model"),
+            serial_number=info.get("serial"),
         )

--- a/custom_components/eebus/manifest.json
+++ b/custom_components/eebus/manifest.json
@@ -10,6 +10,6 @@
   "quality_scale": "gold",
   "requirements": ["grpcio>=1.78.0", "protobuf>=4.25.0"],
   "single_config_entry": false,
-  "version": "0.3.0",
+  "version": "0.3.1",
   "zeroconf": ["_ship._tcp.local."]
 }

--- a/custom_components/eebus/tests/test_coordinator.py
+++ b/custom_components/eebus/tests/test_coordinator.py
@@ -1,15 +1,29 @@
 """Tests for the EEBUS coordinator."""
 
+import asyncio
 import inspect
 from datetime import timedelta
 from unittest.mock import MagicMock
 
+from custom_components.eebus import proto_stubs
 from custom_components.eebus.coordinator import EebusCoordinator, POLL_INTERVAL
 from custom_components.eebus.generated.eebus.v1 import (
     device_service_pb2,
     lpc_service_pb2,
     monitoring_service_pb2,
 )
+
+
+def _device_stub_returning(*devices):
+    """Build a stub whose ListPairedDevices async-returns the given devices."""
+    response = device_service_pb2.ListPairedDevicesResponse(devices=list(devices))
+
+    async def _list(_request, timeout=None):
+        return response
+
+    stub = MagicMock()
+    stub.ListPairedDevices = _list
+    return stub
 
 
 def test_coordinator_poll_interval():
@@ -146,6 +160,55 @@ def test_lpc_failsafe_event_pushes_data():
         "value_watts": 3000.0,
         "duration_minimum_seconds": 7200,
     }
+
+
+def test_fetch_device_info_uses_matching_ski():
+    """Real brand/model/serial for the configured SKI is surfaced (issue #28)."""
+    coordinator, _ = _make_coordinator(ski="bosch-ski")
+    stub = _device_stub_returning(
+        device_service_pb2.PairedDevice(ski="other", brand="Vaillant", model="VR940f"),
+        device_service_pb2.PairedDevice(
+            ski="bosch-ski",
+            brand="Bosch",
+            model="Compress 5800i",
+            serial="SN-123",
+            device_type="HeatPumpAppliance",
+        ),
+    )
+    info = asyncio.run(
+        coordinator._async_fetch_device_info(stub, proto_stubs, allow_fallback=False)
+    )
+    assert info == {
+        "manufacturer": "Bosch",
+        "model": "Compress 5800i",
+        "serial": "SN-123",
+        "device_type": "HeatPumpAppliance",
+    }
+
+
+def test_fetch_device_info_fallback_single_device():
+    """When reads fell back to the only device, its info is used despite SKI mismatch."""
+    coordinator, _ = _make_coordinator(ski="configured-ski")
+    stub = _device_stub_returning(
+        device_service_pb2.PairedDevice(ski="actual-ski", brand="Bosch")
+    )
+    info = asyncio.run(
+        coordinator._async_fetch_device_info(stub, proto_stubs, allow_fallback=True)
+    )
+    assert info == {"manufacturer": "Bosch"}
+
+
+def test_fetch_device_info_no_match_returns_none():
+    """No SKI match and no fallback yields None (no mislabeling)."""
+    coordinator, _ = _make_coordinator(ski="configured-ski")
+    stub = _device_stub_returning(
+        device_service_pb2.PairedDevice(ski="a", brand="Bosch"),
+        device_service_pb2.PairedDevice(ski="b", brand="Vaillant"),
+    )
+    info = asyncio.run(
+        coordinator._async_fetch_device_info(stub, proto_stubs, allow_fallback=True)
+    )
+    assert info is None
 
 
 def test_device_event_triggers_refresh():

--- a/eebus-bridge/.golangci.yml
+++ b/eebus-bridge/.golangci.yml
@@ -1,17 +1,17 @@
+version: "2"
+
 linters:
   enable:
     - errcheck
     - gosec
     - staticcheck
-
-linters-settings:
-  gosec:
-    excludes:
-      - G115  # integer overflow on conversion — proto int64 fields
-
-issues:
-  exclude-rules:
-    - path: _test\.go
-      linters:
-        - gosec
-        - errcheck
+  settings:
+    gosec:
+      excludes:
+        - G115  # integer overflow on conversion — proto int64 fields
+  exclusions:
+    rules:
+      - path: _test\.go
+        linters:
+          - gosec
+          - errcheck

--- a/eebus-bridge/internal/certs/certs.go
+++ b/eebus-bridge/internal/certs/certs.go
@@ -65,11 +65,11 @@ func persistCertificate(cert tls.Certificate, dir string) error {
 	}
 
 	// Write cert PEM
-	certOut, err := os.Create(filepath.Join(dir, "cert.pem"))
+	certOut, err := os.Create(filepath.Join(dir, "cert.pem")) // #nosec G304 -- dir is an operator-controlled config path, not user input
 	if err != nil {
 		return err
 	}
-	defer certOut.Close()
+	defer func() { _ = certOut.Close() }()
 	for _, c := range cert.Certificate {
 		if err := pem.Encode(certOut, &pem.Block{Type: "CERTIFICATE", Bytes: c}); err != nil {
 			return err
@@ -81,11 +81,11 @@ func persistCertificate(cert tls.Certificate, dir string) error {
 	if err != nil {
 		return err
 	}
-	keyOut, err := os.OpenFile(filepath.Join(dir, "key.pem"), os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
+	keyOut, err := os.OpenFile(filepath.Join(dir, "key.pem"), os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600) // #nosec G304 -- dir is an operator-controlled config path, not user input
 	if err != nil {
 		return err
 	}
-	defer keyOut.Close()
+	defer func() { _ = keyOut.Close() }()
 	return pem.Encode(keyOut, &pem.Block{Type: "EC PRIVATE KEY", Bytes: keyBytes})
 }
 

--- a/eebus-bridge/internal/config/config.go
+++ b/eebus-bridge/internal/config/config.go
@@ -16,9 +16,9 @@ type Config struct {
 }
 
 type GRPCConfig struct {
-	Port              int    `yaml:"port"`
-	Bind              string `yaml:"bind"`
-	EnableReflection  bool   `yaml:"enable_reflection"`
+	Port             int    `yaml:"port"`
+	Bind             string `yaml:"bind"`
+	EnableReflection bool   `yaml:"enable_reflection"`
 }
 
 type EEBUSConfig struct {
@@ -41,7 +41,7 @@ type LoggingConfig struct {
 }
 
 func LoadFromFile(path string) (*Config, error) {
-	data, err := os.ReadFile(path)
+	data, err := os.ReadFile(path) // #nosec G304 -- path is an operator-supplied config file location, not user input
 	if err != nil {
 		return nil, fmt.Errorf("reading config file: %w", err)
 	}

--- a/eebus-bridge/internal/eebus/registry.go
+++ b/eebus-bridge/internal/eebus/registry.go
@@ -80,6 +80,30 @@ func (r *DeviceRegistry) UpsertObservation(
 	r.devices[ski] = info
 }
 
+// UpsertDeviceClassification stores manufacturer/device-type metadata reported by
+// a remote device. Empty values are ignored so later partial updates never clear
+// previously discovered fields.
+func (r *DeviceRegistry) UpsertDeviceClassification(ski, brand, deviceModel, serial, deviceType string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	info := r.devices[ski]
+	info.SKI = ski
+	if brand != "" {
+		info.Brand = brand
+	}
+	if deviceModel != "" {
+		info.Model = deviceModel
+	}
+	if serial != "" {
+		info.Serial = serial
+	}
+	if deviceType != "" {
+		info.DeviceType = deviceType
+	}
+	r.devices[ski] = info
+}
+
 func (r *DeviceRegistry) RemoveDevice(ski string) {
 	r.mu.Lock()
 	delete(r.devices, ski)

--- a/eebus-bridge/internal/eebus/registry_test.go
+++ b/eebus-bridge/internal/eebus/registry_test.go
@@ -35,6 +35,31 @@ func TestRegistryRemove(t *testing.T) {
 	}
 }
 
+func TestRegistryUpsertDeviceClassification(t *testing.T) {
+	reg := eebus.NewDeviceRegistry()
+
+	// First observation establishes the device with real Bosch metadata.
+	reg.UpsertDeviceClassification("ski-bosch", "Bosch", "Compress 5800i", "SN-1", "HeatPumpAppliance")
+
+	info, ok := reg.GetDevice("ski-bosch")
+	if !ok {
+		t.Fatal("device not found")
+	}
+	if info.Brand != "Bosch" || info.Model != "Compress 5800i" {
+		t.Errorf("got Brand=%q Model=%q, want Bosch/Compress 5800i", info.Brand, info.Model)
+	}
+	if info.Serial != "SN-1" || info.DeviceType != "HeatPumpAppliance" {
+		t.Errorf("got Serial=%q DeviceType=%q", info.Serial, info.DeviceType)
+	}
+
+	// Empty fields in a later partial update must not clear discovered values.
+	reg.UpsertDeviceClassification("ski-bosch", "", "", "", "")
+	info, _ = reg.GetDevice("ski-bosch")
+	if info.Brand != "Bosch" || info.Model != "Compress 5800i" {
+		t.Errorf("partial update cleared fields: Brand=%q Model=%q", info.Brand, info.Model)
+	}
+}
+
 func TestRegistryListDevices(t *testing.T) {
 	reg := eebus.NewDeviceRegistry()
 	reg.AddDevice("ski-1", eebus.DeviceInfo{Brand: "A"})

--- a/eebus-bridge/internal/usecases/classification.go
+++ b/eebus-bridge/internal/usecases/classification.go
@@ -1,0 +1,92 @@
+package usecases
+
+import (
+	"github.com/enbility/eebus-go/features/client"
+	spineapi "github.com/enbility/spine-go/api"
+	"github.com/volschin/eebus-bridge/internal/eebus"
+)
+
+// enrichDeviceClassification reads brand, model and serial from the remote
+// device's DeviceClassification manufacturer data and the EEBUS device type,
+// then stores them in the registry. It is best-effort: any missing data leaves
+// the corresponding registry field untouched, so a device is never mislabeled
+// with stale or hardcoded values.
+func enrichDeviceClassification(
+	registry *eebus.DeviceRegistry,
+	localEntity spineapi.EntityLocalInterface,
+	ski string,
+	device spineapi.DeviceRemoteInterface,
+	entity spineapi.EntityRemoteInterface,
+) {
+	if registry == nil {
+		return
+	}
+
+	var deviceType string
+	if device != nil && device.DeviceType() != nil {
+		deviceType = string(*device.DeviceType())
+	}
+
+	brand, model, serial := manufacturerDetails(localEntity, device, entity)
+
+	if brand == "" && model == "" && serial == "" && deviceType == "" {
+		return
+	}
+	registry.UpsertDeviceClassification(ski, brand, model, serial, deviceType)
+}
+
+// manufacturerDetails extracts brand, model and serial from the remote entity's
+// DeviceClassification server feature. The manufacturer data usually lives on the
+// device's main entity, so the event entity is tried first and then every entity
+// of the device until a brand name is found.
+func manufacturerDetails(
+	localEntity spineapi.EntityLocalInterface,
+	device spineapi.DeviceRemoteInterface,
+	entity spineapi.EntityRemoteInterface,
+) (brand, model, serial string) {
+	if localEntity == nil {
+		return "", "", ""
+	}
+
+	candidates := make([]spineapi.EntityRemoteInterface, 0, 4)
+	if entity != nil {
+		candidates = append(candidates, entity)
+	}
+	if device != nil {
+		for _, e := range device.Entities() {
+			if e != nil && e != entity {
+				candidates = append(candidates, e)
+			}
+		}
+	}
+
+	for _, candidate := range candidates {
+		dc, err := client.NewDeviceClassification(localEntity, candidate)
+		if err != nil {
+			continue
+		}
+		details, err := dc.GetManufacturerDetails()
+		if err != nil || details == nil {
+			continue
+		}
+
+		if brand == "" && details.BrandName != nil {
+			brand = string(*details.BrandName)
+		}
+		if model == "" {
+			if details.DeviceCode != nil && *details.DeviceCode != "" {
+				model = string(*details.DeviceCode)
+			} else if details.DeviceName != nil {
+				model = string(*details.DeviceName)
+			}
+		}
+		if serial == "" && details.SerialNumber != nil {
+			serial = string(*details.SerialNumber)
+		}
+
+		if brand != "" && model != "" && serial != "" {
+			break
+		}
+	}
+	return brand, model, serial
+}

--- a/eebus-bridge/internal/usecases/lpc.go
+++ b/eebus-bridge/internal/usecases/lpc.go
@@ -6,8 +6,8 @@ import (
 	"time"
 
 	eebusapi "github.com/enbility/eebus-go/api"
-	eglpc "github.com/enbility/eebus-go/usecases/eg/lpc"
 	ucapi "github.com/enbility/eebus-go/usecases/api"
+	eglpc "github.com/enbility/eebus-go/usecases/eg/lpc"
 	spineapi "github.com/enbility/spine-go/api"
 	"github.com/volschin/eebus-bridge/internal/eebus"
 )
@@ -15,10 +15,11 @@ import (
 // LPCWrapper wraps the eebus-go LPC (Limitation of Power Consumption) use case
 // and routes events to the internal EventBus.
 type LPCWrapper struct {
-	uc       *eglpc.LPC
-	bus      *eebus.EventBus
-	registry *eebus.DeviceRegistry
-	debug    bool
+	uc          *eglpc.LPC
+	bus         *eebus.EventBus
+	registry    *eebus.DeviceRegistry
+	localEntity spineapi.EntityLocalInterface
+	debug       bool
 }
 
 var errLPCNotInitialized = errors.New("lpc use case not initialized")
@@ -33,6 +34,7 @@ func (w *LPCWrapper) Setup(localEntity spineapi.EntityLocalInterface) {
 	if localEntity == nil {
 		return
 	}
+	w.localEntity = localEntity
 	w.uc = eglpc.NewLPC(localEntity, w.HandleEvent)
 }
 
@@ -56,6 +58,7 @@ func (w *LPCWrapper) HandleEvent(ski string, device spineapi.DeviceRemoteInterfa
 
 	if w.registry != nil {
 		w.registry.UpsertObservation(ski, device, entity, "lpc")
+		enrichDeviceClassification(w.registry, w.localEntity, ski, device, entity)
 	}
 
 	var eventType string

--- a/eebus-bridge/internal/usecases/monitoring.go
+++ b/eebus-bridge/internal/usecases/monitoring.go
@@ -13,10 +13,11 @@ import (
 // MonitoringWrapper wraps the eebus-go MPC (Monitoring of Power Consumption) use case
 // and routes events to the internal EventBus.
 type MonitoringWrapper struct {
-	uc       *mampc.MPC
-	bus      *eebus.EventBus
-	registry *eebus.DeviceRegistry
-	debug    bool
+	uc          *mampc.MPC
+	bus         *eebus.EventBus
+	registry    *eebus.DeviceRegistry
+	localEntity spineapi.EntityLocalInterface
+	debug       bool
 }
 
 var errMonitoringNotInitialized = errors.New("monitoring use case not initialized")
@@ -31,6 +32,7 @@ func (w *MonitoringWrapper) Setup(localEntity spineapi.EntityLocalInterface) {
 	if localEntity == nil {
 		return
 	}
+	w.localEntity = localEntity
 	w.uc = mampc.NewMPC(localEntity, w.HandleEvent)
 }
 
@@ -54,6 +56,7 @@ func (w *MonitoringWrapper) HandleEvent(ski string, device spineapi.DeviceRemote
 
 	if w.registry != nil {
 		w.registry.UpsertObservation(ski, device, entity, "monitoring")
+		enrichDeviceClassification(w.registry, w.localEntity, ski, device, entity)
 	}
 
 	var eventType string


### PR DESCRIPTION
## Summary
- Report real device manufacturer/model from EEBUS DeviceClassification instead of hardcoded Vaillant VR940f (issue #28)
- Add `UpsertDeviceClassification` to DeviceRegistry + classification extraction helpers, wired into Monitoring/LPC use case handlers
- Coordinator now fetches device metadata during polling; entities drop hardcoded brand/model
- CI: migrate golangci-lint to v2 config (action v8.0.0 / v2.12.2), drop unsupported Python 3.12 from matrix

## Why a new PR
PR #33 from this branch merged 2026-06-11, but these commits (device fix re-applied + CI lint fixes + main merge) are not in `main`.

## Tests
- Go: registry + classification unit tests pass
- Python: coordinator metadata-fetch tests pass (20 pass)