### PR TITLE
fix(eebus): normalize SKI to prevent duplicate device registry keys

### DIFF
--- a/eebus-bridge/internal/eebus/callbacks.go
+++ b/eebus-bridge/internal/eebus/callbacks.go
@@ -31,6 +31,7 @@ var _ api.ServiceReaderInterface = (*Callbacks)(nil)
 
 // RemoteSKIConnected is called when a remote SKI connects.
 func (c *Callbacks) RemoteSKIConnected(service api.ServiceInterface, ski string) {
+	ski = NormalizeSKI(ski)
 	if c.debugEvents {
 		log.Printf("[DEBUG] EEBUS callback: remote SKI connected: ski=%s", ski)
 	}
@@ -43,6 +44,7 @@ func (c *Callbacks) RemoteSKIConnected(service api.ServiceInterface, ski string)
 
 // RemoteSKIDisconnected is called when a remote SKI disconnects.
 func (c *Callbacks) RemoteSKIDisconnected(service api.ServiceInterface, ski string) {
+	ski = NormalizeSKI(ski)
 	if c.debugEvents {
 		log.Printf("[DEBUG] EEBUS callback: remote SKI disconnected: ski=%s", ski)
 	}
@@ -75,6 +77,7 @@ func (c *Callbacks) ServiceShipIDUpdate(ski string, shipID string) {
 
 // ServicePairingDetailUpdate is called when the pairing state of a remote service changes.
 func (c *Callbacks) ServicePairingDetailUpdate(ski string, detail *shipapi.ConnectionStateDetail) {
+	ski = NormalizeSKI(ski)
 	if c.debugEvents {
 		if detail != nil {
 			log.Printf("[DEBUG] EEBUS callback: pairing detail updated: ski=%s state=%v", ski, detail.State())
@@ -113,5 +116,6 @@ func (c *Callbacks) DiscoveredServices() []shipapi.RemoteService {
 func (c *Callbacks) PairingState(ski string) *shipapi.ConnectionStateDetail {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
+	ski = NormalizeSKI(ski)
 	return c.pairingStates[ski]
 }

--- a/eebus-bridge/internal/eebus/callbacks_test.go
+++ b/eebus-bridge/internal/eebus/callbacks_test.go
@@ -17,8 +17,9 @@ func TestCallbacksDispatchConnect(t *testing.T) {
 
 	select {
 	case evt := <-ch:
-		if evt.SKI != "test-ski-123" {
-			t.Errorf("SKI = %q, want test-ski-123", evt.SKI)
+		// SKI is normalized (uppercased, whitespace stripped) before dispatch.
+		if evt.SKI != "TEST-SKI-123" {
+			t.Errorf("SKI = %q, want TEST-SKI-123", evt.SKI)
 		}
 		if evt.Type != "device.connected" {
 			t.Errorf("Type = %q, want device.connected", evt.Type)

--- a/eebus-bridge/internal/eebus/registry.go
+++ b/eebus-bridge/internal/eebus/registry.go
@@ -1,6 +1,7 @@
 package eebus
 
 import (
+	"strings"
 	"sync"
 
 	spineapi "github.com/enbility/spine-go/api"
@@ -28,8 +29,18 @@ func NewDeviceRegistry() *DeviceRegistry {
 	}
 }
 
+// NormalizeSKI canonicalizes a SKI for use as a registry key: uppercase, no
+// surrounding or embedded whitespace. Remote peers (e.g. Bosch/Connect-Key) may
+// report the same SKI with differing case or spacing; normalizing prevents the
+// same device being stored under multiple keys, which later causes resolveEntity
+// lookups to fail with NOT_FOUND.
+func NormalizeSKI(ski string) string {
+	return strings.ToUpper(strings.ReplaceAll(strings.TrimSpace(ski), " ", ""))
+}
+
 func (r *DeviceRegistry) AddDevice(ski string, info DeviceInfo) {
 	r.mu.Lock()
+	ski = NormalizeSKI(ski)
 	info.SKI = ski
 	r.devices[ski] = info
 	r.mu.Unlock()
@@ -43,6 +54,15 @@ func (r *DeviceRegistry) UpsertObservation(
 ) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+
+	// A remote (e.g. Bosch/Connect-Key) can report the entity through the
+	// use-case callback with an empty SKI. Fall back to the real remote device
+	// SKI so HA's later WriteConsumptionLimit resolves the entity instead of
+	// failing with NOT_FOUND.
+	if ski == "" && remoteDevice != nil {
+		ski = remoteDevice.Ski()
+	}
+	ski = NormalizeSKI(ski)
 
 	info := r.devices[ski]
 	info.SKI = ski
@@ -87,6 +107,7 @@ func (r *DeviceRegistry) UpsertDeviceClassification(ski, brand, deviceModel, ser
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
+	ski = NormalizeSKI(ski)
 	info := r.devices[ski]
 	info.SKI = ski
 	if brand != "" {
@@ -106,6 +127,7 @@ func (r *DeviceRegistry) UpsertDeviceClassification(ski, brand, deviceModel, ser
 
 func (r *DeviceRegistry) RemoveDevice(ski string) {
 	r.mu.Lock()
+	ski = NormalizeSKI(ski)
 	delete(r.devices, ski)
 	r.mu.Unlock()
 }
@@ -113,6 +135,7 @@ func (r *DeviceRegistry) RemoveDevice(ski string) {
 func (r *DeviceRegistry) GetDevice(ski string) (DeviceInfo, bool) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
+	ski = NormalizeSKI(ski)
 	info, ok := r.devices[ski]
 	return info, ok
 }
@@ -130,6 +153,7 @@ func (r *DeviceRegistry) ListDevices() []DeviceInfo {
 func (r *DeviceRegistry) FirstEntity(ski string) spineapi.EntityRemoteInterface {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
+	ski = NormalizeSKI(ski)
 	info, ok := r.devices[ski]
 	if !ok || len(info.RemoteEntities) == 0 {
 		return nil

--- a/eebus-bridge/internal/eebus/registry_test.go
+++ b/eebus-bridge/internal/eebus/registry_test.go
@@ -60,6 +60,44 @@ func TestRegistryUpsertDeviceClassification(t *testing.T) {
 	}
 }
 
+func TestNormalizeSKI(t *testing.T) {
+	cases := map[string]string{
+		"abcdef":       "ABCDEF",
+		"  ab cd ef  ": "ABCDEF",
+		"AbCdEf":       "ABCDEF",
+		"":             "",
+	}
+	for in, want := range cases {
+		if got := eebus.NormalizeSKI(in); got != want {
+			t.Errorf("NormalizeSKI(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestRegistrySKINormalizationConsistency(t *testing.T) {
+	reg := eebus.NewDeviceRegistry()
+
+	// Stored with lowercase + spaces; looked up with uppercase, no spaces.
+	reg.AddDevice("ab cd 12", eebus.DeviceInfo{Brand: "Bosch"})
+
+	if _, ok := reg.GetDevice("ABCD12"); !ok {
+		t.Error("normalized lookup failed: device stored under non-normalized key")
+	}
+
+	// Classification reported under a differently-cased SKI must land on the
+	// same record so brand/model are not split across two keys.
+	reg.UpsertDeviceClassification("ABCD12", "Bosch", "Compress 5800i", "", "")
+	info, ok := reg.GetDevice("ab cd 12")
+	if !ok || info.Model != "Compress 5800i" {
+		t.Errorf("classification not merged onto same device: ok=%v model=%q", ok, info.Model)
+	}
+
+	reg.RemoveDevice("Ab Cd 12")
+	if _, ok := reg.GetDevice("ABCD12"); ok {
+		t.Error("normalized removal failed")
+	}
+}
+
 func TestRegistryListDevices(t *testing.T) {
 	reg := eebus.NewDeviceRegistry()
 	reg.AddDevice("ski-1", eebus.DeviceInfo{Brand: "A"})

--- a/eebus-bridge/internal/grpc/integration_test.go
+++ b/eebus-bridge/internal/grpc/integration_test.go
@@ -81,8 +81,9 @@ func TestIntegrationDeviceServiceRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("stream.Recv: %v", err)
 	}
-	if evt.Ski != "remote-ski-test" {
-		t.Errorf("event SKI = %q", evt.Ski)
+	// SKI is normalized (uppercased, whitespace stripped) before dispatch.
+	if evt.Ski != "REMOTE-SKI-TEST" {
+		t.Errorf("event SKI = %q, want REMOTE-SKI-TEST", evt.Ski)
 	}
 	if evt.EventType != pb.DeviceEventType_DEVICE_EVENT_CONNECTED {
 		t.Errorf("event type = %v", evt.EventType)


### PR DESCRIPTION
## Summary
Ports the highest-confidence Tier-1 fix from the `bgewehr` fork (Bosch Compress 5800i work) — **SKI normalization** — re-applied additively on top of the issue-#28 device-classification code already in `main`.

Remote peers (Bosch/Connect-Key) report the same SKI with differing case/whitespace, and use-case callbacks can fire with an empty SKI. Both make the device registry key the same device under multiple keys → later `resolveEntity` lookups (e.g. HA `WriteConsumptionLimit`) fail with `NOT_FOUND`.

## Changes
- `NormalizeSKI` (uppercase + strip whitespace), applied on every registry read/write and in SHIP callbacks (`RemoteSKIConnected/Disconnected`, `ServicePairingDetailUpdate`, `PairingState`).
- Empty-SKI fallback to `remoteDevice.Ski()` in `UpsertObservation`.
- Normalization in `UpsertDeviceClassification` so brand/model merge onto the same record as observations (keeps issue-#28 metadata intact).

## Tests
- New: `TestNormalizeSKI`, `TestRegistrySKINormalizationConsistency`.
- Updated: `TestCallbacksDispatchConnect` for normalized output.
- Full Go suite passes (`go build ./...`, `go test ./...`).

## Scope note — other Tier-1 items deferred
The fork branched **before** issue-#28 landed, so its Go files can't be taken wholesale (they'd revert the device-classification work). Remaining Tier-1 items need separate, larger PRs:
- **LPC heartbeat** — requires new gRPC RPCs + proto regen (touches the `grpcio==1.78.0` HA pin) + Python client wiring.
- **Energy production/measurement sensors** — live in a large `monitoring_service.go` rewrite entangled with the classification code; needs careful hand-port.
- **debugProtocol log gating** — bundled into that same monitoring rewrite.

Happy to follow up with those as discrete PRs.