### PR TITLE
feat(docker): add gRPC healthcheck to bridge image

### DIFF
--- a/eebus-bridge/Dockerfile
+++ b/eebus-bridge/Dockerfile
@@ -24,6 +24,9 @@ COPY --from=builder /eebus-bridge /usr/local/bin/eebus-bridge
 VOLUME /data
 EXPOSE 50051 4712
 
+HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
+  CMD ["eebus-bridge", "-healthcheck", "--config", "/etc/eebus-bridge/config.yaml"]
+
 USER eebus
 ENTRYPOINT ["eebus-bridge"]
 CMD ["--config", "/etc/eebus-bridge/config.yaml"]

--- a/eebus-bridge/cmd/eebus-bridge/healthcheck.go
+++ b/eebus-bridge/cmd/eebus-bridge/healthcheck.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/volschin/eebus-bridge/internal/config"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/health/grpc_health_v1"
+)
+
+// runHealthcheck dials the bridge's gRPC health service and reports SERVING.
+// It is invoked via `eebus-bridge -healthcheck` from the Docker HEALTHCHECK so
+// the probe reuses the single binary instead of shipping grpc_health_probe.
+func runHealthcheck(configPath string) error {
+	cfg, err := config.LoadFromFile(configPath)
+	if err != nil {
+		return fmt.Errorf("loading config: %w", err)
+	}
+
+	addr := fmt.Sprintf("%s:%d", cfg.GRPC.Bind, cfg.GRPC.Port)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	conn, err := grpc.NewClient(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		return fmt.Errorf("dial %s: %w", addr, err)
+	}
+	defer conn.Close()
+
+	resp, err := grpc_health_v1.NewHealthClient(conn).Check(ctx, &grpc_health_v1.HealthCheckRequest{})
+	if err != nil {
+		return fmt.Errorf("health check %s: %w", addr, err)
+	}
+	if resp.GetStatus() != grpc_health_v1.HealthCheckResponse_SERVING {
+		return fmt.Errorf("status %s", resp.GetStatus())
+	}
+	return nil
+}

--- a/eebus-bridge/cmd/eebus-bridge/main.go
+++ b/eebus-bridge/cmd/eebus-bridge/main.go
@@ -17,7 +17,15 @@ import (
 
 func main() {
 	configPath := flag.String("config", "config.yaml", "path to config file")
+	healthcheck := flag.Bool("healthcheck", false, "probe the gRPC health service and exit")
 	flag.Parse()
+
+	if *healthcheck {
+		if err := runHealthcheck(*configPath); err != nil {
+			log.Fatalf("healthcheck: %v", err)
+		}
+		return
+	}
 
 	cfg, err := config.LoadFromFile(*configPath)
 	if err != nil {


### PR DESCRIPTION
## What

Adds a Docker `HEALTHCHECK` to the eebus-bridge image.

## How

- New `-healthcheck` flag on the bridge binary: loads config, dials the gRPC health service on `grpc.bind:grpc.port` (plaintext loopback — server has no TLS), checks `SERVING`, exits 0/1.
- `Dockerfile` `HEALTHCHECK` (interval 30s, timeout 5s, start-period 20s, retries 3) invokes the same binary.

## Why same-binary probe

Single static binary on alpine; the standard gRPC health service is already registered in `server.go`. No `grpc_health_probe` download or extra dependency needed.

## Notes

- Compose inherits the image `HEALTHCHECK` automatically; `network_mode: host` + bind `127.0.0.1` means the probe dials loopback in the same namespace.
- Probe reads the config file for bind/port (already mounted in compose).

## Test

`go build ./...` and `go vet ./cmd/...` pass.