### PR TITLE
feat(bridge): ship-go log forwarding for handshake diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,38 @@ automation:
 1. SKI in der Bridge-Log pruefen (wird beim Start ausgegeben)
 2. In der myVaillant-App unter Netzwerk > EEBUS den Bridge-SKI bestaetigen
 3. Sicherstellen, dass beide Geraete im selben Netzwerk sind
+4. Vaillant-Gateways erlauben nur **eine** EEBUS-Verbindung -- pruefen, dass kein
+   anderer Energiemanager (z. B. sensoNET-Cloud) den Slot belegt
+5. Bleibt die Verbindung in einer Reconnect-Schleife (Status erreicht nie
+   `Trusted`), das SHIP-Logging aktivieren (siehe unten), um den Abbruchgrund
+   zu sehen
+
+</details>
+
+<details>
+<summary>SHIP-Handshake debuggen</summary>
+
+Die internen ship-go/eebus-go-Logs sind standardmaessig stumm. Zum Anzeigen der
+SHIP-Handshake-Fehler und Abbruchgruende:
+
+```yaml
+logging:
+  ship_log: true     # Debug/Info/Error -- enthaelt den Abbruchgrund
+  # ship_trace: true # rohe Nachrichten pro Paket, sehr ausfuehrlich
+```
+
+Oder per Umgebungsvariable (z. B. in `docker-compose.yml`):
+
+```
+EEBUS_SHIP_LOG=true
+```
+
+Anschliessend im Bridge-Log nach `[SHIP DEBUG]`/`[SHIP ERROR]` suchen, z. B.:
+
+- `SHIP handshake error: ... handshake timeout` -- Geraet antwortet nicht /
+  Pairing geraeteseitig nicht bestaetigt
+- `Node rejected by application` -- Geraet hat den Bridge-SKI aktiv abgelehnt
+- TLS/Zertifikatsfehler -- SKI stimmt nicht ueberein
 
 </details>
 

--- a/eebus-bridge/internal/config/config.go
+++ b/eebus-bridge/internal/config/config.go
@@ -38,6 +38,11 @@ type CertificatesConfig struct {
 
 type LoggingConfig struct {
 	DebugEvents bool `yaml:"debug_events"`
+	// ShipLog forwards ship-go/eebus-go internal Debug/Info/Error logs (SHIP
+	// handshake errors and abort reasons) to the bridge logger.
+	ShipLog bool `yaml:"ship_log"`
+	// ShipTrace additionally enables raw per-message Trace logs (very verbose).
+	ShipTrace bool `yaml:"ship_trace"`
 }
 
 func LoadFromFile(path string) (*Config, error) {
@@ -127,6 +132,16 @@ func applyEnvOverrides(cfg *Config) {
 	if v := os.Getenv("EEBUS_DEBUG_EVENTS"); v != "" {
 		if enabled, err := strconv.ParseBool(v); err == nil {
 			cfg.Logging.DebugEvents = enabled
+		}
+	}
+	if v := os.Getenv("EEBUS_SHIP_LOG"); v != "" {
+		if enabled, err := strconv.ParseBool(v); err == nil {
+			cfg.Logging.ShipLog = enabled
+		}
+	}
+	if v := os.Getenv("EEBUS_SHIP_TRACE"); v != "" {
+		if enabled, err := strconv.ParseBool(v); err == nil {
+			cfg.Logging.ShipTrace = enabled
 		}
 	}
 }

--- a/eebus-bridge/internal/eebus/logging.go
+++ b/eebus-bridge/internal/eebus/logging.go
@@ -1,0 +1,47 @@
+package eebus
+
+import "log"
+
+// shipLogger adapts the ship-go/eebus-go logging.LoggingInterface to the
+// bridge's stdlib logger. Trace output (raw per-message JSON) is gated behind
+// a separate flag because it is extremely verbose; Debug carries the useful
+// SHIP handshake error/abort reasons.
+type shipLogger struct {
+	trace bool
+}
+
+func (l *shipLogger) Trace(args ...interface{}) {
+	if l.trace {
+		log.Print(append([]interface{}{"[SHIP TRACE] "}, args...)...)
+	}
+}
+
+func (l *shipLogger) Tracef(format string, args ...interface{}) {
+	if l.trace {
+		log.Printf("[SHIP TRACE] "+format, args...)
+	}
+}
+
+func (l *shipLogger) Debug(args ...interface{}) {
+	log.Print(append([]interface{}{"[SHIP DEBUG] "}, args...)...)
+}
+
+func (l *shipLogger) Debugf(format string, args ...interface{}) {
+	log.Printf("[SHIP DEBUG] "+format, args...)
+}
+
+func (l *shipLogger) Info(args ...interface{}) {
+	log.Print(append([]interface{}{"[SHIP INFO] "}, args...)...)
+}
+
+func (l *shipLogger) Infof(format string, args ...interface{}) {
+	log.Printf("[SHIP INFO] "+format, args...)
+}
+
+func (l *shipLogger) Error(args ...interface{}) {
+	log.Print(append([]interface{}{"[SHIP ERROR] "}, args...)...)
+}
+
+func (l *shipLogger) Errorf(format string, args ...interface{}) {
+	log.Printf("[SHIP ERROR] "+format, args...)
+}

--- a/eebus-bridge/internal/eebus/service.go
+++ b/eebus-bridge/internal/eebus/service.go
@@ -39,6 +39,12 @@ func NewBridgeService(cfg *config.Config, cert tls.Certificate, bus *EventBus) (
 	callbacks := NewCallbacks(bus, cfg.Logging.DebugEvents)
 	svc := eebusservice.NewService(eebusConfig, callbacks)
 
+	// Forward ship-go/eebus-go internal logs (SHIP handshake errors, abort
+	// reasons) to the bridge logger when enabled. Default is silent.
+	if cfg.Logging.ShipLog || cfg.Logging.ShipTrace {
+		svc.SetLogging(&shipLogger{trace: cfg.Logging.ShipTrace})
+	}
+
 	return &BridgeService{
 		service:   svc,
 		callbacks: callbacks,


### PR DESCRIPTION
## Why

A paired device was stuck in a reconnect loop: pairing state cycled
`Initiated(2) → InProgress(4) → ReceivedPairingRequest(3) → None(0)` then
disconnected, never reaching `Trusted(5)`/`Completed(7)`. The actual SHIP
handshake abort reason was invisible — ship-go/eebus-go internal logs default
to `NoLogging`.

## What

- New `shipLogger` adapter (`internal/eebus/logging.go`) forwarding
  `logging.LoggingInterface` to the stdlib logger, wired via
  `Service.SetLogging` when enabled.
- Config knobs (`internal/config/config.go`):
  - `ship_log` / `EEBUS_SHIP_LOG` — Debug/Info/Error (carries the handshake
    abort reason, logged at Debug in ship-go `handshake.go:217`)
  - `ship_trace` / `EEBUS_SHIP_TRACE` — raw per-message Trace (very verbose)
- README troubleshooting: how to enable SHIP logging + decode common abort
  reasons; note Vaillant's single EEBUS-slot limit.

Default stays silent.

## Test

- `go build ./...` + `go vet` pass.
- No behavior change unless a knob is set.