### PR TITLE
fix(ci): healthcheck errcheck + Go build cache restore

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,7 @@ jobs:
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: "1.26"
+          cache-dependency-path: eebus-bridge/go.sum
       - run: go vet ./...
       - name: golangci-lint
         uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1 # renovate: datasource=github-releases depName=golangci/golangci-lint-action

--- a/eebus-bridge/cmd/eebus-bridge/healthcheck.go
+++ b/eebus-bridge/cmd/eebus-bridge/healthcheck.go
@@ -29,7 +29,7 @@ func runHealthcheck(configPath string) error {
 	if err != nil {
 		return fmt.Errorf("dial %s: %w", addr, err)
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 
 	resp, err := grpc_health_v1.NewHealthClient(conn).Check(ctx, &grpc_health_v1.HealthCheckRequest{})
 	if err != nil {


### PR DESCRIPTION
PR #57 squash-merged before two follow-up fixes landed, leaving main with red CI and no Go build cache.

## What
- healthcheck.go: `defer func() { _ = conn.Close() }()` — satisfies errcheck (golangci-lint v2.12.2 fails the go job on main otherwise).
- ci.yml: `cache-dependency-path: eebus-bridge/go.sum` on setup-go (module lives in eebus-bridge/, so root go.mod lookup failed → cache never restored).

Cherry-picked from feat/ship-log-level (commits that missed the #57 merge window).

## Test
go build ./... passes locally.