### PR TITLE
feat(sensors): per-phase, frequency and produced-energy measurements

### DIFF
--- a/custom_components/eebus/coordinator.py
+++ b/custom_components/eebus/coordinator.py
@@ -22,6 +22,25 @@ RPC_TIMEOUT = 10
 RE_REGISTER_NOT_FOUND_STREAK = 4
 STREAM_RETRY_SECONDS = 30
 
+# Maps a GetMeasurements entry type (as emitted by the Go bridge) to the
+# coordinator data key consumed by the per-phase / grid / produced-energy
+# sensors. Types not present here (e.g. power_consumption, energy_consumed) are
+# handled by their own dedicated reads.
+FLAT_MEASUREMENT_TYPE_TO_KEY: dict[str, str] = {
+    "power_l1": "power_l1_w",
+    "power_l2": "power_l2_w",
+    "power_l3": "power_l3_w",
+    "current_l1": "current_l1_a",
+    "current_l2": "current_l2_a",
+    "current_l3": "current_l3_a",
+    "voltage_l1": "voltage_l1_v",
+    "voltage_l2": "voltage_l2_v",
+    "voltage_l3": "voltage_l3_v",
+    "frequency": "frequency_hz",
+    "energy_produced": "energy_produced_kwh",
+}
+FLAT_MEASUREMENT_KEYS: tuple[str, ...] = tuple(FLAT_MEASUREMENT_TYPE_TO_KEY.values())
+
 
 def _is_unimplemented(err: grpc.aio.AioRpcError) -> bool:
     """Return True when gRPC reports method/use case is not implemented."""
@@ -90,6 +109,10 @@ class EebusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 "local_ski": status.local_ski,
                 "ski_registered": self._ski_registered,
             }
