### PR TITLE
chore(grpc): remove dead RPCs with no client (YAGNI)

### DIFF
--- a/custom_components/eebus/generated/eebus/v1/device_service_pb2.py
+++ b/custom_components/eebus/generated/eebus/v1/device_service_pb2.py
@@ -25,7 +25,7 @@ _sym_db = _symbol_database.Default()
 from . import common_pb2 as eebus_dot_v1_dot_common__pb2
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x1d\x65\x65\x62us/v1/device_service.proto\x12\x08\x65\x65\x62us.v1\x1a\x15\x65\x65\x62us/v1/common.proto\"3\n\rServiceStatus\x12\x0f\n\x07running\x18\x01 \x01(\x08\x12\x11\n\tlocal_ski\x18\x02 \x01(\t\"p\n\x10\x44iscoveredDevice\x12\x0b\n\x03ski\x18\x01 \x01(\t\x12\r\n\x05\x62rand\x18\x02 \x01(\t\x12\r\n\x05model\x18\x03 \x01(\t\x12\x0e\n\x06serial\x18\x04 \x01(\t\x12\x13\n\x0b\x64\x65vice_type\x18\x05 \x01(\t\x12\x0c\n\x04host\x18\x06 \x01(\t\"B\n\x13ListDevicesResponse\x12+\n\x07\x64\x65vices\x18\x01 \x03(\x0b\x32\x1a.eebus.v1.DiscoveredDevice\"!\n\x12RegisterSKIRequest\x12\x0b\n\x03ski\x18\x01 \x01(\t\"C\n\rPairingStatus\x12\x0b\n\x03ski\x18\x01 \x01(\t\x12%\n\x05state\x18\x02 \x01(\x0e\x32\x16.eebus.v1.PairingState\"{\n\x0cPairedDevice\x12\x0b\n\x03ski\x18\x01 \x01(\t\x12\r\n\x05\x62rand\x18\x02 \x01(\t\x12\r\n\x05model\x18\x03 \x01(\t\x12\x0e\n\x06serial\x18\x04 \x01(\t\x12\x13\n\x0b\x64\x65vice_type\x18\x05 \x01(\t\x12\x1b\n\x13supported_use_cases\x18\x06 \x03(\t\"D\n\x19ListPairedDevicesResponse\x12\'\n\x07\x64\x65vices\x18\x01 \x03(\x0b\x32\x16.eebus.v1.PairedDevice\"I\n\x0b\x44\x65viceEvent\x12\x0b\n\x03ski\x18\x01 \x01(\t\x12-\n\nevent_type\x18\x02 \x01(\x0e\x32\x19.eebus.v1.DeviceEventType*\xa2\x01\n\x0cPairingState\x12\x1d\n\x19PAIRING_STATE_UNSPECIFIED\x10\x00\x12\x19\n\x15PAIRING_STATE_PENDING\x10\x01\x12#\n\x1fPAIRING_STATE_WAITING_FOR_TRUST\x10\x02\x12\x19\n\x15PAIRING_STATE_TRUSTED\x10\x03\x12\x18\n\x14PAIRING_STATE_DENIED\x10\x04*\x8a\x01\n\x0f\x44\x65viceEventType\x12\x1c\n\x18\x44\x45VICE_EVENT_UNSPECIFIED\x10\x00\x12\x1a\n\x16\x44\x45VICE_EVENT_CONNECTED\x10\x01\x12\x1d\n\x19\x44\x45VICE_EVENT_DISCONNECTED\x10\x02\x12\x1e\n\x1a\x44\x45VICE_EVENT_TRUST_REMOVED\x10\x03\x32\xe8\x03\n\rDeviceService\x12\x35\n\tGetStatus\x12\x0f.eebus.v1.Empty\x1a\x17.eebus.v1.ServiceStatus\x12G\n\x15ListDiscoveredDevices\x12\x0f.eebus.v1.Empty\x1a\x1d.eebus.v1.ListDevicesResponse\x12\x42\n\x11RegisterRemoteSKI\x12\x1c.eebus.v1.RegisterSKIRequest\x1a\x0f.eebus.v1.Empty\x12?\n\x13UnregisterRemoteSKI\x12\x17.eebus.v1.DeviceRequest\x1a\x0f.eebus.v1.Empty\x12\x44\n\x10GetPairingStatus\x12\x17.eebus.v1.DeviceRequest\x1a\x17.eebus.v1.PairingStatus\x12I\n\x11ListPairedDevices\x12\x0f.eebus.v1.Empty\x1a#.eebus.v1.ListPairedDevicesResponse\x12\x41\n\x15SubscribeDeviceEvents\x12\x0f.eebus.v1.Empty\x1a\x15.eebus.v1.DeviceEvent0\x01\x42=Z;github.com/volschin/eebus-bridge/gen/proto/eebus/v1;eebusv1b\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x1d\x65\x65\x62us/v1/device_service.proto\x12\x08\x65\x65\x62us.v1\x1a\x15\x65\x65\x62us/v1/common.proto\"3\n\rServiceStatus\x12\x0f\n\x07running\x18\x01 \x01(\x08\x12\x11\n\tlocal_ski\x18\x02 \x01(\t\"p\n\x10\x44iscoveredDevice\x12\x0b\n\x03ski\x18\x01 \x01(\t\x12\r\n\x05\x62rand\x18\x02 \x01(\t\x12\r\n\x05model\x18\x03 \x01(\t\x12\x0e\n\x06serial\x18\x04 \x01(\t\x12\x13\n\x0b\x64\x65vice_type\x18\x05 \x01(\t\x12\x0c\n\x04host\x18\x06 \x01(\t\"B\n\x13ListDevicesResponse\x12+\n\x07\x64\x65vices\x18\x01 \x03(\x0b\x32\x1a.eebus.v1.DiscoveredDevice\"!\n\x12RegisterSKIRequest\x12\x0b\n\x03ski\x18\x01 \x01(\t\"{\n\x0cPairedDevice\x12\x0b\n\x03ski\x18\x01 \x01(\t\x12\r\n\x05\x62rand\x18\x02 \x01(\t\x12\r\n\x05model\x18\x03 \x01(\t\x12\x0e\n\x06serial\x18\x04 \x01(\t\x12\x13\n\x0b\x64\x65vice_type\x18\x05 \x01(\t\x12\x1b\n\x13supported_use_cases\x18\x06 \x03(\t\"D\n\x19ListPairedDevicesResponse\x12\'\n\x07\x64\x65vices\x18\x01 \x03(\x0b\x32\x16.eebus.v1.PairedDevice\"I\n\x0b\x44\x65viceEvent\x12\x0b\n\x03ski\x18\x01 \x01(\t\x12-\n\nevent_type\x18\x02 \x01(\x0e\x32\x19.eebus.v1.DeviceEventType*\x8a\x01\n\x0f\x44\x65viceEventType\x12\x1c\n\x18\x44\x45VICE_EVENT_UNSPECIFIED\x10\x00\x12\x1a\n\x16\x44\x45VICE_EVENT_CONNECTED\x10\x01\x12\x1d\n\x19\x44\x45VICE_EVENT_DISCONNECTED\x10\x02\x12\x1e\n\x1a\x44\x45VICE_EVENT_TRUST_REMOVED\x10\x03\x32\xe1\x02\n\rDeviceService\x12\x35\n\tGetStatus\x12\x0f.eebus.v1.Empty\x1a\x17.eebus.v1.ServiceStatus\x12G\n\x15ListDiscoveredDevices\x12\x0f.eebus.v1.Empty\x1a\x1d.eebus.v1.ListDevicesResponse\x12\x42\n\x11RegisterRemoteSKI\x12\x1c.eebus.v1.RegisterSKIRequest\x1a\x0f.eebus.v1.Empty\x12I\n\x11ListPairedDevices\x12\x0f.eebus.v1.Empty\x1a#.eebus.v1.ListPairedDevicesResponse\x12\x41\n\x15SubscribeDeviceEvents\x12\x0f.eebus.v1.Empty\x1a\x15.eebus.v1.DeviceEvent0\x01\x42=Z;github.com/volschin/eebus-bridge/gen/proto/eebus/v1;eebusv1b\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -33,10 +33,8 @@ _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'eebus.v1.device_service_pb2
 if not _descriptor._USE_C_DESCRIPTORS:
   _globals['DESCRIPTOR']._loaded_options = None
   _globals['DESCRIPTOR']._serialized_options = b'Z;github.com/volschin/eebus-bridge/gen/proto/eebus/v1;eebusv1'
-  _globals['_PAIRINGSTATE']._serialized_start=676
-  _globals['_PAIRINGSTATE']._serialized_end=838
-  _globals['_DEVICEEVENTTYPE']._serialized_start=841
-  _globals['_DEVICEEVENTTYPE']._serialized_end=979
+  _globals['_DEVICEEVENTTYPE']._serialized_start=607
+  _globals['_DEVICEEVENTTYPE']._serialized_end=745
   _globals['_SERVICESTATUS']._serialized_start=66
   _globals['_SERVICESTATUS']._serialized_end=117
   _globals['_DISCOVEREDDEVICE']._serialized_start=119
@@ -45,14 +43,12 @@ if not _descriptor._USE_C_DESCRIPTORS:
   _globals['_LISTDEVICESRESPONSE']._serialized_end=299
   _globals['_REGISTERSKIREQUEST']._serialized_start=301
   _globals['_REGISTERSKIREQUEST']._serialized_end=334
-  _globals['_PAIRINGSTATUS']._serialized_start=336
-  _globals['_PAIRINGSTATUS']._serialized_end=403
-  _globals['_PAIREDDEVICE']._serialized_start=405
-  _globals['_PAIREDDEVICE']._serialized_end=528
-  _globals['_LISTPAIREDDEVICESRESPONSE']._serialized_start=530
-  _globals['_LISTPAIREDDEVICESRESPONSE']._serialized_end=598
-  _globals['_DEVICEEVENT']._serialized_start=600
-  _globals['_DEVICEEVENT']._serialized_end=673
-  _globals['_DEVICESERVICE']._serialized_start=982
-  _globals['_DEVICESERVICE']._serialized_end=1470
+  _globals['_PAIREDDEVICE']._serialized_start=336
+  _globals['_PAIREDDEVICE']._serialized_end=459
+  _globals['_LISTPAIREDDEVICESRESPONSE']._serialized_start=461
+  _globals['_LISTPAIREDDEVICESRESPONSE']._serialized_end=529
+  _globals['_DEVICEEVENT']._serialized_start=531
+  _globals['_DEVICEEVENT']._serialized_end=604
+  _globals['_DEVICESERVICE']._serialized_start=748
+  _globals['_DEVICESERVICE']._serialized_end=1101
 # @@protoc_insertion_point(module_scope)

--- a/custom_components/eebus/generated/eebus/v1/device_service_pb2.pyi
+++ b/custom_components/eebus/generated/eebus/v1/device_service_pb2.pyi
@@ -8,25 +8,12 @@ from typing import ClassVar as _ClassVar, Optional as _Optional, Union as _Union
 
 DESCRIPTOR: _descriptor.FileDescriptor
 
