### PR TITLE
ci(release-drafter): migrate deprecated label fields

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -3,25 +3,27 @@ tag-template: "v$RESOLVED_VERSION"
 
 categories:
   - title: "New Features"
-    labels: ["feature", "enhancement"]
+    semver-increment: minor
+    when:
+      labels: ["feature", "enhancement"]
   - title: "Bug Fixes"
-    labels: ["fix", "bugfix", "bug"]
+    when:
+      labels: ["fix", "bugfix", "bug"]
   - title: "Documentation"
-    labels: ["documentation", "docs"]
+    when:
+      labels: ["documentation", "docs"]
   - title: "Maintenance"
-    labels: ["chore", "maintenance", "ci"]
+    when:
+      labels: ["chore", "maintenance", "ci"]
+  - type: "version-resolver"
+    semver-increment: "major"
+    when:
+      labels: ["major"]
+  - type: "version-resolver"
+    semver-increment: "patch"
 
 change-template: "- $TITLE @$AUTHOR (#$NUMBER)"
 change-title-escapes: '\<*_&'
-
-version-resolver:
-  major:
-    labels: ["major"]
-  minor:
-    labels: ["feature", "enhancement"]
-  patch:
-    labels: ["fix", "bugfix", "bug", "documentation", "chore"]
-  default: patch
 
 template: |
   ## Changes


### PR DESCRIPTION
## What

Silences the release-drafter deprecation warnings seen in the v0.5.0 release run.

## Changes

- `categories[*].labels` → `categories[*].when.labels`
- `version-resolver.{major,minor,patch}.labels` → `semver-increment` on the New Features category (minor) + `type: version-resolver` entries for major and the patch default

Behavior preserved: feature/enhancement ⇒ minor, `major` label ⇒ major, everything else ⇒ patch.

Per release-drafter [#1558](https://github.com/release-drafter/release-drafter/pull/1558).

## Test

YAML parses clean.