### PR TITLE
feat(lpc): implement DeviceDiagnosis heartbeat

### DIFF
--- a/eebus-bridge/cmd/eebus-bridge/main.go
+++ b/eebus-bridge/cmd/eebus-bridge/main.go
@@ -63,6 +63,14 @@ func main() {
 	monitoringWrapper.Setup(localEntity)
 	bridgeSvc.Service().AddUseCase(lpcWrapper.UseCase())
 	bridgeSvc.Service().AddUseCase(monitoringWrapper.UseCase())
+	// Controllable systems revert an active LPC limit to its failsafe value when
+	// heartbeats stop arriving, so keep the local heartbeat running for the
+	// lifetime of the bridge.
+	if err := lpcWrapper.StartHeartbeat(""); err != nil {
+		log.Printf("starting LPC heartbeat failed: %v", err)
+	} else {
+		log.Println("Started LPC heartbeat")
+	}
 	log.Println("Registered EEBUS use cases: LPC, Monitoring")
 
 	grpcSrv := bridgegrpc.NewServer(cfg.GRPC.Bind, cfg.GRPC.Port, cfg.GRPC.EnableReflection)
@@ -108,6 +116,9 @@ func main() {
 	<-sigCh
 
 	log.Println("Shutting down...")
+	if err := lpcWrapper.StopHeartbeat(); err != nil {
+		log.Printf("stopping LPC heartbeat failed: %v", err)
+	}
 	grpcSrv.Stop()
 	bridgeSvc.Shutdown()
 	log.Println("Shutdown complete")

--- a/eebus-bridge/internal/grpc/lpc_service.go
+++ b/eebus-bridge/internal/grpc/lpc_service.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"time"
 
-	spineapi "github.com/enbility/spine-go/api"
 	ucapi "github.com/enbility/eebus-go/usecases/api"
+	spineapi "github.com/enbility/spine-go/api"
 	pb "github.com/volschin/eebus-bridge/gen/proto/eebus/v1"
 	"github.com/volschin/eebus-bridge/internal/eebus"
 	"github.com/volschin/eebus-bridge/internal/usecases"
@@ -130,16 +130,49 @@ func (s *LPCService) WriteFailsafeLimit(_ context.Context, req *pb.WriteFailsafe
 	return &pb.Empty{}, nil
 }
 
-func (s *LPCService) StartHeartbeat(_ context.Context, _ *pb.DeviceRequest) (*pb.Empty, error) {
-	return nil, status.Error(codes.Unimplemented, "heartbeat not supported by underlying use case")
+func (s *LPCService) StartHeartbeat(_ context.Context, req *pb.DeviceRequest) (*pb.Empty, error) {
+	if req == nil {
+		return nil, status.Error(codes.InvalidArgument, "request is required")
+	}
+	if s.lpc == nil {
+		return nil, status.Error(codes.Unavailable, "LPC use case not initialized")
+	}
+	if err := s.lpc.StartHeartbeat(req.Ski); err != nil {
+		return nil, status.Errorf(codes.Internal, "starting LPC heartbeat: %v", err)
+	}
+	return &pb.Empty{}, nil
 }
 
 func (s *LPCService) StopHeartbeat(_ context.Context, _ *pb.DeviceRequest) (*pb.Empty, error) {
-	return nil, status.Error(codes.Unimplemented, "heartbeat not supported by underlying use case")
+	if s.lpc == nil {
+		return nil, status.Error(codes.Unavailable, "LPC use case not initialized")
+	}
+	if err := s.lpc.StopHeartbeat(); err != nil {
+		return nil, status.Errorf(codes.Internal, "stopping LPC heartbeat: %v", err)
+	}
+	return &pb.Empty{}, nil
 }
 
-func (s *LPCService) GetHeartbeatStatus(_ context.Context, _ *pb.DeviceRequest) (*pb.HeartbeatStatus, error) {
-	return nil, status.Error(codes.Unimplemented, "heartbeat not supported by underlying use case")
+func (s *LPCService) GetHeartbeatStatus(_ context.Context, req *pb.DeviceRequest) (*pb.HeartbeatStatus, error) {
+	if req == nil {
+		return nil, status.Error(codes.InvalidArgument, "request is required")
+	}
+	if s.lpc == nil {
+		return nil, status.Error(codes.Unavailable, "LPC use case not initialized")
+	}
+	// Heartbeat state is a property of the local entity, so report Running even
+	// when the remote SKI cannot be resolved yet.
+	entity, err := s.resolveEntity(req.Ski)
+	if err != nil {
+		return &pb.HeartbeatStatus{
+			Running:        s.lpc.IsHeartbeatRunning(),
+			WithinDuration: false,
+		}, nil
+	}
+	return &pb.HeartbeatStatus{
+		Running:        s.lpc.IsHeartbeatRunning(),
+		WithinDuration: s.lpc.IsHeartbeatWithinDuration(entity),
+	}, nil
 }
 
 func (s *LPCService) GetConsumptionNominalMax(_ context.Context, req *pb.DeviceRequest) (*pb.PowerValue, error) {

--- a/eebus-bridge/internal/grpc/lpc_service_test.go
+++ b/eebus-bridge/internal/grpc/lpc_service_test.go
@@ -49,3 +49,25 @@ func TestSubscribeLPCEvents(t *testing.T) {
 		t.Errorf("EventType = %v, want LPC_EVENT_LIMIT_UPDATED", evt.EventType)
 	}
 }
+
+func TestHeartbeatHandlersValidation(t *testing.T) {
+	// nil lpc wrapper: handlers must report Unavailable, never panic.
+	svc := bridgegrpc.NewLPCService(nil, eebus.NewEventBus(), eebus.NewDeviceRegistry())
+	ctx := context.Background()
+
+	if _, err := svc.StartHeartbeat(ctx, nil); err == nil {
+		t.Error("StartHeartbeat(nil request) should error")
+	}
+	if _, err := svc.StartHeartbeat(ctx, &pb.DeviceRequest{Ski: "x"}); err == nil {
+		t.Error("StartHeartbeat with nil lpc should error (Unavailable)")
+	}
+	if _, err := svc.StopHeartbeat(ctx, &pb.DeviceRequest{}); err == nil {
+		t.Error("StopHeartbeat with nil lpc should error (Unavailable)")
+	}
+	if _, err := svc.GetHeartbeatStatus(ctx, nil); err == nil {
+		t.Error("GetHeartbeatStatus(nil request) should error")
+	}
+	if _, err := svc.GetHeartbeatStatus(ctx, &pb.DeviceRequest{Ski: "x"}); err == nil {
+		t.Error("GetHeartbeatStatus with nil lpc should error (Unavailable)")
+	}
+}

--- a/eebus-bridge/internal/usecases/lpc.go
+++ b/eebus-bridge/internal/usecases/lpc.go
@@ -138,3 +138,38 @@ func (w *LPCWrapper) ConsumptionNominalMax(entity spineapi.EntityRemoteInterface
 	}
 	return w.uc.ConsumptionNominalMax(entity)
 }
+
+// StartHeartbeat starts the local entity's periodic DeviceDiagnosis heartbeat.
+// Controllable systems (e.g. heat pumps) drop an LPC limit to its failsafe value
+// when heartbeats stop arriving, so the bridge must keep the heartbeat running.
+// The ski argument is accepted for API symmetry but unused: the heartbeat is a
+// property of the local entity, not of a specific remote.
+func (w *LPCWrapper) StartHeartbeat(_ string) error {
+	if w.localEntity == nil {
+		return errLPCNotInitialized
+	}
+	return w.localEntity.HeartbeatManager().StartHeartbeat()
+}
+
+// StopHeartbeat stops the periodic heartbeat requests.
+func (w *LPCWrapper) StopHeartbeat() error {
+	if w.localEntity == nil {
+		return errLPCNotInitialized
+	}
+	w.localEntity.HeartbeatManager().StopHeartbeat()
+	return nil
+}
+
+// IsHeartbeatRunning reports whether the local heartbeat is currently active.
+func (w *LPCWrapper) IsHeartbeatRunning() bool {
+	if w.localEntity == nil {
+		return false
+	}
+	return w.localEntity.HeartbeatManager().IsHeartbeatRunning()
+}
+
+// IsHeartbeatWithinDuration reports whether the heartbeat is currently active.
+// The entity argument is accepted for API symmetry with per-remote callers.
+func (w *LPCWrapper) IsHeartbeatWithinDuration(_ spineapi.EntityRemoteInterface) bool {
+	return w.IsHeartbeatRunning()
+}

--- a/eebus-bridge/internal/usecases/lpc_test.go
+++ b/eebus-bridge/internal/usecases/lpc_test.go
@@ -68,6 +68,25 @@ func TestLPCFailsafeDurationEventRouting(t *testing.T) {
 	}
 }
 
+func TestLPCHeartbeatWithoutLocalEntity(t *testing.T) {
+	// Without Setup() the wrapper has no local entity; heartbeat operations must
+	// fail gracefully rather than panic.
+	lpcWrapper := usecases.NewLPCWrapper(eebus.NewEventBus(), nil, false)
+
+	if err := lpcWrapper.StartHeartbeat(""); err == nil {
+		t.Error("StartHeartbeat without local entity should return an error")
+	}
+	if err := lpcWrapper.StopHeartbeat(); err == nil {
+		t.Error("StopHeartbeat without local entity should return an error")
+	}
+	if lpcWrapper.IsHeartbeatRunning() {
+		t.Error("IsHeartbeatRunning should be false without local entity")
+	}
+	if lpcWrapper.IsHeartbeatWithinDuration(nil) {
+		t.Error("IsHeartbeatWithinDuration should be false without local entity")
+	}
+}
+
 func TestLPCUnknownEventIgnored(t *testing.T) {
 	bus := eebus.NewEventBus()
 	ch := bus.Subscribe()


### PR DESCRIPTION
## Summary
Implements the LPC DeviceDiagnosis heartbeat. Controllable systems (e.g. heat pumps) revert an **active LPC limit to its failsafe value** when heartbeats stop arriving, so the bridge must keep the heartbeat running.

The proto RPCs (`StartHeartbeat`/`StopHeartbeat`/`GetHeartbeatStatus`) and the `HeartbeatStatus` message already exist in `main` — the handlers just returned `Unimplemented`. **No proto regeneration**, so the `grpcio==1.78.0` HA pin is untouched.

## Changes
- **`LPCWrapper`** — drives the local entity's `HeartbeatManager` (`Start`/`Stop`/`IsHeartbeatRunning`), with nil-entity guards.
- **`LPCService`** — implements the three gRPC handlers; `GetHeartbeatStatus` reports `Running` even when the remote SKI isn't resolvable yet.
- **`main.go`** — starts the heartbeat after use cases are registered, stops it on shutdown. gRPC server bind/reflection (127.0.0.1 hardening) left untouched.

## Ported, not merged
The `bgewehr` fork branched before recent `main` work; its versions of these files also revert the gRPC bind hardening and device-classification code. This re-applies only the heartbeat additively on current `main`.

## Tests
- `TestLPCHeartbeatWithoutLocalEntity` — wrapper nil-entity guards.
- `TestHeartbeatHandlersValidation` — gRPC handler nil-request / Unavailable paths.
- Full Go suite + integration tests pass (`go test ./...`, `-tags=integration`).

## Not included (separate follow-up)
Optional HA-side heartbeat-status binary sensor. The bridge auto-runs the heartbeat, so no HA change is required for the core fix.