-class PairingState(int, metaclass=_enum_type_wrapper.EnumTypeWrapper):
-    __slots__ = ()
-    PAIRING_STATE_UNSPECIFIED: _ClassVar[PairingState]
-    PAIRING_STATE_PENDING: _ClassVar[PairingState]
-    PAIRING_STATE_WAITING_FOR_TRUST: _ClassVar[PairingState]
-    PAIRING_STATE_TRUSTED: _ClassVar[PairingState]
-    PAIRING_STATE_DENIED: _ClassVar[PairingState]
-
 class DeviceEventType(int, metaclass=_enum_type_wrapper.EnumTypeWrapper):
     __slots__ = ()
     DEVICE_EVENT_UNSPECIFIED: _ClassVar[DeviceEventType]
     DEVICE_EVENT_CONNECTED: _ClassVar[DeviceEventType]
     DEVICE_EVENT_DISCONNECTED: _ClassVar[DeviceEventType]
     DEVICE_EVENT_TRUST_REMOVED: _ClassVar[DeviceEventType]
-PAIRING_STATE_UNSPECIFIED: PairingState
-PAIRING_STATE_PENDING: PairingState
-PAIRING_STATE_WAITING_FOR_TRUST: PairingState
-PAIRING_STATE_TRUSTED: PairingState
-PAIRING_STATE_DENIED: PairingState
 DEVICE_EVENT_UNSPECIFIED: DeviceEventType
 DEVICE_EVENT_CONNECTED: DeviceEventType
 DEVICE_EVENT_DISCONNECTED: DeviceEventType
@@ -67,14 +54,6 @@ class RegisterSKIRequest(_message.Message):
     SKI_FIELD_NUMBER: _ClassVar[int]
     ski: str
     def __init__(self, ski: _Optional[str] = ...) -> None: ...
-
-class PairingStatus(_message.Message):
-    __slots__ = ("ski", "state")
-    SKI_FIELD_NUMBER: _ClassVar[int]
-    STATE_FIELD_NUMBER: _ClassVar[int]
-    ski: str
-    state: PairingState
-    def __init__(self, ski: _Optional[str] = ..., state: _Optional[_Union[PairingState, str]] = ...) -> None: ...
 
 class PairedDevice(_message.Message):
     __slots__ = ("ski", "brand", "model", "serial", "device_type", "supported_use_cases")

--- a/custom_components/eebus/generated/eebus/v1/device_service_pb2_grpc.py
+++ b/custom_components/eebus/generated/eebus/v1/device_service_pb2_grpc.py
@@ -50,16 +50,6 @@ class DeviceServiceStub(object):
                 request_serializer=eebus_dot_v1_dot_device__service__pb2.RegisterSKIRequest.SerializeToString,
                 response_deserializer=eebus_dot_v1_dot_common__pb2.Empty.FromString,
                 _registered_method=True)
