### PR TITLE
chore: gitignore .gstack/ tool output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__/
 eebus-bridge/bin/
 eebus-bridge/eebus-bridge
 .pytest_cache/
+.gstack/


### PR DESCRIPTION
## Summary
- Add `.gstack/` to `.gitignore` so gstack tool output (reviews, security reports) stops showing as untracked.

Docs/config-only change.