+            # Per-phase / grid / produced-energy measurements default to None and
+            # are populated from GetMeasurements when the device advertises them.
+            for _key in FLAT_MEASUREMENT_KEYS:
+                data[_key] = None
             if self.ski == status.local_ski:
                 _LOGGER.warning(
                     "Configured remote SKI %s matches bridge local SKI; monitoring reads will stay empty",
@@ -151,6 +174,7 @@ class EebusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 scoped_energy = self._extract_scoped_energy_kwh(measurements.measurements)
                 data["energy_consumed_heating_kwh"] = scoped_energy["heating"]
                 data["energy_consumed_dhw_kwh"] = scoped_energy["dhw"]
+                data.update(self._extract_flat_measurements(measurements.measurements))
                 _LOGGER.debug(
                     "EEBUS scoped energy read for SKI %s: heating=%s dhw=%s entries=%s",
                     self.ski,
@@ -170,6 +194,9 @@ class EebusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                         )
                         data["energy_consumed_heating_kwh"] = scoped_energy["heating"]
                         data["energy_consumed_dhw_kwh"] = scoped_energy["dhw"]
+                        data.update(
+                            self._extract_flat_measurements(measurements.measurements)
+                        )
                         used_fallback = True
                         _LOGGER.debug(
                             "EEBUS scoped energy read for SKI %s used fallback: heating=%s dhw=%s entries=%s",
@@ -571,6 +598,24 @@ class EebusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             if "energy" in normalized and ("heating" in normalized or "space_heating" in normalized):
                 result["heating"] = value
 
+        return result
+
+    @staticmethod
+    def _extract_flat_measurements(measurements: list[Any]) -> dict[str, float | None]:
+        """Map per-phase / grid / produced-energy entries to coordinator keys."""
+        result: dict[str, float | None] = {}
+        for measurement in measurements:
+            measurement_type = str(getattr(measurement, "type", "")).lower().strip()
+            if not measurement_type:
+                continue
+            normalized = measurement_type.replace("-", "_").replace(" ", "_")
+            key = FLAT_MEASUREMENT_TYPE_TO_KEY.get(normalized)
+            if key is None:
+                continue
+            value = getattr(measurement, "value", None)
+            if value is None:
+                continue
+            result[key] = value
         return result
 
     async def async_write_lpc_limit(self, value_watts: float) -> None:

--- a/custom_components/eebus/icons.json
+++ b/custom_components/eebus/icons.json
@@ -5,7 +5,18 @@
       "energy_consumed": { "default": "mdi:lightning-bolt" },
       "energy_consumed_heating": { "default": "mdi:radiator" },
       "energy_consumed_dhw": { "default": "mdi:water-boiler" },
-      "consumption_limit": { "default": "mdi:speedometer" }
+      "consumption_limit": { "default": "mdi:speedometer" },
+      "power_l1": { "default": "mdi:flash" },
+      "power_l2": { "default": "mdi:flash" },
+      "power_l3": { "default": "mdi:flash" },
+      "current_l1": { "default": "mdi:current-ac" },
+      "current_l2": { "default": "mdi:current-ac" },
+      "current_l3": { "default": "mdi:current-ac" },
+      "voltage_l1": { "default": "mdi:sine-wave" },
+      "voltage_l2": { "default": "mdi:sine-wave" },
+      "voltage_l3": { "default": "mdi:sine-wave" },
+      "frequency": { "default": "mdi:sine-wave" },
+      "energy_produced": { "default": "mdi:transmission-tower-export" }
     },
     "number": {
       "lpc_limit": { "default": "mdi:speedometer" },

--- a/custom_components/eebus/manifest.json
+++ b/custom_components/eebus/manifest.json
@@ -10,6 +10,6 @@
   "quality_scale": "gold",
   "requirements": ["grpcio>=1.78.0", "protobuf>=4.25.0"],
   "single_config_entry": false,
-  "version": "0.3.1",
+  "version": "0.4.0",
   "zeroconf": ["_ship._tcp.local."]
 }

--- a/custom_components/eebus/sensor.py
+++ b/custom_components/eebus/sensor.py
@@ -2,18 +2,97 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+
 from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorEntity,
+    SensorEntityDescription,
     SensorStateClass,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import EntityCategory, UnitOfEnergy, UnitOfPower
+from homeassistant.const import (
+    EntityCategory,
+    UnitOfElectricCurrent,
+    UnitOfElectricPotential,
+    UnitOfEnergy,
+    UnitOfFrequency,
+    UnitOfPower,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .coordinator import EebusCoordinator
 from .entity import EebusEntity
+
+
+@dataclass(frozen=True, kw_only=True)
+class EebusMeasurementDescription(SensorEntityDescription):
+    """Describes a coordinator-data-backed EEBUS measurement sensor."""
+
+    data_key: str
+
+
+# Per-phase power/current/voltage, grid frequency and produced energy. These are
+# only meaningful when the device advertises them; the sensors report None
+# (unavailable) otherwise. Disabled by default to avoid cluttering devices (e.g.
+# single-phase heat pumps) that never populate them.
+MEASUREMENT_SENSORS: tuple[EebusMeasurementDescription, ...] = (
+    *(
+        EebusMeasurementDescription(
+            key=f"power_l{phase}",
+            data_key=f"power_l{phase}_w",
+            translation_key=f"power_l{phase}",
+            device_class=SensorDeviceClass.POWER,
+            native_unit_of_measurement=UnitOfPower.WATT,
+            state_class=SensorStateClass.MEASUREMENT,
+            entity_registry_enabled_default=False,
+        )
+        for phase in (1, 2, 3)
+    ),
+    *(
+        EebusMeasurementDescription(
+            key=f"current_l{phase}",
+            data_key=f"current_l{phase}_a",
+            translation_key=f"current_l{phase}",
+            device_class=SensorDeviceClass.CURRENT,
+            native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
+            state_class=SensorStateClass.MEASUREMENT,
+            entity_registry_enabled_default=False,
+        )
+        for phase in (1, 2, 3)
+    ),
+    *(
+        EebusMeasurementDescription(
+            key=f"voltage_l{phase}",
+            data_key=f"voltage_l{phase}_v",
+            translation_key=f"voltage_l{phase}",
+            device_class=SensorDeviceClass.VOLTAGE,
+            native_unit_of_measurement=UnitOfElectricPotential.VOLT,
+            state_class=SensorStateClass.MEASUREMENT,
+            entity_registry_enabled_default=False,
+        )
+        for phase in (1, 2, 3)
+    ),
+    EebusMeasurementDescription(
+        key="frequency",
+        data_key="frequency_hz",
+        translation_key="frequency",
+        device_class=SensorDeviceClass.FREQUENCY,
+        native_unit_of_measurement=UnitOfFrequency.HERTZ,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_registry_enabled_default=False,
+    ),
+    EebusMeasurementDescription(
+        key="energy_produced",
+        data_key="energy_produced_kwh",
+        translation_key="energy_produced",
+        device_class=SensorDeviceClass.ENERGY,
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        entity_registry_enabled_default=False,
+    ),
+)
 
 
 async def async_setup_entry(
@@ -23,13 +102,41 @@ async def async_setup_entry(
 ) -> None:
     """Set up EEBUS sensors."""
     coordinator: EebusCoordinator = entry.runtime_data
-    async_add_entities([
+    entities: list[SensorEntity] = [
         EebusPowerSensor(coordinator),
         EebusEnergyConsumedSensor(coordinator),
         EebusEnergyConsumedHeatingSensor(coordinator),
         EebusEnergyConsumedDhwSensor(coordinator),
         EebusConsumptionLimitSensor(coordinator),
-    ])
+    ]
+    entities.extend(
+        EebusMeasurementSensor(coordinator, description)
+        for description in MEASUREMENT_SENSORS
+    )
+    async_add_entities(entities)
+
+
+class EebusMeasurementSensor(EebusEntity, SensorEntity):
+    """Generic sensor backed by a coordinator data key."""
+
+    entity_description: EebusMeasurementDescription
+
+    def __init__(
+        self,
+        coordinator: EebusCoordinator,
+        description: EebusMeasurementDescription,
+    ) -> None:
+        """Initialize."""
+        super().__init__(coordinator)
+        self.entity_description = description
+        self._attr_unique_id = f"{coordinator.ski}_{description.key}"
+
+    @property
+    def native_value(self) -> float | None:
+        """Return the measurement value, or None when unavailable."""
+        if self.coordinator.data is None:
+            return None
+        return self.coordinator.data.get(self.entity_description.data_key)
 
 
 class EebusPowerSensor(EebusEntity, SensorEntity):

--- a/custom_components/eebus/strings.json
+++ b/custom_components/eebus/strings.json
@@ -50,7 +50,18 @@
       "energy_consumed": { "name": "Energy Consumed" },
       "energy_consumed_heating": { "name": "Energy Consumed Heating" },
       "energy_consumed_dhw": { "name": "Energy Consumed Domestic Hot Water" },
-      "consumption_limit": { "name": "Consumption Limit" }
+      "consumption_limit": { "name": "Consumption Limit" },
+      "power_l1": { "name": "Power L1" },
+      "power_l2": { "name": "Power L2" },
+      "power_l3": { "name": "Power L3" },
+      "current_l1": { "name": "Current L1" },
+      "current_l2": { "name": "Current L2" },
+      "current_l3": { "name": "Current L3" },
+      "voltage_l1": { "name": "Voltage L1" },
+      "voltage_l2": { "name": "Voltage L2" },
+      "voltage_l3": { "name": "Voltage L3" },
+      "frequency": { "name": "Grid Frequency" },
+      "energy_produced": { "name": "Energy Produced" }
     },
     "number": {
       "lpc_limit": { "name": "LPC Limit" },

--- a/custom_components/eebus/tests/test_coordinator.py
+++ b/custom_components/eebus/tests/test_coordinator.py
@@ -3,6 +3,7 @@
 import asyncio
 import inspect
 from datetime import timedelta
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 from custom_components.eebus import proto_stubs
@@ -222,3 +223,40 @@ def test_device_event_triggers_refresh():
     )
     coordinator._handle_device_event(event)
     coordinator.hass.async_create_task.assert_called_once()
+
+
+def _entry(measurement_type, value):
+    """Build a duck-typed GetMeasurements entry (type/value attributes)."""
+    return SimpleNamespace(type=measurement_type, value=value)
+
+
+def test_extract_flat_measurements_maps_types():
+    """Per-phase / grid / produced-energy entries map to coordinator keys."""
+    entries = [
+        _entry("power_l1", 230.0),
+        _entry("current_l2", 4.5),
+        _entry("voltage_l3", 231.2),
+        _entry("frequency", 50.0),
+        _entry("energy_produced", 12.3),
+        # Unrelated / scoped types are ignored by the flat extractor.
+        _entry("energy_consumed", 99.0),
+    ]
+    result = EebusCoordinator._extract_flat_measurements(entries)
+    assert result == {
+        "power_l1_w": 230.0,
+        "current_l2_a": 4.5,
+        "voltage_l3_v": 231.2,
+        "frequency_hz": 50.0,
+        "energy_produced_kwh": 12.3,
+    }
+
+
+def test_extract_flat_measurements_ignores_blank_and_missing():
+    """Entries without a type are skipped; a value of 0.0 is kept."""
+    entries = [
+        _entry("", 1.0),
+        _entry("voltage_l1", None),
+        _entry("power_l1", 0.0),
+    ]
+    result = EebusCoordinator._extract_flat_measurements(entries)
+    assert result == {"power_l1_w": 0.0}

--- a/custom_components/eebus/translations/de.json
+++ b/custom_components/eebus/translations/de.json
@@ -50,7 +50,18 @@
       "energy_consumed": { "name": "Energieverbrauch" },
       "energy_consumed_heating": { "name": "Energieverbrauch Heizung" },
       "energy_consumed_dhw": { "name": "Energieverbrauch Warmwasser" },
-      "consumption_limit": { "name": "Leistungslimit" }
+      "consumption_limit": { "name": "Leistungslimit" },
+      "power_l1": { "name": "Leistung L1" },
+      "power_l2": { "name": "Leistung L2" },
+      "power_l3": { "name": "Leistung L3" },
+      "current_l1": { "name": "Strom L1" },
+      "current_l2": { "name": "Strom L2" },
+      "current_l3": { "name": "Strom L3" },
+      "voltage_l1": { "name": "Spannung L1" },
+      "voltage_l2": { "name": "Spannung L2" },
+      "voltage_l3": { "name": "Spannung L3" },
+      "frequency": { "name": "Netzfrequenz" },
+      "energy_produced": { "name": "Eingespeiste Energie" }
     },
     "number": {
       "lpc_limit": { "name": "LPC Limit" },

--- a/custom_components/eebus/translations/en.json
+++ b/custom_components/eebus/translations/en.json
@@ -50,7 +50,18 @@
       "energy_consumed": { "name": "Energy Consumed" },
       "energy_consumed_heating": { "name": "Energy Consumed Heating" },
       "energy_consumed_dhw": { "name": "Energy Consumed Domestic Hot Water" },
-      "consumption_limit": { "name": "Consumption Limit" }
+      "consumption_limit": { "name": "Consumption Limit" },
+      "power_l1": { "name": "Power L1" },
+      "power_l2": { "name": "Power L2" },
+      "power_l3": { "name": "Power L3" },
+      "current_l1": { "name": "Current L1" },
+      "current_l2": { "name": "Current L2" },
+      "current_l3": { "name": "Current L3" },
+      "voltage_l1": { "name": "Voltage L1" },
+      "voltage_l2": { "name": "Voltage L2" },
+      "voltage_l3": { "name": "Voltage L3" },
+      "frequency": { "name": "Grid Frequency" },
+      "energy_produced": { "name": "Energy Produced" }
     },
     "number": {
       "lpc_limit": { "name": "LPC Limit" },

--- a/eebus-bridge/internal/grpc/monitoring_service.go
+++ b/eebus-bridge/internal/grpc/monitoring_service.go
@@ -78,24 +78,40 @@ func (s *MonitoringService) GetMeasurements(_ context.Context, req *pb.DeviceReq
 		return nil, status.Error(codes.Unavailable, "monitoring use case not initialized")
 	}
 	now := timestamppb.Now()
-	measurements := make([]*pb.MeasurementEntry, 0, 2)
+	measurements := make([]*pb.MeasurementEntry, 0, 12)
 
 	if value, err := s.readPower(req.Ski); err == nil {
-		measurements = append(measurements, &pb.MeasurementEntry{
-			Type:      "power_consumption",
-			Value:     value,
-			Unit:      "W",
-			Timestamp: now,
-		})
+		appendMeasurement(&measurements, now, "power_consumption", value, "W")
+	}
+
+	if values, err := s.readPowerPerPhase(req.Ski); err == nil {
+		for idx, value := range values {
+			appendMeasurement(&measurements, now, fmt.Sprintf("power_l%d", idx+1), value, "W")
+		}
+	}
+
+	if values, err := s.readCurrentPerPhase(req.Ski); err == nil {
+		for idx, value := range values {
+			appendMeasurement(&measurements, now, fmt.Sprintf("current_l%d", idx+1), value, "A")
+		}
+	}
+
+	if values, err := s.readVoltagePerPhase(req.Ski); err == nil {
+		for idx, value := range values {
+			appendMeasurement(&measurements, now, fmt.Sprintf("voltage_l%d", idx+1), value, "V")
+		}
+	}
+
+	if value, err := s.readFrequency(req.Ski); err == nil {
+		appendMeasurement(&measurements, now, "frequency", value, "Hz")
 	}
 
 	if value, err := s.readEnergyConsumed(req.Ski); err == nil {
-		measurements = append(measurements, &pb.MeasurementEntry{
-			Type:      "energy_consumed",
-			Value:     value,
-			Unit:      "kWh",
-			Timestamp: now,
-		})
+		appendMeasurement(&measurements, now, "energy_consumed", value, "kWh")
+	}
+
+	if value, err := s.readEnergyProduced(req.Ski); err == nil {
+		appendMeasurement(&measurements, now, "energy_produced", value, "kWh")
 	}
 
 	if len(measurements) == 0 {
@@ -198,6 +214,143 @@ func (s *MonitoringService) readEnergyConsumed(ski string) (float64, error) {
 	}
 	log.Printf("[DEBUG] Monitoring.readEnergyConsumed nil-entity fallback succeeded: requested_ski=%s kWh=%f", ski, value)
 	return value, nil
+}
+
+// The following readers expose the additional MPC measurements (per-phase
+// power/current/voltage, grid frequency and produced energy). They are
+// best-effort: GetMeasurements only appends their results when the read
+// succeeds, so a device that does not advertise a given measurement simply
+// omits it rather than failing the whole call. Each falls back to a nil-entity
+// read (guarded against panics) when the SKI cannot be resolved, matching the
+// behaviour of readPower / readEnergyConsumed.
+
+func (s *MonitoringService) readEnergyProduced(ski string) (float64, error) {
+	entity, err := s.resolveEntity(ski)
+	if err == nil {
+		return s.monitoring.EnergyProduced(entity)
+	}
+	if status.Code(err) != codes.NotFound {
+		return 0, err
+	}
+	value, fallbackErr := s.safeEnergyProducedNilEntity()
+	if fallbackErr != nil {
+		return 0, err
+	}
+	return value, nil
+}
+
+func (s *MonitoringService) readPowerPerPhase(ski string) ([]float64, error) {
+	entity, err := s.resolveEntity(ski)
+	if err == nil {
+		return s.monitoring.PowerPerPhase(entity)
+	}
+	if status.Code(err) != codes.NotFound {
+		return nil, err
+	}
+	values, fallbackErr := s.safePowerPerPhaseNilEntity()
+	if fallbackErr != nil {
+		return nil, err
+	}
+	return values, nil
+}
+
+func (s *MonitoringService) readCurrentPerPhase(ski string) ([]float64, error) {
+	entity, err := s.resolveEntity(ski)
+	if err == nil {
+		return s.monitoring.CurrentPerPhase(entity)
+	}
+	if status.Code(err) != codes.NotFound {
+		return nil, err
+	}
+	values, fallbackErr := s.safeCurrentPerPhaseNilEntity()
+	if fallbackErr != nil {
+		return nil, err
+	}
+	return values, nil
+}
+
+func (s *MonitoringService) readVoltagePerPhase(ski string) ([]float64, error) {
+	entity, err := s.resolveEntity(ski)
+	if err == nil {
+		return s.monitoring.VoltagePerPhase(entity)
+	}
+	if status.Code(err) != codes.NotFound {
+		return nil, err
+	}
+	values, fallbackErr := s.safeVoltagePerPhaseNilEntity()
+	if fallbackErr != nil {
+		return nil, err
+	}
+	return values, nil
+}
+
+func (s *MonitoringService) readFrequency(ski string) (float64, error) {
+	entity, err := s.resolveEntity(ski)
+	if err == nil {
+		return s.monitoring.Frequency(entity)
+	}
+	if status.Code(err) != codes.NotFound {
+		return 0, err
+	}
+	value, fallbackErr := s.safeFrequencyNilEntity()
+	if fallbackErr != nil {
+		return 0, err
+	}
+	return value, nil
+}
+
+func appendMeasurement(measurements *[]*pb.MeasurementEntry, now *timestamppb.Timestamp, measurementType string, value float64, unit string) {
+	*measurements = append(*measurements, &pb.MeasurementEntry{
+		Type:      measurementType,
+		Value:     value,
+		Unit:      unit,
+		Timestamp: now,
+	})
+}
+
+func (s *MonitoringService) safeEnergyProducedNilEntity() (value float64, err error) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			err = fmt.Errorf("panic during nil-entity produced energy read: %v", recovered)
+		}
+	}()
+	return s.monitoring.EnergyProduced(nil)
+}
+
+func (s *MonitoringService) safePowerPerPhaseNilEntity() (values []float64, err error) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			err = fmt.Errorf("panic during nil-entity power-per-phase read: %v", recovered)
+		}
+	}()
+	return s.monitoring.PowerPerPhase(nil)
+}
+
+func (s *MonitoringService) safeCurrentPerPhaseNilEntity() (values []float64, err error) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			err = fmt.Errorf("panic during nil-entity current-per-phase read: %v", recovered)
+		}
+	}()
+	return s.monitoring.CurrentPerPhase(nil)
+}
+
+func (s *MonitoringService) safeVoltagePerPhaseNilEntity() (values []float64, err error) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			err = fmt.Errorf("panic during nil-entity voltage-per-phase read: %v", recovered)
+		}
+	}()
+	return s.monitoring.VoltagePerPhase(nil)
+}
+
+func (s *MonitoringService) safeFrequencyNilEntity() (value float64, err error) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			err = fmt.Errorf("panic during nil-entity frequency read: %v", recovered)
+		}
+	}()
+	return s.monitoring.Frequency(nil)
 }
 
 func (s *MonitoringService) safePowerNilEntity() (value float64, err error) {


### PR DESCRIPTION
## Summary
Surfaces the additional MPC measurements the eebus-go use case already supports but that the bridge never reported beyond `power_consumption` / `energy_consumed`:

- per-phase **power** (L1–L3), **current** (L1–L3), **voltage** (L1–L3)
- grid **frequency**
- **produced energy** (feed-in)

## Bridge (Go)
- `GetMeasurements` emits the new entries via best-effort reads. Each resolves the entity and falls back to a panic-guarded nil-entity read, matching the existing `readPower` / `readEnergyConsumed` pattern. A device that does not advertise a measurement simply omits it — never fatal.
- The existing `resolveEntity` empty-SKI fallback and the device-classification code are left intact.

## Integration (Python)
- Coordinator maps the new `GetMeasurements` entries to data keys (`_extract_flat_measurements`).
- Description-driven sensors (one generic `EebusMeasurementSensor` + a description tuple), **disabled by default** so single-phase devices (e.g. many heat pumps) aren't cluttered with never-populated entities.
- `en`/`de`/`strings` translations, icons, manifest `0.3.1 → 0.4.0`.

## Ported, not merged
Re-applied additively on current `main`. The fork's version also reverts the gRPC bind hardening and device-classification code and adds a `debugProtocol` raw-SPINE dump — **none of that is included here** (the raw-dump is a separate, debug-only follow-up).

## Tests
- `test_extract_flat_measurements_*` — type→key mapping, blank/None handling, 0.0 kept.
- Go `build`/`vet`/`test` and the full Python suite (25 tests) pass locally; `ruff` clean.