-        self.UnregisterRemoteSKI = channel.unary_unary(
-                '/eebus.v1.DeviceService/UnregisterRemoteSKI',
-                request_serializer=eebus_dot_v1_dot_common__pb2.DeviceRequest.SerializeToString,
-                response_deserializer=eebus_dot_v1_dot_common__pb2.Empty.FromString,
-                _registered_method=True)
-        self.GetPairingStatus = channel.unary_unary(
-                '/eebus.v1.DeviceService/GetPairingStatus',
-                request_serializer=eebus_dot_v1_dot_common__pb2.DeviceRequest.SerializeToString,
-                response_deserializer=eebus_dot_v1_dot_device__service__pb2.PairingStatus.FromString,
-                _registered_method=True)
         self.ListPairedDevices = channel.unary_unary(
                 '/eebus.v1.DeviceService/ListPairedDevices',
                 request_serializer=eebus_dot_v1_dot_common__pb2.Empty.SerializeToString,
@@ -88,18 +78,6 @@ class DeviceServiceServicer(object):
         raise NotImplementedError('Method not implemented!')
 
     def RegisterRemoteSKI(self, request, context):
-        """Missing associated documentation comment in .proto file."""
-        context.set_code(grpc.StatusCode.UNIMPLEMENTED)
-        context.set_details('Method not implemented!')
-        raise NotImplementedError('Method not implemented!')
-
-    def UnregisterRemoteSKI(self, request, context):
-        """Missing associated documentation comment in .proto file."""
-        context.set_code(grpc.StatusCode.UNIMPLEMENTED)
-        context.set_details('Method not implemented!')
-        raise NotImplementedError('Method not implemented!')
-
-    def GetPairingStatus(self, request, context):
         """Missing associated documentation comment in .proto file."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details('Method not implemented!')
@@ -134,16 +112,6 @@ def add_DeviceServiceServicer_to_server(servicer, server):
                     servicer.RegisterRemoteSKI,
                     request_deserializer=eebus_dot_v1_dot_device__service__pb2.RegisterSKIRequest.FromString,
                     response_serializer=eebus_dot_v1_dot_common__pb2.Empty.SerializeToString,
-            ),
-            'UnregisterRemoteSKI': grpc.unary_unary_rpc_method_handler(
-                    servicer.UnregisterRemoteSKI,
-                    request_deserializer=eebus_dot_v1_dot_common__pb2.DeviceRequest.FromString,
-                    response_serializer=eebus_dot_v1_dot_common__pb2.Empty.SerializeToString,
-            ),
-            'GetPairingStatus': grpc.unary_unary_rpc_method_handler(
-                    servicer.GetPairingStatus,
-                    request_deserializer=eebus_dot_v1_dot_common__pb2.DeviceRequest.FromString,
-                    response_serializer=eebus_dot_v1_dot_device__service__pb2.PairingStatus.SerializeToString,
             ),
             'ListPairedDevices': grpc.unary_unary_rpc_method_handler(
                     servicer.ListPairedDevices,
@@ -237,60 +205,6 @@ class DeviceService(object):
             '/eebus.v1.DeviceService/RegisterRemoteSKI',
             eebus_dot_v1_dot_device__service__pb2.RegisterSKIRequest.SerializeToString,
             eebus_dot_v1_dot_common__pb2.Empty.FromString,
-            options,
-            channel_credentials,
-            insecure,
-            call_credentials,
-            compression,
-            wait_for_ready,
-            timeout,
-            metadata,
-            _registered_method=True)
-
-    @staticmethod
-    def UnregisterRemoteSKI(request,
-            target,
-            options=(),
-            channel_credentials=None,
-            call_credentials=None,
-            insecure=False,
-            compression=None,
-            wait_for_ready=None,
-            timeout=None,
-            metadata=None):
-        return grpc.experimental.unary_unary(
-            request,
-            target,
-            '/eebus.v1.DeviceService/UnregisterRemoteSKI',
-            eebus_dot_v1_dot_common__pb2.DeviceRequest.SerializeToString,
-            eebus_dot_v1_dot_common__pb2.Empty.FromString,
-            options,
-            channel_credentials,
-            insecure,
-            call_credentials,
-            compression,
-            wait_for_ready,
-            timeout,
-            metadata,
-            _registered_method=True)
-
-    @staticmethod
-    def GetPairingStatus(request,
-            target,
-            options=(),
-            channel_credentials=None,
-            call_credentials=None,
-            insecure=False,
-            compression=None,
-            wait_for_ready=None,
-            timeout=None,
-            metadata=None):
-        return grpc.experimental.unary_unary(
-            request,
-            target,
-            '/eebus.v1.DeviceService/GetPairingStatus',
-            eebus_dot_v1_dot_common__pb2.DeviceRequest.SerializeToString,
-            eebus_dot_v1_dot_device__service__pb2.PairingStatus.FromString,
             options,
             channel_credentials,
             insecure,

--- a/custom_components/eebus/generated/eebus/v1/lpc_service_pb2.py
+++ b/custom_components/eebus/generated/eebus/v1/lpc_service_pb2.py
@@ -25,7 +25,7 @@ _sym_db = _symbol_database.Default()
 from . import common_pb2 as eebus_dot_v1_dot_common__pb2
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x1a\x65\x65\x62us/v1/lpc_service.proto\x12\x08\x65\x65\x62us.v1\x1a\x15\x65\x65\x62us/v1/common.proto\"f\n\x15WriteLoadLimitRequest\x12\x0b\n\x03ski\x18\x01 \x01(\t\x12\x13\n\x0bvalue_watts\x18\x02 \x01(\x01\x12\x18\n\x10\x64uration_seconds\x18\x03 \x01(\x03\x12\x11\n\tis_active\x18\x04 \x01(\x08\"F\n\rFailsafeLimit\x12\x13\n\x0bvalue_watts\x18\x01 \x01(\x01\x12 \n\x18\x64uration_minimum_seconds\x18\x02 \x01(\x03\"_\n\x19WriteFailsafeLimitRequest\x12\x0b\n\x03ski\x18\x01 \x01(\t\x12\x13\n\x0bvalue_watts\x18\x02 \x01(\x01\x12 \n\x18\x64uration_minimum_seconds\x18\x03 \x01(\x03\";\n\x0fHeartbeatStatus\x12\x0f\n\x07running\x18\x01 \x01(\x08\x12\x17\n\x0fwithin_duration\x18\x02 \x01(\x08\"\x1b\n\nPowerValue\x12\r\n\x05watts\x18\x01 \x01(\x01\"\xac\x01\n\x08LPCEvent\x12\x0b\n\x03ski\x18\x01 \x01(\t\x12*\n\nevent_type\x18\x02 \x01(\x0e\x32\x16.eebus.v1.LPCEventType\x12+\n\x0climit_update\x18\x03 \x01(\x0b\x32\x13.eebus.v1.LoadLimitH\x00\x12\x32\n\x0f\x66\x61ilsafe_update\x18\x04 \x01(\x0b\x32\x17.eebus.v1.FailsafeLimitH\x00\x42\x06\n\x04\x64\x61ta*\x87\x01\n\x0cLPCEventType\x12\x19\n\x15LPC_EVENT_UNSPECIFIED\x10\x00\x12\x1b\n\x17LPC_EVENT_LIMIT_UPDATED\x10\x01\x12\x1e\n\x1aLPC_EVENT_FAILSAFE_UPDATED\x10\x02\x12\x1f\n\x1bLPC_EVENT_HEARTBEAT_TIMEOUT\x10\x03\x32\xff\x04\n\nLPCService\x12\x43\n\x13GetConsumptionLimit\x12\x17.eebus.v1.DeviceRequest\x1a\x13.eebus.v1.LoadLimit\x12I\n\x15WriteConsumptionLimit\x12\x1f.eebus.v1.WriteLoadLimitRequest\x1a\x0f.eebus.v1.Empty\x12\x44\n\x10GetFailsafeLimit\x12\x17.eebus.v1.DeviceRequest\x1a\x17.eebus.v1.FailsafeLimit\x12J\n\x12WriteFailsafeLimit\x12#.eebus.v1.WriteFailsafeLimitRequest\x1a\x0f.eebus.v1.Empty\x12:\n\x0eStartHeartbeat\x12\x17.eebus.v1.DeviceRequest\x1a\x0f.eebus.v1.Empty\x12\x39\n\rStopHeartbeat\x12\x17.eebus.v1.DeviceRequest\x1a\x0f.eebus.v1.Empty\x12H\n\x12GetHeartbeatStatus\x12\x17.eebus.v1.DeviceRequest\x1a\x19.eebus.v1.HeartbeatStatus\x12I\n\x18GetConsumptionNominalMax\x12\x17.eebus.v1.DeviceRequest\x1a\x14.eebus.v1.PowerValue\x12\x43\n\x12SubscribeLPCEvents\x12\x17.eebus.v1.DeviceRequest\x1a\x12.eebus.v1.LPCEvent0\x01\x42=Z;github.com/volschin/eebus-bridge/gen/proto/eebus/v1;eebusv1b\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x1a\x65\x65\x62us/v1/lpc_service.proto\x12\x08\x65\x65\x62us.v1\x1a\x15\x65\x65\x62us/v1/common.proto\"f\n\x15WriteLoadLimitRequest\x12\x0b\n\x03ski\x18\x01 \x01(\t\x12\x13\n\x0bvalue_watts\x18\x02 \x01(\x01\x12\x18\n\x10\x64uration_seconds\x18\x03 \x01(\x03\x12\x11\n\tis_active\x18\x04 \x01(\x08\"F\n\rFailsafeLimit\x12\x13\n\x0bvalue_watts\x18\x01 \x01(\x01\x12 \n\x18\x64uration_minimum_seconds\x18\x02 \x01(\x03\"_\n\x19WriteFailsafeLimitRequest\x12\x0b\n\x03ski\x18\x01 \x01(\t\x12\x13\n\x0bvalue_watts\x18\x02 \x01(\x01\x12 \n\x18\x64uration_minimum_seconds\x18\x03 \x01(\x03\";\n\x0fHeartbeatStatus\x12\x0f\n\x07running\x18\x01 \x01(\x08\x12\x17\n\x0fwithin_duration\x18\x02 \x01(\x08\"\xac\x01\n\x08LPCEvent\x12\x0b\n\x03ski\x18\x01 \x01(\t\x12*\n\nevent_type\x18\x02 \x01(\x0e\x32\x16.eebus.v1.LPCEventType\x12+\n\x0climit_update\x18\x03 \x01(\x0b\x32\x13.eebus.v1.LoadLimitH\x00\x12\x32\n\x0f\x66\x61ilsafe_update\x18\x04 \x01(\x0b\x32\x17.eebus.v1.FailsafeLimitH\x00\x42\x06\n\x04\x64\x61ta*\x87\x01\n\x0cLPCEventType\x12\x19\n\x15LPC_EVENT_UNSPECIFIED\x10\x00\x12\x1b\n\x17LPC_EVENT_LIMIT_UPDATED\x10\x01\x12\x1e\n\x1aLPC_EVENT_FAILSAFE_UPDATED\x10\x02\x12\x1f\n\x1bLPC_EVENT_HEARTBEAT_TIMEOUT\x10\x03\x32\xb4\x04\n\nLPCService\x12\x43\n\x13GetConsumptionLimit\x12\x17.eebus.v1.DeviceRequest\x1a\x13.eebus.v1.LoadLimit\x12I\n\x15WriteConsumptionLimit\x12\x1f.eebus.v1.WriteLoadLimitRequest\x1a\x0f.eebus.v1.Empty\x12\x44\n\x10GetFailsafeLimit\x12\x17.eebus.v1.DeviceRequest\x1a\x17.eebus.v1.FailsafeLimit\x12J\n\x12WriteFailsafeLimit\x12#.eebus.v1.WriteFailsafeLimitRequest\x1a\x0f.eebus.v1.Empty\x12:\n\x0eStartHeartbeat\x12\x17.eebus.v1.DeviceRequest\x1a\x0f.eebus.v1.Empty\x12\x39\n\rStopHeartbeat\x12\x17.eebus.v1.DeviceRequest\x1a\x0f.eebus.v1.Empty\x12H\n\x12GetHeartbeatStatus\x12\x17.eebus.v1.DeviceRequest\x1a\x19.eebus.v1.HeartbeatStatus\x12\x43\n\x12SubscribeLPCEvents\x12\x17.eebus.v1.DeviceRequest\x1a\x12.eebus.v1.LPCEvent0\x01\x42=Z;github.com/volschin/eebus-bridge/gen/proto/eebus/v1;eebusv1b\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -33,8 +33,8 @@ _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'eebus.v1.lpc_service_pb2', 
 if not _descriptor._USE_C_DESCRIPTORS:
   _globals['DESCRIPTOR']._loaded_options = None
   _globals['DESCRIPTOR']._serialized_options = b'Z;github.com/volschin/eebus-bridge/gen/proto/eebus/v1;eebusv1'
-  _globals['_LPCEVENTTYPE']._serialized_start=602
-  _globals['_LPCEVENTTYPE']._serialized_end=737
+  _globals['_LPCEVENTTYPE']._serialized_start=573
+  _globals['_LPCEVENTTYPE']._serialized_end=708
   _globals['_WRITELOADLIMITREQUEST']._serialized_start=63
   _globals['_WRITELOADLIMITREQUEST']._serialized_end=165
   _globals['_FAILSAFELIMIT']._serialized_start=167
@@ -43,10 +43,8 @@ if not _descriptor._USE_C_DESCRIPTORS:
   _globals['_WRITEFAILSAFELIMITREQUEST']._serialized_end=334
   _globals['_HEARTBEATSTATUS']._serialized_start=336
   _globals['_HEARTBEATSTATUS']._serialized_end=395
-  _globals['_POWERVALUE']._serialized_start=397
-  _globals['_POWERVALUE']._serialized_end=424
-  _globals['_LPCEVENT']._serialized_start=427
-  _globals['_LPCEVENT']._serialized_end=599
-  _globals['_LPCSERVICE']._serialized_start=740
-  _globals['_LPCSERVICE']._serialized_end=1379
+  _globals['_LPCEVENT']._serialized_start=398
+  _globals['_LPCEVENT']._serialized_end=570
+  _globals['_LPCSERVICE']._serialized_start=711
+  _globals['_LPCSERVICE']._serialized_end=1275
 # @@protoc_insertion_point(module_scope)

--- a/custom_components/eebus/generated/eebus/v1/lpc_service_pb2.pyi
+++ b/custom_components/eebus/generated/eebus/v1/lpc_service_pb2.pyi
@@ -56,12 +56,6 @@ class HeartbeatStatus(_message.Message):
     within_duration: bool
     def __init__(self, running: bool = ..., within_duration: bool = ...) -> None: ...
 
-class PowerValue(_message.Message):
-    __slots__ = ("watts",)
-    WATTS_FIELD_NUMBER: _ClassVar[int]
-    watts: float
-    def __init__(self, watts: _Optional[float] = ...) -> None: ...
-
 class LPCEvent(_message.Message):
     __slots__ = ("ski", "event_type", "limit_update", "failsafe_update")
     SKI_FIELD_NUMBER: _ClassVar[int]

--- a/custom_components/eebus/generated/eebus/v1/lpc_service_pb2_grpc.py
+++ b/custom_components/eebus/generated/eebus/v1/lpc_service_pb2_grpc.py
@@ -70,11 +70,6 @@ class LPCServiceStub(object):
                 request_serializer=eebus_dot_v1_dot_common__pb2.DeviceRequest.SerializeToString,
                 response_deserializer=eebus_dot_v1_dot_lpc__service__pb2.HeartbeatStatus.FromString,
                 _registered_method=True)
-        self.GetConsumptionNominalMax = channel.unary_unary(
-                '/eebus.v1.LPCService/GetConsumptionNominalMax',
-                request_serializer=eebus_dot_v1_dot_common__pb2.DeviceRequest.SerializeToString,
-                response_deserializer=eebus_dot_v1_dot_lpc__service__pb2.PowerValue.FromString,
-                _registered_method=True)
         self.SubscribeLPCEvents = channel.unary_stream(
                 '/eebus.v1.LPCService/SubscribeLPCEvents',
                 request_serializer=eebus_dot_v1_dot_common__pb2.DeviceRequest.SerializeToString,
@@ -127,12 +122,6 @@ class LPCServiceServicer(object):
         context.set_details('Method not implemented!')
         raise NotImplementedError('Method not implemented!')
 
-    def GetConsumptionNominalMax(self, request, context):
-        """Missing associated documentation comment in .proto file."""
-        context.set_code(grpc.StatusCode.UNIMPLEMENTED)
-        context.set_details('Method not implemented!')
-        raise NotImplementedError('Method not implemented!')
-
     def SubscribeLPCEvents(self, request, context):
         """Missing associated documentation comment in .proto file."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
@@ -176,11 +165,6 @@ def add_LPCServiceServicer_to_server(servicer, server):
                     servicer.GetHeartbeatStatus,
                     request_deserializer=eebus_dot_v1_dot_common__pb2.DeviceRequest.FromString,
                     response_serializer=eebus_dot_v1_dot_lpc__service__pb2.HeartbeatStatus.SerializeToString,
-            ),
-            'GetConsumptionNominalMax': grpc.unary_unary_rpc_method_handler(
-                    servicer.GetConsumptionNominalMax,
-                    request_deserializer=eebus_dot_v1_dot_common__pb2.DeviceRequest.FromString,
-                    response_serializer=eebus_dot_v1_dot_lpc__service__pb2.PowerValue.SerializeToString,
             ),
             'SubscribeLPCEvents': grpc.unary_stream_rpc_method_handler(
                     servicer.SubscribeLPCEvents,
@@ -377,33 +361,6 @@ class LPCService(object):
             '/eebus.v1.LPCService/GetHeartbeatStatus',
             eebus_dot_v1_dot_common__pb2.DeviceRequest.SerializeToString,
             eebus_dot_v1_dot_lpc__service__pb2.HeartbeatStatus.FromString,
-            options,
-            channel_credentials,
-            insecure,
-            call_credentials,
-            compression,
-            wait_for_ready,
-            timeout,
-            metadata,
-            _registered_method=True)
-
-    @staticmethod
-    def GetConsumptionNominalMax(request,
-            target,
-            options=(),
-            channel_credentials=None,
-            call_credentials=None,
-            insecure=False,
-            compression=None,
-            wait_for_ready=None,
-            timeout=None,
-            metadata=None):
-        return grpc.experimental.unary_unary(
-            request,
-            target,
-            '/eebus.v1.LPCService/GetConsumptionNominalMax',
-            eebus_dot_v1_dot_common__pb2.DeviceRequest.SerializeToString,
-            eebus_dot_v1_dot_lpc__service__pb2.PowerValue.FromString,
             options,
             channel_credentials,
             insecure,

--- a/eebus-bridge/cmd/eebus-bridge/main.go
+++ b/eebus-bridge/cmd/eebus-bridge/main.go
@@ -104,9 +104,6 @@ func main() {
 			case "device.register_ski":
 				bridgeSvc.RegisterRemoteSKI(evt.SKI)
 				log.Printf("Registered remote SKI: %s", evt.SKI)
-			case "device.unregister_ski":
-				bridgeSvc.UnregisterRemoteSKI(evt.SKI)
-				log.Printf("Unregistered remote SKI: %s", evt.SKI)
 			}
 		}
 	}()

