### PR TITLE
fix(lpc): resolve LPC entity via use-case scenarios (#47)

### DIFF
--- a/eebus-bridge/internal/grpc/lpc_service.go
+++ b/eebus-bridge/internal/grpc/lpc_service.go
@@ -237,6 +237,15 @@ func convertLoadLimit(l ucapi.LoadLimit) *pb.LoadLimit {
 }
 
 func (s *LPCService) resolveEntity(ski string) (spineapi.EntityRemoteInterface, error) {
+	// Prefer an entity that actually advertises the LPC use case. A device such as a
+	// Vaillant VR940f gateway registers several entities under one SKI; the flat
+	// registry returns whichever was observed first (often the monitoring meter),
+	// which eebus-go rejects on write with ErrNoCompatibleEntity (issue #47).
+	if s.lpc != nil {
+		if entity := s.lpc.CompatibleEntity(ski); entity != nil {
+			return entity, nil
+		}
+	}
 	if s.registry == nil {
 		return nil, status.Error(codes.Unavailable, "device registry not initialized")
 	}

--- a/eebus-bridge/internal/usecases/lpc.go
+++ b/eebus-bridge/internal/usecases/lpc.go
@@ -79,6 +79,44 @@ func (w *LPCWrapper) HandleEvent(ski string, device spineapi.DeviceRemoteInterfa
 	}
 }
 
+// CompatibleEntity returns the first remote entity that actually supports the LPC
+// (Limitation of Power Consumption) use case for the given SKI. A gateway can
+// register several entities under one device SKI — e.g. a Vaillant VR940f exposes
+// both an EG-M monitoring meter entity and the heat-pump LPC entity. The flat
+// device registry returns whichever entity was observed first, so an LPC write may
+// be handed the monitoring entity, which eebus-go rejects with ErrNoCompatibleEntity
+// ("no compatible entity"). RemoteEntitiesScenarios lists only entities that
+// advertise the LPC use case, so resolving from it picks the correct one (issue #47).
+//
+// An empty ski matches the first LPC-capable entity of any device. Returns nil when
+// the use case is not set up or no compatible entity has been negotiated yet.
+func (w *LPCWrapper) CompatibleEntity(ski string) spineapi.EntityRemoteInterface {
+	if w.uc == nil {
+		return nil
+	}
+	for _, rs := range w.uc.RemoteEntitiesScenarios() {
+		entity := rs.Entity
+		if entity == nil || entity.Device() == nil {
+			continue
+		}
+		if lpcEntityMatchesSKI(entity.Device().Ski(), ski) {
+			return entity
+		}
+	}
+	return nil
+}
+
+// lpcEntityMatchesSKI reports whether a remote entity advertising the given (raw)
+// SKI satisfies a resolve request for want. An empty want matches any entity;
+// otherwise SKIs are compared after normalization so case and spacing differences
+// reported by the remote do not cause a spurious mismatch.
+func lpcEntityMatchesSKI(entitySKI, want string) bool {
+	if want == "" {
+		return true
+	}
+	return eebus.NormalizeSKI(entitySKI) == eebus.NormalizeSKI(want)
+}
+
 // ConsumptionLimit returns the current load control limit for the given remote entity.
 func (w *LPCWrapper) ConsumptionLimit(entity spineapi.EntityRemoteInterface) (ucapi.LoadLimit, error) {
 	if w.uc == nil {

--- a/eebus-bridge/internal/usecases/lpc_select_test.go
+++ b/eebus-bridge/internal/usecases/lpc_select_test.go
@@ -1,0 +1,37 @@
+package usecases
+
+import "testing"
+
+func TestLPCEntityMatchesSKI(t *testing.T) {
+	tests := []struct {
+		name       string
+		entitySKI  string
+		want       string
+		wantResult bool
+	}{
+		{"empty want matches any", "abcd1234", "", true},
+		{"exact match", "abcd1234", "abcd1234", true},
+		{"case insensitive", "ABCD1234", "abcd1234", true},
+		{"whitespace insensitive", "ab cd 12 34", "abcd1234", true},
+		{"surrounding whitespace", "  abcd1234  ", "abcd1234", true},
+		{"mismatch", "abcd1234", "ffff0000", false},
+		{"empty entity ski non-empty want", "", "abcd1234", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := lpcEntityMatchesSKI(tt.entitySKI, tt.want); got != tt.wantResult {
+				t.Errorf("lpcEntityMatchesSKI(%q, %q) = %v, want %v",
+					tt.entitySKI, tt.want, got, tt.wantResult)
+			}
+		})
+	}
+}
+
+// CompatibleEntity must not panic and must return nil before Setup (uc == nil),
+// so resolveEntity falls back to the registry instead of crashing.
+func TestCompatibleEntityNilUseCase(t *testing.T) {
+	w := NewLPCWrapper(nil, nil, false)
+	if got := w.CompatibleEntity("abcd1234"); got != nil {
+		t.Errorf("CompatibleEntity on un-set-up wrapper = %v, want nil", got)
+	}
+}


### PR DESCRIPTION
## Problem

`WriteConsumptionLimit` fails with `no compatible entity` on multi-entity gateways such as the Vaillant VR940f (issue #47).

The device registry stored every observed remote entity in one flat slice (`RemoteEntities`) shared across **all** use cases and `FirstEntity` returned index 0. A gateway exposes several entities under one device SKI — e.g. an EG-M monitoring meter entity plus the heat-pump LPC entity. Whichever callback fired first (monitoring polls ~60s, usually wins) determined index 0, so LPC writes were often handed the monitoring meter entity, which eebus-go rejects in `IsCompatibleEntityType` → `ErrNoCompatibleEntity`.

Diagnostic tell from the report: `GetConsumptionLimit` returned `data not available` (entity passed the type check) while `WriteConsumptionLimit` returned `no compatible entity` (entity failed it) — same SKI resolving to **different** entities, confirming order-dependent selection rather than a firmware gap.

## Fix

- `LPCWrapper.CompatibleEntity(ski)` selects from `uc.RemoteEntitiesScenarios()` — only entities that actually advertise the LPC use case — matched by normalized SKI.
- `LPCService.resolveEntity` tries `CompatibleEntity` first, then falls back to the flat registry when the use case has not negotiated a compatible entity yet (preserves heartbeat-status behavior).
- `lpcEntityMatchesSKI` does case/whitespace-insensitive SKI matching; empty SKI matches the first LPC-capable entity.

## Tests

- `TestLPCEntityMatchesSKI` — empty wildcard, exact, case/whitespace insensitivity, mismatch.
- `TestCompatibleEntityNilUseCase` — nil before Setup, no panic, registry fallback.

Build + vet + full suite green.

## Caveat

Routes writes to the correct entity, but does not prove the VR940f *accepts* the limit (LoadControl server side). Needs a grpcurl write retest on hardware to confirm end-to-end.

Closes #47