--- a/eebus-bridge/gen/proto/eebus/v1/device_service.pb.go
+++ b/eebus-bridge/gen/proto/eebus/v1/device_service.pb.go
@@ -21,61 +21,6 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
-type PairingState int32
-
-const (
-	PairingState_PAIRING_STATE_UNSPECIFIED       PairingState = 0
-	PairingState_PAIRING_STATE_PENDING           PairingState = 1
-	PairingState_PAIRING_STATE_WAITING_FOR_TRUST PairingState = 2
-	PairingState_PAIRING_STATE_TRUSTED           PairingState = 3
-	PairingState_PAIRING_STATE_DENIED            PairingState = 4
-)
-
-// Enum value maps for PairingState.
-var (
-	PairingState_name = map[int32]string{
-		0: "PAIRING_STATE_UNSPECIFIED",
-		1: "PAIRING_STATE_PENDING",
-		2: "PAIRING_STATE_WAITING_FOR_TRUST",
-		3: "PAIRING_STATE_TRUSTED",
-		4: "PAIRING_STATE_DENIED",
-	}
-	PairingState_value = map[string]int32{
-		"PAIRING_STATE_UNSPECIFIED":       0,
-		"PAIRING_STATE_PENDING":           1,
-		"PAIRING_STATE_WAITING_FOR_TRUST": 2,
-		"PAIRING_STATE_TRUSTED":           3,
-		"PAIRING_STATE_DENIED":            4,
-	}
-)
-
-func (x PairingState) Enum() *PairingState {
-	p := new(PairingState)
-	*p = x
-	return p
-}
-
-func (x PairingState) String() string {
-	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
-}
-
-func (PairingState) Descriptor() protoreflect.EnumDescriptor {
-	return file_eebus_v1_device_service_proto_enumTypes[0].Descriptor()
-}
-
-func (PairingState) Type() protoreflect.EnumType {
-	return &file_eebus_v1_device_service_proto_enumTypes[0]
-}
-
-func (x PairingState) Number() protoreflect.EnumNumber {
-	return protoreflect.EnumNumber(x)
-}
-
-// Deprecated: Use PairingState.Descriptor instead.
-func (PairingState) EnumDescriptor() ([]byte, []int) {
-	return file_eebus_v1_device_service_proto_rawDescGZIP(), []int{0}
-}
-
 type DeviceEventType int32
 
 const (
@@ -112,11 +57,11 @@ func (x DeviceEventType) String() string {
 }
 
 func (DeviceEventType) Descriptor() protoreflect.EnumDescriptor {
-	return file_eebus_v1_device_service_proto_enumTypes[1].Descriptor()
+	return file_eebus_v1_device_service_proto_enumTypes[0].Descriptor()
 }
 
 func (DeviceEventType) Type() protoreflect.EnumType {
-	return &file_eebus_v1_device_service_proto_enumTypes[1]
+	return &file_eebus_v1_device_service_proto_enumTypes[0]
 }
 
 func (x DeviceEventType) Number() protoreflect.EnumNumber {
@@ -125,7 +70,7 @@ func (x DeviceEventType) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use DeviceEventType.Descriptor instead.
 func (DeviceEventType) EnumDescriptor() ([]byte, []int) {
-	return file_eebus_v1_device_service_proto_rawDescGZIP(), []int{1}
+	return file_eebus_v1_device_service_proto_rawDescGZIP(), []int{0}
 }
 
 type ServiceStatus struct {
@@ -352,58 +297,6 @@ func (x *RegisterSKIRequest) GetSki() string {
 	return ""
 }
 
-type PairingStatus struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Ski           string                 `protobuf:"bytes,1,opt,name=ski,proto3" json:"ski,omitempty"`
-	State         PairingState           `protobuf:"varint,2,opt,name=state,proto3,enum=eebus.v1.PairingState" json:"state,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
-}
-
-func (x *PairingStatus) Reset() {
-	*x = PairingStatus{}
-	mi := &file_eebus_v1_device_service_proto_msgTypes[4]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *PairingStatus) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*PairingStatus) ProtoMessage() {}
-
-func (x *PairingStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_eebus_v1_device_service_proto_msgTypes[4]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-// Deprecated: Use PairingStatus.ProtoReflect.Descriptor instead.
-func (*PairingStatus) Descriptor() ([]byte, []int) {
-	return file_eebus_v1_device_service_proto_rawDescGZIP(), []int{4}
-}
-
-func (x *PairingStatus) GetSki() string {
-	if x != nil {
-		return x.Ski
-	}
-	return ""
-}
-
-func (x *PairingStatus) GetState() PairingState {
-	if x != nil {
-		return x.State
-	}
-	return PairingState_PAIRING_STATE_UNSPECIFIED
-}
-
 type PairedDevice struct {
 	state             protoimpl.MessageState `protogen:"open.v1"`
 	Ski               string                 `protobuf:"bytes,1,opt,name=ski,proto3" json:"ski,omitempty"`
@@ -418,7 +311,7 @@ type PairedDevice struct {
 
 func (x *PairedDevice) Reset() {
 	*x = PairedDevice{}
-	mi := &file_eebus_v1_device_service_proto_msgTypes[5]
+	mi := &file_eebus_v1_device_service_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -430,7 +323,7 @@ func (x *PairedDevice) String() string {
 func (*PairedDevice) ProtoMessage() {}
 
 func (x *PairedDevice) ProtoReflect() protoreflect.Message {
-	mi := &file_eebus_v1_device_service_proto_msgTypes[5]
+	mi := &file_eebus_v1_device_service_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -443,7 +336,7 @@ func (x *PairedDevice) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PairedDevice.ProtoReflect.Descriptor instead.
 func (*PairedDevice) Descriptor() ([]byte, []int) {
-	return file_eebus_v1_device_service_proto_rawDescGZIP(), []int{5}
+	return file_eebus_v1_device_service_proto_rawDescGZIP(), []int{4}
 }
 
 func (x *PairedDevice) GetSki() string {
@@ -497,7 +390,7 @@ type ListPairedDevicesResponse struct {
 
 func (x *ListPairedDevicesResponse) Reset() {
 	*x = ListPairedDevicesResponse{}
-	mi := &file_eebus_v1_device_service_proto_msgTypes[6]
+	mi := &file_eebus_v1_device_service_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -509,7 +402,7 @@ func (x *ListPairedDevicesResponse) String() string {
 func (*ListPairedDevicesResponse) ProtoMessage() {}
 
 func (x *ListPairedDevicesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_eebus_v1_device_service_proto_msgTypes[6]
+	mi := &file_eebus_v1_device_service_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -522,7 +415,7 @@ func (x *ListPairedDevicesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListPairedDevicesResponse.ProtoReflect.Descriptor instead.
 func (*ListPairedDevicesResponse) Descriptor() ([]byte, []int) {
-	return file_eebus_v1_device_service_proto_rawDescGZIP(), []int{6}
+	return file_eebus_v1_device_service_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *ListPairedDevicesResponse) GetDevices() []*PairedDevice {
@@ -542,7 +435,7 @@ type DeviceEvent struct {
 
 func (x *DeviceEvent) Reset() {
 	*x = DeviceEvent{}
-	mi := &file_eebus_v1_device_service_proto_msgTypes[7]
+	mi := &file_eebus_v1_device_service_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -554,7 +447,7 @@ func (x *DeviceEvent) String() string {
 func (*DeviceEvent) ProtoMessage() {}
 
 func (x *DeviceEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_eebus_v1_device_service_proto_msgTypes[7]
+	mi := &file_eebus_v1_device_service_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -567,7 +460,7 @@ func (x *DeviceEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeviceEvent.ProtoReflect.Descriptor instead.
 func (*DeviceEvent) Descriptor() ([]byte, []int) {
-	return file_eebus_v1_device_service_proto_rawDescGZIP(), []int{7}
+	return file_eebus_v1_device_service_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *DeviceEvent) GetSki() string {
@@ -603,10 +496,7 @@ const file_eebus_v1_device_service_proto_rawDesc = "" +
 	"\x13ListDevicesResponse\x124\n" +
 	"\adevices\x18\x01 \x03(\v2\x1a.eebus.v1.DiscoveredDeviceR\adevices\"&\n" +
 	"\x12RegisterSKIRequest\x12\x10\n" +
-	"\x03ski\x18\x01 \x01(\tR\x03ski\"O\n" +
-	"\rPairingStatus\x12\x10\n" +
-	"\x03ski\x18\x01 \x01(\tR\x03ski\x12,\n" +
-	"\x05state\x18\x02 \x01(\x0e2\x16.eebus.v1.PairingStateR\x05state\"\xb5\x01\n" +
+	"\x03ski\x18\x01 \x01(\tR\x03ski\"\xb5\x01\n" +
 	"\fPairedDevice\x12\x10\n" +
 	"\x03ski\x18\x01 \x01(\tR\x03ski\x12\x14\n" +
 	"\x05brand\x18\x02 \x01(\tR\x05brand\x12\x14\n" +
@@ -620,24 +510,16 @@ const file_eebus_v1_device_service_proto_rawDesc = "" +
 	"\vDeviceEvent\x12\x10\n" +
 	"\x03ski\x18\x01 \x01(\tR\x03ski\x128\n" +
 	"\n" +
-	"event_type\x18\x02 \x01(\x0e2\x19.eebus.v1.DeviceEventTypeR\teventType*\xa2\x01\n" +
-	"\fPairingState\x12\x1d\n" +
-	"\x19PAIRING_STATE_UNSPECIFIED\x10\x00\x12\x19\n" +
-	"\x15PAIRING_STATE_PENDING\x10\x01\x12#\n" +
-	"\x1fPAIRING_STATE_WAITING_FOR_TRUST\x10\x02\x12\x19\n" +
-	"\x15PAIRING_STATE_TRUSTED\x10\x03\x12\x18\n" +
-	"\x14PAIRING_STATE_DENIED\x10\x04*\x8a\x01\n" +
+	"event_type\x18\x02 \x01(\x0e2\x19.eebus.v1.DeviceEventTypeR\teventType*\x8a\x01\n" +
 	"\x0fDeviceEventType\x12\x1c\n" +
 	"\x18DEVICE_EVENT_UNSPECIFIED\x10\x00\x12\x1a\n" +
 	"\x16DEVICE_EVENT_CONNECTED\x10\x01\x12\x1d\n" +
 	"\x19DEVICE_EVENT_DISCONNECTED\x10\x02\x12\x1e\n" +
-	"\x1aDEVICE_EVENT_TRUST_REMOVED\x10\x032\xe8\x03\n" +
+	"\x1aDEVICE_EVENT_TRUST_REMOVED\x10\x032\xe1\x02\n" +
 	"\rDeviceService\x125\n" +
 	"\tGetStatus\x12\x0f.eebus.v1.Empty\x1a\x17.eebus.v1.ServiceStatus\x12G\n" +
 	"\x15ListDiscoveredDevices\x12\x0f.eebus.v1.Empty\x1a\x1d.eebus.v1.ListDevicesResponse\x12B\n" +
-	"\x11RegisterRemoteSKI\x12\x1c.eebus.v1.RegisterSKIRequest\x1a\x0f.eebus.v1.Empty\x12?\n" +
-	"\x13UnregisterRemoteSKI\x12\x17.eebus.v1.DeviceRequest\x1a\x0f.eebus.v1.Empty\x12D\n" +
-	"\x10GetPairingStatus\x12\x17.eebus.v1.DeviceRequest\x1a\x17.eebus.v1.PairingStatus\x12I\n" +
+	"\x11RegisterRemoteSKI\x12\x1c.eebus.v1.RegisterSKIRequest\x1a\x0f.eebus.v1.Empty\x12I\n" +
 	"\x11ListPairedDevices\x12\x0f.eebus.v1.Empty\x1a#.eebus.v1.ListPairedDevicesResponse\x12A\n" +
 	"\x15SubscribeDeviceEvents\x12\x0f.eebus.v1.Empty\x1a\x15.eebus.v1.DeviceEvent0\x01B=Z;github.com/volschin/eebus-bridge/gen/proto/eebus/v1;eebusv1b\x06proto3"
 
@@ -653,46 +535,38 @@ func file_eebus_v1_device_service_proto_rawDescGZIP() []byte {
 	return file_eebus_v1_device_service_proto_rawDescData
 }
 
-var file_eebus_v1_device_service_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
-var file_eebus_v1_device_service_proto_msgTypes = make([]protoimpl.MessageInfo, 8)
+var file_eebus_v1_device_service_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
+var file_eebus_v1_device_service_proto_msgTypes = make([]protoimpl.MessageInfo, 7)
 var file_eebus_v1_device_service_proto_goTypes = []any{
-	(PairingState)(0),                 // 0: eebus.v1.PairingState
-	(DeviceEventType)(0),              // 1: eebus.v1.DeviceEventType
-	(*ServiceStatus)(nil),             // 2: eebus.v1.ServiceStatus
-	(*DiscoveredDevice)(nil),          // 3: eebus.v1.DiscoveredDevice
-	(*ListDevicesResponse)(nil),       // 4: eebus.v1.ListDevicesResponse
-	(*RegisterSKIRequest)(nil),        // 5: eebus.v1.RegisterSKIRequest
-	(*PairingStatus)(nil),             // 6: eebus.v1.PairingStatus
-	(*PairedDevice)(nil),              // 7: eebus.v1.PairedDevice
-	(*ListPairedDevicesResponse)(nil), // 8: eebus.v1.ListPairedDevicesResponse
-	(*DeviceEvent)(nil),               // 9: eebus.v1.DeviceEvent
-	(*Empty)(nil),                     // 10: eebus.v1.Empty
-	(*DeviceRequest)(nil),             // 11: eebus.v1.DeviceRequest
+	(DeviceEventType)(0),              // 0: eebus.v1.DeviceEventType
+	(*ServiceStatus)(nil),             // 1: eebus.v1.ServiceStatus
+	(*DiscoveredDevice)(nil),          // 2: eebus.v1.DiscoveredDevice
+	(*ListDevicesResponse)(nil),       // 3: eebus.v1.ListDevicesResponse
+	(*RegisterSKIRequest)(nil),        // 4: eebus.v1.RegisterSKIRequest
+	(*PairedDevice)(nil),              // 5: eebus.v1.PairedDevice
+	(*ListPairedDevicesResponse)(nil), // 6: eebus.v1.ListPairedDevicesResponse
+	(*DeviceEvent)(nil),               // 7: eebus.v1.DeviceEvent
+	(*Empty)(nil),                     // 8: eebus.v1.Empty
 }
 var file_eebus_v1_device_service_proto_depIdxs = []int32{
-	3,  // 0: eebus.v1.ListDevicesResponse.devices:type_name -> eebus.v1.DiscoveredDevice
-	0,  // 1: eebus.v1.PairingStatus.state:type_name -> eebus.v1.PairingState
-	7,  // 2: eebus.v1.ListPairedDevicesResponse.devices:type_name -> eebus.v1.PairedDevice
-	1,  // 3: eebus.v1.DeviceEvent.event_type:type_name -> eebus.v1.DeviceEventType
-	10, // 4: eebus.v1.DeviceService.GetStatus:input_type -> eebus.v1.Empty
-	10, // 5: eebus.v1.DeviceService.ListDiscoveredDevices:input_type -> eebus.v1.Empty
-	5,  // 6: eebus.v1.DeviceService.RegisterRemoteSKI:input_type -> eebus.v1.RegisterSKIRequest
-	11, // 7: eebus.v1.DeviceService.UnregisterRemoteSKI:input_type -> eebus.v1.DeviceRequest
-	11, // 8: eebus.v1.DeviceService.GetPairingStatus:input_type -> eebus.v1.DeviceRequest
-	10, // 9: eebus.v1.DeviceService.ListPairedDevices:input_type -> eebus.v1.Empty
-	10, // 10: eebus.v1.DeviceService.SubscribeDeviceEvents:input_type -> eebus.v1.Empty
-	2,  // 11: eebus.v1.DeviceService.GetStatus:output_type -> eebus.v1.ServiceStatus
-	4,  // 12: eebus.v1.DeviceService.ListDiscoveredDevices:output_type -> eebus.v1.ListDevicesResponse
-	10, // 13: eebus.v1.DeviceService.RegisterRemoteSKI:output_type -> eebus.v1.Empty
-	10, // 14: eebus.v1.DeviceService.UnregisterRemoteSKI:output_type -> eebus.v1.Empty
-	6,  // 15: eebus.v1.DeviceService.GetPairingStatus:output_type -> eebus.v1.PairingStatus
-	8,  // 16: eebus.v1.DeviceService.ListPairedDevices:output_type -> eebus.v1.ListPairedDevicesResponse
-	9,  // 17: eebus.v1.DeviceService.SubscribeDeviceEvents:output_type -> eebus.v1.DeviceEvent
-	11, // [11:18] is the sub-list for method output_type
-	4,  // [4:11] is the sub-list for method input_type
-	4,  // [4:4] is the sub-list for extension type_name
-	4,  // [4:4] is the sub-list for extension extendee
-	0,  // [0:4] is the sub-list for field type_name
+	2, // 0: eebus.v1.ListDevicesResponse.devices:type_name -> eebus.v1.DiscoveredDevice
+	5, // 1: eebus.v1.ListPairedDevicesResponse.devices:type_name -> eebus.v1.PairedDevice
+	0, // 2: eebus.v1.DeviceEvent.event_type:type_name -> eebus.v1.DeviceEventType
+	8, // 3: eebus.v1.DeviceService.GetStatus:input_type -> eebus.v1.Empty
+	8, // 4: eebus.v1.DeviceService.ListDiscoveredDevices:input_type -> eebus.v1.Empty
+	4, // 5: eebus.v1.DeviceService.RegisterRemoteSKI:input_type -> eebus.v1.RegisterSKIRequest
+	8, // 6: eebus.v1.DeviceService.ListPairedDevices:input_type -> eebus.v1.Empty
+	8, // 7: eebus.v1.DeviceService.SubscribeDeviceEvents:input_type -> eebus.v1.Empty
+	1, // 8: eebus.v1.DeviceService.GetStatus:output_type -> eebus.v1.ServiceStatus
+	3, // 9: eebus.v1.DeviceService.ListDiscoveredDevices:output_type -> eebus.v1.ListDevicesResponse
+	8, // 10: eebus.v1.DeviceService.RegisterRemoteSKI:output_type -> eebus.v1.Empty
+	6, // 11: eebus.v1.DeviceService.ListPairedDevices:output_type -> eebus.v1.ListPairedDevicesResponse
+	7, // 12: eebus.v1.DeviceService.SubscribeDeviceEvents:output_type -> eebus.v1.DeviceEvent
+	8, // [8:13] is the sub-list for method output_type
+	3, // [3:8] is the sub-list for method input_type
+	3, // [3:3] is the sub-list for extension type_name
+	3, // [3:3] is the sub-list for extension extendee
+	0, // [0:3] is the sub-list for field type_name
 }
 
 func init() { file_eebus_v1_device_service_proto_init() }
@@ -706,8 +580,8 @@ func file_eebus_v1_device_service_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_eebus_v1_device_service_proto_rawDesc), len(file_eebus_v1_device_service_proto_rawDesc)),
-			NumEnums:      2,
-			NumMessages:   8,
+			NumEnums:      1,
+			NumMessages:   7,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/eebus-bridge/gen/proto/eebus/v1/device_service_grpc.pb.go
+++ b/eebus-bridge/gen/proto/eebus/v1/device_service_grpc.pb.go
@@ -22,8 +22,6 @@ const (
 	DeviceService_GetStatus_FullMethodName             = "/eebus.v1.DeviceService/GetStatus"
 	DeviceService_ListDiscoveredDevices_FullMethodName = "/eebus.v1.DeviceService/ListDiscoveredDevices"
 	DeviceService_RegisterRemoteSKI_FullMethodName     = "/eebus.v1.DeviceService/RegisterRemoteSKI"
-	DeviceService_UnregisterRemoteSKI_FullMethodName   = "/eebus.v1.DeviceService/UnregisterRemoteSKI"
-	DeviceService_GetPairingStatus_FullMethodName      = "/eebus.v1.DeviceService/GetPairingStatus"
 	DeviceService_ListPairedDevices_FullMethodName     = "/eebus.v1.DeviceService/ListPairedDevices"
 	DeviceService_SubscribeDeviceEvents_FullMethodName = "/eebus.v1.DeviceService/SubscribeDeviceEvents"
 )
@@ -35,8 +33,6 @@ type DeviceServiceClient interface {
 	GetStatus(ctx context.Context, in *Empty, opts ...grpc.CallOption) (*ServiceStatus, error)
 	ListDiscoveredDevices(ctx context.Context, in *Empty, opts ...grpc.CallOption) (*ListDevicesResponse, error)
 	RegisterRemoteSKI(ctx context.Context, in *RegisterSKIRequest, opts ...grpc.CallOption) (*Empty, error)
-	UnregisterRemoteSKI(ctx context.Context, in *DeviceRequest, opts ...grpc.CallOption) (*Empty, error)
-	GetPairingStatus(ctx context.Context, in *DeviceRequest, opts ...grpc.CallOption) (*PairingStatus, error)
 	ListPairedDevices(ctx context.Context, in *Empty, opts ...grpc.CallOption) (*ListPairedDevicesResponse, error)
 	SubscribeDeviceEvents(ctx context.Context, in *Empty, opts ...grpc.CallOption) (grpc.ServerStreamingClient[DeviceEvent], error)
 }
@@ -79,26 +75,6 @@ func (c *deviceServiceClient) RegisterRemoteSKI(ctx context.Context, in *Registe
 	return out, nil
 }
 
-func (c *deviceServiceClient) UnregisterRemoteSKI(ctx context.Context, in *DeviceRequest, opts ...grpc.CallOption) (*Empty, error) {
-	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	out := new(Empty)
-	err := c.cc.Invoke(ctx, DeviceService_UnregisterRemoteSKI_FullMethodName, in, out, cOpts...)
-	if err != nil {
-		return nil, err
-	}
-	return out, nil
-}
-
-func (c *deviceServiceClient) GetPairingStatus(ctx context.Context, in *DeviceRequest, opts ...grpc.CallOption) (*PairingStatus, error) {
-	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	out := new(PairingStatus)
-	err := c.cc.Invoke(ctx, DeviceService_GetPairingStatus_FullMethodName, in, out, cOpts...)
-	if err != nil {
-		return nil, err
-	}
-	return out, nil
-}
-
 func (c *deviceServiceClient) ListPairedDevices(ctx context.Context, in *Empty, opts ...grpc.CallOption) (*ListPairedDevicesResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(ListPairedDevicesResponse)
@@ -135,8 +111,6 @@ type DeviceServiceServer interface {
 	GetStatus(context.Context, *Empty) (*ServiceStatus, error)
 	ListDiscoveredDevices(context.Context, *Empty) (*ListDevicesResponse, error)
 	RegisterRemoteSKI(context.Context, *RegisterSKIRequest) (*Empty, error)
-	UnregisterRemoteSKI(context.Context, *DeviceRequest) (*Empty, error)
-	GetPairingStatus(context.Context, *DeviceRequest) (*PairingStatus, error)
 	ListPairedDevices(context.Context, *Empty) (*ListPairedDevicesResponse, error)
 	SubscribeDeviceEvents(*Empty, grpc.ServerStreamingServer[DeviceEvent]) error
 	mustEmbedUnimplementedDeviceServiceServer()
@@ -157,12 +131,6 @@ func (UnimplementedDeviceServiceServer) ListDiscoveredDevices(context.Context, *
 }
 func (UnimplementedDeviceServiceServer) RegisterRemoteSKI(context.Context, *RegisterSKIRequest) (*Empty, error) {
 	return nil, status.Error(codes.Unimplemented, "method RegisterRemoteSKI not implemented")
-}
-func (UnimplementedDeviceServiceServer) UnregisterRemoteSKI(context.Context, *DeviceRequest) (*Empty, error) {
-	return nil, status.Error(codes.Unimplemented, "method UnregisterRemoteSKI not implemented")
-}
-func (UnimplementedDeviceServiceServer) GetPairingStatus(context.Context, *DeviceRequest) (*PairingStatus, error) {
-	return nil, status.Error(codes.Unimplemented, "method GetPairingStatus not implemented")
 }
 func (UnimplementedDeviceServiceServer) ListPairedDevices(context.Context, *Empty) (*ListPairedDevicesResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ListPairedDevices not implemented")
@@ -245,42 +213,6 @@ func _DeviceService_RegisterRemoteSKI_Handler(srv interface{}, ctx context.Conte
 	return interceptor(ctx, in, info, handler)
 }
 
-func _DeviceService_UnregisterRemoteSKI_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(DeviceRequest)
-	if err := dec(in); err != nil {
-		return nil, err
-	}
-	if interceptor == nil {
-		return srv.(DeviceServiceServer).UnregisterRemoteSKI(ctx, in)
-	}
-	info := &grpc.UnaryServerInfo{
-		Server:     srv,
-		FullMethod: DeviceService_UnregisterRemoteSKI_FullMethodName,
-	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(DeviceServiceServer).UnregisterRemoteSKI(ctx, req.(*DeviceRequest))
-	}
-	return interceptor(ctx, in, info, handler)
-}
-
-func _DeviceService_GetPairingStatus_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(DeviceRequest)
-	if err := dec(in); err != nil {
-		return nil, err
-	}
-	if interceptor == nil {
-		return srv.(DeviceServiceServer).GetPairingStatus(ctx, in)
-	}
-	info := &grpc.UnaryServerInfo{
-		Server:     srv,
-		FullMethod: DeviceService_GetPairingStatus_FullMethodName,
-	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(DeviceServiceServer).GetPairingStatus(ctx, req.(*DeviceRequest))
-	}
-	return interceptor(ctx, in, info, handler)
-}
-
 func _DeviceService_ListPairedDevices_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(Empty)
 	if err := dec(in); err != nil {
@@ -328,14 +260,6 @@ var DeviceService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "RegisterRemoteSKI",
 			Handler:    _DeviceService_RegisterRemoteSKI_Handler,
-		},
-		{
-			MethodName: "UnregisterRemoteSKI",
-			Handler:    _DeviceService_UnregisterRemoteSKI_Handler,
-		},
-		{
-			MethodName: "GetPairingStatus",
-			Handler:    _DeviceService_GetPairingStatus_Handler,
 		},
 		{
 			MethodName: "ListPairedDevices",

--- a/eebus-bridge/gen/proto/eebus/v1/lpc_service.pb.go
+++ b/eebus-bridge/gen/proto/eebus/v1/lpc_service.pb.go
@@ -305,50 +305,6 @@ func (x *HeartbeatStatus) GetWithinDuration() bool {
 	return false
 }
 
-type PowerValue struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Watts         float64                `protobuf:"fixed64,1,opt,name=watts,proto3" json:"watts,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
-}
-
-func (x *PowerValue) Reset() {
-	*x = PowerValue{}
-	mi := &file_eebus_v1_lpc_service_proto_msgTypes[4]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *PowerValue) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*PowerValue) ProtoMessage() {}
-
-func (x *PowerValue) ProtoReflect() protoreflect.Message {
-	mi := &file_eebus_v1_lpc_service_proto_msgTypes[4]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-// Deprecated: Use PowerValue.ProtoReflect.Descriptor instead.
-func (*PowerValue) Descriptor() ([]byte, []int) {
-	return file_eebus_v1_lpc_service_proto_rawDescGZIP(), []int{4}
-}
-
-func (x *PowerValue) GetWatts() float64 {
-	if x != nil {
-		return x.Watts
-	}
-	return 0
-}
-
 type LPCEvent struct {
 	state     protoimpl.MessageState `protogen:"open.v1"`
 	Ski       string                 `protobuf:"bytes,1,opt,name=ski,proto3" json:"ski,omitempty"`
@@ -364,7 +320,7 @@ type LPCEvent struct {
 
 func (x *LPCEvent) Reset() {
 	*x = LPCEvent{}
-	mi := &file_eebus_v1_lpc_service_proto_msgTypes[5]
+	mi := &file_eebus_v1_lpc_service_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -376,7 +332,7 @@ func (x *LPCEvent) String() string {
 func (*LPCEvent) ProtoMessage() {}
 
 func (x *LPCEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_eebus_v1_lpc_service_proto_msgTypes[5]
+	mi := &file_eebus_v1_lpc_service_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -389,7 +345,7 @@ func (x *LPCEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LPCEvent.ProtoReflect.Descriptor instead.
 func (*LPCEvent) Descriptor() ([]byte, []int) {
-	return file_eebus_v1_lpc_service_proto_rawDescGZIP(), []int{5}
+	return file_eebus_v1_lpc_service_proto_rawDescGZIP(), []int{4}
 }
 
 func (x *LPCEvent) GetSki() string {
@@ -469,10 +425,7 @@ const file_eebus_v1_lpc_service_proto_rawDesc = "" +
 	"\x18duration_minimum_seconds\x18\x03 \x01(\x03R\x16durationMinimumSeconds\"T\n" +
 	"\x0fHeartbeatStatus\x12\x18\n" +
 	"\arunning\x18\x01 \x01(\bR\arunning\x12'\n" +
-	"\x0fwithin_duration\x18\x02 \x01(\bR\x0ewithinDuration\"\"\n" +
-	"\n" +
-	"PowerValue\x12\x14\n" +
-	"\x05watts\x18\x01 \x01(\x01R\x05watts\"\xd9\x01\n" +
+	"\x0fwithin_duration\x18\x02 \x01(\bR\x0ewithinDuration\"\xd9\x01\n" +
 	"\bLPCEvent\x12\x10\n" +
 	"\x03ski\x18\x01 \x01(\tR\x03ski\x125\n" +
 	"\n" +
@@ -484,7 +437,7 @@ const file_eebus_v1_lpc_service_proto_rawDesc = "" +
 	"\x15LPC_EVENT_UNSPECIFIED\x10\x00\x12\x1b\n" +
 	"\x17LPC_EVENT_LIMIT_UPDATED\x10\x01\x12\x1e\n" +
 	"\x1aLPC_EVENT_FAILSAFE_UPDATED\x10\x02\x12\x1f\n" +
-	"\x1bLPC_EVENT_HEARTBEAT_TIMEOUT\x10\x032\xff\x04\n" +
+	"\x1bLPC_EVENT_HEARTBEAT_TIMEOUT\x10\x032\xb4\x04\n" +
 	"\n" +
 	"LPCService\x12C\n" +
 	"\x13GetConsumptionLimit\x12\x17.eebus.v1.DeviceRequest\x1a\x13.eebus.v1.LoadLimit\x12I\n" +
@@ -493,8 +446,7 @@ const file_eebus_v1_lpc_service_proto_rawDesc = "" +
 	"\x12WriteFailsafeLimit\x12#.eebus.v1.WriteFailsafeLimitRequest\x1a\x0f.eebus.v1.Empty\x12:\n" +
 	"\x0eStartHeartbeat\x12\x17.eebus.v1.DeviceRequest\x1a\x0f.eebus.v1.Empty\x129\n" +
 	"\rStopHeartbeat\x12\x17.eebus.v1.DeviceRequest\x1a\x0f.eebus.v1.Empty\x12H\n" +
-	"\x12GetHeartbeatStatus\x12\x17.eebus.v1.DeviceRequest\x1a\x19.eebus.v1.HeartbeatStatus\x12I\n" +
-	"\x18GetConsumptionNominalMax\x12\x17.eebus.v1.DeviceRequest\x1a\x14.eebus.v1.PowerValue\x12C\n" +
+	"\x12GetHeartbeatStatus\x12\x17.eebus.v1.DeviceRequest\x1a\x19.eebus.v1.HeartbeatStatus\x12C\n" +
 	"\x12SubscribeLPCEvents\x12\x17.eebus.v1.DeviceRequest\x1a\x12.eebus.v1.LPCEvent0\x01B=Z;github.com/volschin/eebus-bridge/gen/proto/eebus/v1;eebusv1b\x06proto3"
 
 var (
@@ -510,43 +462,40 @@ func file_eebus_v1_lpc_service_proto_rawDescGZIP() []byte {
 }
 
 var file_eebus_v1_lpc_service_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_eebus_v1_lpc_service_proto_msgTypes = make([]protoimpl.MessageInfo, 6)
+var file_eebus_v1_lpc_service_proto_msgTypes = make([]protoimpl.MessageInfo, 5)
 var file_eebus_v1_lpc_service_proto_goTypes = []any{
 	(LPCEventType)(0),                 // 0: eebus.v1.LPCEventType
 	(*WriteLoadLimitRequest)(nil),     // 1: eebus.v1.WriteLoadLimitRequest
 	(*FailsafeLimit)(nil),             // 2: eebus.v1.FailsafeLimit
 	(*WriteFailsafeLimitRequest)(nil), // 3: eebus.v1.WriteFailsafeLimitRequest
 	(*HeartbeatStatus)(nil),           // 4: eebus.v1.HeartbeatStatus
-	(*PowerValue)(nil),                // 5: eebus.v1.PowerValue
-	(*LPCEvent)(nil),                  // 6: eebus.v1.LPCEvent
-	(*LoadLimit)(nil),                 // 7: eebus.v1.LoadLimit
-	(*DeviceRequest)(nil),             // 8: eebus.v1.DeviceRequest
-	(*Empty)(nil),                     // 9: eebus.v1.Empty
+	(*LPCEvent)(nil),                  // 5: eebus.v1.LPCEvent
+	(*LoadLimit)(nil),                 // 6: eebus.v1.LoadLimit
+	(*DeviceRequest)(nil),             // 7: eebus.v1.DeviceRequest
+	(*Empty)(nil),                     // 8: eebus.v1.Empty
 }
 var file_eebus_v1_lpc_service_proto_depIdxs = []int32{
 	0,  // 0: eebus.v1.LPCEvent.event_type:type_name -> eebus.v1.LPCEventType
-	7,  // 1: eebus.v1.LPCEvent.limit_update:type_name -> eebus.v1.LoadLimit
+	6,  // 1: eebus.v1.LPCEvent.limit_update:type_name -> eebus.v1.LoadLimit
 	2,  // 2: eebus.v1.LPCEvent.failsafe_update:type_name -> eebus.v1.FailsafeLimit
-	8,  // 3: eebus.v1.LPCService.GetConsumptionLimit:input_type -> eebus.v1.DeviceRequest
+	7,  // 3: eebus.v1.LPCService.GetConsumptionLimit:input_type -> eebus.v1.DeviceRequest
 	1,  // 4: eebus.v1.LPCService.WriteConsumptionLimit:input_type -> eebus.v1.WriteLoadLimitRequest
-	8,  // 5: eebus.v1.LPCService.GetFailsafeLimit:input_type -> eebus.v1.DeviceRequest
+	7,  // 5: eebus.v1.LPCService.GetFailsafeLimit:input_type -> eebus.v1.DeviceRequest
 	3,  // 6: eebus.v1.LPCService.WriteFailsafeLimit:input_type -> eebus.v1.WriteFailsafeLimitRequest
-	8,  // 7: eebus.v1.LPCService.StartHeartbeat:input_type -> eebus.v1.DeviceRequest
-	8,  // 8: eebus.v1.LPCService.StopHeartbeat:input_type -> eebus.v1.DeviceRequest
-	8,  // 9: eebus.v1.LPCService.GetHeartbeatStatus:input_type -> eebus.v1.DeviceRequest
-	8,  // 10: eebus.v1.LPCService.GetConsumptionNominalMax:input_type -> eebus.v1.DeviceRequest
-	8,  // 11: eebus.v1.LPCService.SubscribeLPCEvents:input_type -> eebus.v1.DeviceRequest
-	7,  // 12: eebus.v1.LPCService.GetConsumptionLimit:output_type -> eebus.v1.LoadLimit
-	9,  // 13: eebus.v1.LPCService.WriteConsumptionLimit:output_type -> eebus.v1.Empty
-	2,  // 14: eebus.v1.LPCService.GetFailsafeLimit:output_type -> eebus.v1.FailsafeLimit
-	9,  // 15: eebus.v1.LPCService.WriteFailsafeLimit:output_type -> eebus.v1.Empty
-	9,  // 16: eebus.v1.LPCService.StartHeartbeat:output_type -> eebus.v1.Empty
-	9,  // 17: eebus.v1.LPCService.StopHeartbeat:output_type -> eebus.v1.Empty
-	4,  // 18: eebus.v1.LPCService.GetHeartbeatStatus:output_type -> eebus.v1.HeartbeatStatus
-	5,  // 19: eebus.v1.LPCService.GetConsumptionNominalMax:output_type -> eebus.v1.PowerValue
-	6,  // 20: eebus.v1.LPCService.SubscribeLPCEvents:output_type -> eebus.v1.LPCEvent
-	12, // [12:21] is the sub-list for method output_type
-	3,  // [3:12] is the sub-list for method input_type
+	7,  // 7: eebus.v1.LPCService.StartHeartbeat:input_type -> eebus.v1.DeviceRequest
+	7,  // 8: eebus.v1.LPCService.StopHeartbeat:input_type -> eebus.v1.DeviceRequest
+	7,  // 9: eebus.v1.LPCService.GetHeartbeatStatus:input_type -> eebus.v1.DeviceRequest
+	7,  // 10: eebus.v1.LPCService.SubscribeLPCEvents:input_type -> eebus.v1.DeviceRequest
+	6,  // 11: eebus.v1.LPCService.GetConsumptionLimit:output_type -> eebus.v1.LoadLimit
+	8,  // 12: eebus.v1.LPCService.WriteConsumptionLimit:output_type -> eebus.v1.Empty
+	2,  // 13: eebus.v1.LPCService.GetFailsafeLimit:output_type -> eebus.v1.FailsafeLimit
+	8,  // 14: eebus.v1.LPCService.WriteFailsafeLimit:output_type -> eebus.v1.Empty
+	8,  // 15: eebus.v1.LPCService.StartHeartbeat:output_type -> eebus.v1.Empty
+	8,  // 16: eebus.v1.LPCService.StopHeartbeat:output_type -> eebus.v1.Empty
+	4,  // 17: eebus.v1.LPCService.GetHeartbeatStatus:output_type -> eebus.v1.HeartbeatStatus
+	5,  // 18: eebus.v1.LPCService.SubscribeLPCEvents:output_type -> eebus.v1.LPCEvent
+	11, // [11:19] is the sub-list for method output_type
+	3,  // [3:11] is the sub-list for method input_type
 	3,  // [3:3] is the sub-list for extension type_name
 	3,  // [3:3] is the sub-list for extension extendee
 	0,  // [0:3] is the sub-list for field type_name
@@ -558,7 +507,7 @@ func file_eebus_v1_lpc_service_proto_init() {
 		return
 	}
 	file_eebus_v1_common_proto_init()
-	file_eebus_v1_lpc_service_proto_msgTypes[5].OneofWrappers = []any{
+	file_eebus_v1_lpc_service_proto_msgTypes[4].OneofWrappers = []any{
 		(*LPCEvent_LimitUpdate)(nil),
 		(*LPCEvent_FailsafeUpdate)(nil),
 	}
@@ -568,7 +517,7 @@ func file_eebus_v1_lpc_service_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_eebus_v1_lpc_service_proto_rawDesc), len(file_eebus_v1_lpc_service_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   6,
+			NumMessages:   5,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/eebus-bridge/gen/proto/eebus/v1/lpc_service_grpc.pb.go
+++ b/eebus-bridge/gen/proto/eebus/v1/lpc_service_grpc.pb.go
@@ -19,15 +19,14 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	LPCService_GetConsumptionLimit_FullMethodName      = "/eebus.v1.LPCService/GetConsumptionLimit"
-	LPCService_WriteConsumptionLimit_FullMethodName    = "/eebus.v1.LPCService/WriteConsumptionLimit"
-	LPCService_GetFailsafeLimit_FullMethodName         = "/eebus.v1.LPCService/GetFailsafeLimit"
-	LPCService_WriteFailsafeLimit_FullMethodName       = "/eebus.v1.LPCService/WriteFailsafeLimit"
-	LPCService_StartHeartbeat_FullMethodName           = "/eebus.v1.LPCService/StartHeartbeat"
-	LPCService_StopHeartbeat_FullMethodName            = "/eebus.v1.LPCService/StopHeartbeat"
-	LPCService_GetHeartbeatStatus_FullMethodName       = "/eebus.v1.LPCService/GetHeartbeatStatus"
-	LPCService_GetConsumptionNominalMax_FullMethodName = "/eebus.v1.LPCService/GetConsumptionNominalMax"
-	LPCService_SubscribeLPCEvents_FullMethodName       = "/eebus.v1.LPCService/SubscribeLPCEvents"
+	LPCService_GetConsumptionLimit_FullMethodName   = "/eebus.v1.LPCService/GetConsumptionLimit"
+	LPCService_WriteConsumptionLimit_FullMethodName = "/eebus.v1.LPCService/WriteConsumptionLimit"
+	LPCService_GetFailsafeLimit_FullMethodName      = "/eebus.v1.LPCService/GetFailsafeLimit"
+	LPCService_WriteFailsafeLimit_FullMethodName    = "/eebus.v1.LPCService/WriteFailsafeLimit"
+	LPCService_StartHeartbeat_FullMethodName        = "/eebus.v1.LPCService/StartHeartbeat"
+	LPCService_StopHeartbeat_FullMethodName         = "/eebus.v1.LPCService/StopHeartbeat"
+	LPCService_GetHeartbeatStatus_FullMethodName    = "/eebus.v1.LPCService/GetHeartbeatStatus"
+	LPCService_SubscribeLPCEvents_FullMethodName    = "/eebus.v1.LPCService/SubscribeLPCEvents"
 )
 
 // LPCServiceClient is the client API for LPCService service.
@@ -41,7 +40,6 @@ type LPCServiceClient interface {
 	StartHeartbeat(ctx context.Context, in *DeviceRequest, opts ...grpc.CallOption) (*Empty, error)
 	StopHeartbeat(ctx context.Context, in *DeviceRequest, opts ...grpc.CallOption) (*Empty, error)
 	GetHeartbeatStatus(ctx context.Context, in *DeviceRequest, opts ...grpc.CallOption) (*HeartbeatStatus, error)
-	GetConsumptionNominalMax(ctx context.Context, in *DeviceRequest, opts ...grpc.CallOption) (*PowerValue, error)
 	SubscribeLPCEvents(ctx context.Context, in *DeviceRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[LPCEvent], error)
 }
 
@@ -123,16 +121,6 @@ func (c *lPCServiceClient) GetHeartbeatStatus(ctx context.Context, in *DeviceReq
 	return out, nil
 }
 
-func (c *lPCServiceClient) GetConsumptionNominalMax(ctx context.Context, in *DeviceRequest, opts ...grpc.CallOption) (*PowerValue, error) {
-	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	out := new(PowerValue)
-	err := c.cc.Invoke(ctx, LPCService_GetConsumptionNominalMax_FullMethodName, in, out, cOpts...)
-	if err != nil {
-		return nil, err
-	}
-	return out, nil
-}
-
 func (c *lPCServiceClient) SubscribeLPCEvents(ctx context.Context, in *DeviceRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[LPCEvent], error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	stream, err := c.cc.NewStream(ctx, &LPCService_ServiceDesc.Streams[0], LPCService_SubscribeLPCEvents_FullMethodName, cOpts...)
@@ -163,7 +151,6 @@ type LPCServiceServer interface {
 	StartHeartbeat(context.Context, *DeviceRequest) (*Empty, error)
 	StopHeartbeat(context.Context, *DeviceRequest) (*Empty, error)
 	GetHeartbeatStatus(context.Context, *DeviceRequest) (*HeartbeatStatus, error)
-	GetConsumptionNominalMax(context.Context, *DeviceRequest) (*PowerValue, error)
 	SubscribeLPCEvents(*DeviceRequest, grpc.ServerStreamingServer[LPCEvent]) error
 	mustEmbedUnimplementedLPCServiceServer()
 }
@@ -195,9 +182,6 @@ func (UnimplementedLPCServiceServer) StopHeartbeat(context.Context, *DeviceReque
 }
 func (UnimplementedLPCServiceServer) GetHeartbeatStatus(context.Context, *DeviceRequest) (*HeartbeatStatus, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetHeartbeatStatus not implemented")
-}
-func (UnimplementedLPCServiceServer) GetConsumptionNominalMax(context.Context, *DeviceRequest) (*PowerValue, error) {
-	return nil, status.Error(codes.Unimplemented, "method GetConsumptionNominalMax not implemented")
 }
 func (UnimplementedLPCServiceServer) SubscribeLPCEvents(*DeviceRequest, grpc.ServerStreamingServer[LPCEvent]) error {
 	return status.Error(codes.Unimplemented, "method SubscribeLPCEvents not implemented")
@@ -349,24 +333,6 @@ func _LPCService_GetHeartbeatStatus_Handler(srv interface{}, ctx context.Context
 	return interceptor(ctx, in, info, handler)
 }
 
-func _LPCService_GetConsumptionNominalMax_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(DeviceRequest)
-	if err := dec(in); err != nil {
-		return nil, err
-	}
-	if interceptor == nil {
-		return srv.(LPCServiceServer).GetConsumptionNominalMax(ctx, in)
-	}
-	info := &grpc.UnaryServerInfo{
-		Server:     srv,
-		FullMethod: LPCService_GetConsumptionNominalMax_FullMethodName,
-	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(LPCServiceServer).GetConsumptionNominalMax(ctx, req.(*DeviceRequest))
-	}
-	return interceptor(ctx, in, info, handler)
-}
-
 func _LPCService_SubscribeLPCEvents_Handler(srv interface{}, stream grpc.ServerStream) error {
 	m := new(DeviceRequest)
 	if err := stream.RecvMsg(m); err != nil {
@@ -412,10 +378,6 @@ var LPCService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "GetHeartbeatStatus",
 			Handler:    _LPCService_GetHeartbeatStatus_Handler,
-		},
-		{
-			MethodName: "GetConsumptionNominalMax",
-			Handler:    _LPCService_GetConsumptionNominalMax_Handler,
 		},
 	},
 	Streams: []grpc.StreamDesc{

--- a/eebus-bridge/internal/eebus/callbacks.go
+++ b/eebus-bridge/internal/eebus/callbacks.go
@@ -13,16 +13,14 @@ type Callbacks struct {
 	bus            *EventBus
 	mu             sync.RWMutex
 	discoveredSvcs []shipapi.RemoteService
-	pairingStates  map[string]*shipapi.ConnectionStateDetail
 	debugEvents    bool
 }
 
 // NewCallbacks creates a new Callbacks instance backed by the given EventBus.
 func NewCallbacks(bus *EventBus, debugEvents bool) *Callbacks {
 	return &Callbacks{
-		bus:           bus,
-		pairingStates: make(map[string]*shipapi.ConnectionStateDetail),
-		debugEvents:   debugEvents,
+		bus:         bus,
+		debugEvents: debugEvents,
 	}
 }
 
@@ -86,10 +84,6 @@ func (c *Callbacks) ServicePairingDetailUpdate(ski string, detail *shipapi.Conne
 		}
 	}
 
-	c.mu.Lock()
-	c.pairingStates[ski] = detail
-	c.mu.Unlock()
-
 	c.bus.Publish(Event{
 		SKI:  ski,
 		Type: "pairing.updated",
@@ -110,12 +104,4 @@ func (c *Callbacks) DiscoveredServices() []shipapi.RemoteService {
 	result := make([]shipapi.RemoteService, len(c.discoveredSvcs))
 	copy(result, c.discoveredSvcs)
 	return result
-}
-
-// PairingState returns the current pairing state for the given SKI, or nil if unknown.
-func (c *Callbacks) PairingState(ski string) *shipapi.ConnectionStateDetail {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-	ski = NormalizeSKI(ski)
-	return c.pairingStates[ski]
 }

--- a/eebus-bridge/internal/eebus/service.go
+++ b/eebus-bridge/internal/eebus/service.go
@@ -80,8 +80,3 @@ func (b *BridgeService) Callbacks() *Callbacks {
 func (b *BridgeService) RegisterRemoteSKI(ski string) {
 	b.service.RegisterRemoteSKI(ski)
 }
-
-// UnregisterRemoteSKI removes trust for a SKI and disconnects if connected.
-func (b *BridgeService) UnregisterRemoteSKI(ski string) {
-	b.service.UnregisterRemoteSKI(ski)
-}

--- a/eebus-bridge/internal/grpc/device_service.go
+++ b/eebus-bridge/internal/grpc/device_service.go
@@ -3,7 +3,6 @@ package grpc
 import (
 	"context"
 
-	shipapi "github.com/enbility/ship-go/api"
 	pb "github.com/volschin/eebus-bridge/gen/proto/eebus/v1"
 	"github.com/volschin/eebus-bridge/internal/eebus"
 )
@@ -46,38 +45,6 @@ func (s *DeviceService) ListDiscoveredDevices(_ context.Context, _ *pb.Empty) (*
 func (s *DeviceService) RegisterRemoteSKI(_ context.Context, req *pb.RegisterSKIRequest) (*pb.Empty, error) {
 	s.bus.Publish(eebus.Event{SKI: req.Ski, Type: "device.register_ski"})
 	return &pb.Empty{}, nil
-}
-
-func (s *DeviceService) UnregisterRemoteSKI(_ context.Context, req *pb.DeviceRequest) (*pb.Empty, error) {
-	s.bus.Publish(eebus.Event{SKI: req.Ski, Type: "device.unregister_ski"})
-	return &pb.Empty{}, nil
-}
-
-func (s *DeviceService) GetPairingStatus(_ context.Context, req *pb.DeviceRequest) (*pb.PairingStatus, error) {
-	state := s.callbacks.PairingState(req.Ski)
-	ps := &pb.PairingStatus{Ski: req.Ski, State: pb.PairingState_PAIRING_STATE_UNSPECIFIED}
-	if state != nil {
-		ps.State = mapConnectionState(state.State())
-	}
-	return ps, nil
-}
-
-func mapConnectionState(cs shipapi.ConnectionState) pb.PairingState {
-	switch cs {
-	case shipapi.ConnectionStateQueued,
-		shipapi.ConnectionStateInitiated,
-		shipapi.ConnectionStateReceivedPairingRequest,
-		shipapi.ConnectionStateInProgress:
-		return pb.PairingState_PAIRING_STATE_PENDING
-	case shipapi.ConnectionStateTrusted,
-		shipapi.ConnectionStateCompleted:
-		return pb.PairingState_PAIRING_STATE_TRUSTED
-	case shipapi.ConnectionStateRemoteDeniedTrust,
-		shipapi.ConnectionStateError:
-		return pb.PairingState_PAIRING_STATE_DENIED
-	default:
-		return pb.PairingState_PAIRING_STATE_UNSPECIFIED
-	}
 }
 
 func (s *DeviceService) ListPairedDevices(_ context.Context, _ *pb.Empty) (*pb.ListPairedDevicesResponse, error) {

--- a/eebus-bridge/internal/grpc/lpc_service.go
+++ b/eebus-bridge/internal/grpc/lpc_service.go
@@ -175,24 +175,6 @@ func (s *LPCService) GetHeartbeatStatus(_ context.Context, req *pb.DeviceRequest
 	}, nil
 }
 
-func (s *LPCService) GetConsumptionNominalMax(_ context.Context, req *pb.DeviceRequest) (*pb.PowerValue, error) {
-	if req == nil {
-		return nil, status.Error(codes.InvalidArgument, "request is required")
-	}
-	if s.lpc == nil {
-		return nil, status.Error(codes.Unavailable, "LPC use case not initialized")
-	}
-	entity, err := s.resolveEntity(req.Ski)
-	if err != nil {
-		return nil, err
-	}
-	value, err := s.lpc.ConsumptionNominalMax(entity)
-	if err != nil {
-		return nil, status.Errorf(codes.Internal, "reading nominal max consumption: %v", err)
-	}
-	return &pb.PowerValue{Watts: value}, nil
-}
-
 func (s *LPCService) SubscribeLPCEvents(req *pb.DeviceRequest, stream pb.LPCService_SubscribeLPCEventsServer) error {
 	ch := s.bus.Subscribe()
 	defer s.bus.Unsubscribe(ch)

--- a/eebus-bridge/internal/usecases/lpc.go
+++ b/eebus-bridge/internal/usecases/lpc.go
@@ -168,15 +168,6 @@ func (w *LPCWrapper) WriteFailsafeDurationMinimum(entity spineapi.EntityRemoteIn
 	return err
 }
 
-// ConsumptionNominalMax returns the nominal maximum active power the controllable system
-// can consume.
-func (w *LPCWrapper) ConsumptionNominalMax(entity spineapi.EntityRemoteInterface) (float64, error) {
-	if w.uc == nil {
-		return 0, errLPCNotInitialized
-	}
-	return w.uc.ConsumptionNominalMax(entity)
-}
-
 // StartHeartbeat starts the local entity's periodic DeviceDiagnosis heartbeat.
 // Controllable systems (e.g. heat pumps) drop an LPC limit to its failsafe value
 // when heartbeats stop arriving, so the bridge must keep the heartbeat running.

--- a/eebus-bridge/proto/eebus/v1/device_service.proto
+++ b/eebus-bridge/proto/eebus/v1/device_service.proto
@@ -10,8 +10,6 @@ service DeviceService {
   rpc GetStatus(Empty) returns (ServiceStatus);
   rpc ListDiscoveredDevices(Empty) returns (ListDevicesResponse);
   rpc RegisterRemoteSKI(RegisterSKIRequest) returns (Empty);
-  rpc UnregisterRemoteSKI(DeviceRequest) returns (Empty);
-  rpc GetPairingStatus(DeviceRequest) returns (PairingStatus);
   rpc ListPairedDevices(Empty) returns (ListPairedDevicesResponse);
   rpc SubscribeDeviceEvents(Empty) returns (stream DeviceEvent);
 }
@@ -36,19 +34,6 @@ message ListDevicesResponse {
 
 message RegisterSKIRequest {
   string ski = 1;
-}
-
-message PairingStatus {
-  string ski = 1;
-  PairingState state = 2;
-}
-
-enum PairingState {
-  PAIRING_STATE_UNSPECIFIED = 0;
-  PAIRING_STATE_PENDING = 1;
-  PAIRING_STATE_WAITING_FOR_TRUST = 2;
-  PAIRING_STATE_TRUSTED = 3;
-  PAIRING_STATE_DENIED = 4;
 }
 
 message PairedDevice {

--- a/eebus-bridge/proto/eebus/v1/lpc_service.proto
+++ b/eebus-bridge/proto/eebus/v1/lpc_service.proto
@@ -14,7 +14,6 @@ service LPCService {
   rpc StartHeartbeat(DeviceRequest) returns (Empty);
   rpc StopHeartbeat(DeviceRequest) returns (Empty);
   rpc GetHeartbeatStatus(DeviceRequest) returns (HeartbeatStatus);
-  rpc GetConsumptionNominalMax(DeviceRequest) returns (PowerValue);
   rpc SubscribeLPCEvents(DeviceRequest) returns (stream LPCEvent);
 }
 
@@ -39,10 +38,6 @@ message WriteFailsafeLimitRequest {
 message HeartbeatStatus {
   bool running = 1;
   bool within_duration = 2;
-}
-
-message PowerValue {
-  double watts = 1;
 }
 
 message LPCEvent {


### PR DESCRIPTION
## Summary
The HA integration is the only gRPC client and never calls these RPCs — dead server surface end-to-end. Found during a YAGNI review (section A).

Removed:
- **`GetConsumptionNominalMax`** — + `PowerValue` message + `LPCWrapper.ConsumptionNominalMax`
- **`GetPairingStatus`** — + `PairingStatus` message + `PairingState` enum + `mapConnectionState` + `Callbacks.PairingState` getter + write-only `pairingStates` map
- **`UnregisterRemoteSKI`** — + `main` bus handler + `BridgeService.UnregisterRemoteSKI`

`ServicePairingDetailUpdate` callback stays (`ServiceReaderInterface` requirement) and still publishes `pairing.updated`; it no longer stores state.

## Process
- Edited both `.proto` files; regenerated Go (`buf generate`) and Python (`generate_proto.sh`) stubs with the committed generator versions (protoc-gen-go v1.36.11, protoc-gen-go-grpc v1.6.1, grpcio-tools 1.78.0) — no generator-version churn.

## Verification
- `go vet`, `go test -race ./...`, integration tests, `go build` — all pass
- 27 pytest pass, ruff clean
- Stub regen deterministic → `proto-drift` CI clean
- Net diff: 105+/660−