### PR TITLE
feat(config_flow): reject bridge's own SKI as device SKI

### DIFF
--- a/custom_components/eebus/config_flow.py
+++ b/custom_components/eebus/config_flow.py
@@ -30,6 +30,15 @@ _LOGGER = logging.getLogger(__name__)
 
 CONFIG_RPC_TIMEOUT = 8
 
+
+def _normalize_ski(ski: str) -> str:
+    """Normalize a SKI for comparison (strip colons/whitespace, lowercase).
+
+    Mirrors the bridge's SKI normalization so a hand-typed value with colons or
+    different casing still matches the bridge's reported local SKI.
+    """
+    return ski.replace(":", "").replace(" ", "").strip().lower()
+
 STEP_USER_DATA_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_GRPC_HOST): str,
@@ -153,19 +162,29 @@ class EebusConfigFlow(ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Handle device selection step."""
+        errors: dict[str, str] = {}
+
         if user_input is not None:
             ski = user_input[CONF_DEVICE_SKI].strip()
-            await self.async_set_unique_id(ski)
-            self._abort_if_unique_id_configured()
 
-            return self.async_create_entry(
-                title=f"EEBUS {ski[:8]}",
-                data={
-                    CONF_GRPC_HOST: self._host,
-                    CONF_GRPC_PORT: self._port,
-                    CONF_DEVICE_SKI: ski,
-                },
-            )
+            # The picker hides the bridge's own SKI, but custom_value=True lets a
+            # user paste it by hand (e.g. the "Local SKI" line from the bridge
+            # log). That SKI never resolves to a remote entity, so reject it
+            # rather than create a permanently broken entry.
+            if _normalize_ski(ski) == _normalize_ski(self._local_ski):
+                errors[CONF_DEVICE_SKI] = "ski_is_local"
+            else:
+                await self.async_set_unique_id(ski)
+                self._abort_if_unique_id_configured()
+
+                return self.async_create_entry(
+                    title=f"EEBUS {ski[:8]}",
+                    data={
+                        CONF_GRPC_HOST: self._host,
+                        CONF_GRPC_PORT: self._port,
+                        CONF_DEVICE_SKI: ski,
+                    },
+                )
 
         options = await self._async_list_discovered_skis()
         schema = vol.Schema(
@@ -179,7 +198,9 @@ class EebusConfigFlow(ConfigFlow, domain=DOMAIN):
                 ),
             }
         )
-        return self.async_show_form(step_id="device", data_schema=schema)
+        return self.async_show_form(
+            step_id="device", data_schema=schema, errors=errors
+        )
 
     async def async_step_reconfigure(
         self, user_input: dict[str, Any] | None = None

--- a/custom_components/eebus/strings.json
+++ b/custom_components/eebus/strings.json
@@ -27,7 +27,8 @@
       }
     },
     "error": {
-      "cannot_connect": "Cannot connect to EEBUS bridge. Check host and port."
+      "cannot_connect": "Cannot connect to EEBUS bridge. Check host and port.",
+      "ski_is_local": "That is the bridge's own SKI. Enter the heat pump's SKI instead."
     },
     "abort": {
       "already_configured": "This device is already configured.",

--- a/custom_components/eebus/tests/test_config_flow.py
+++ b/custom_components/eebus/tests/test_config_flow.py
@@ -2,9 +2,12 @@
 
 import json
 from pathlib import Path
+from unittest.mock import AsyncMock, patch
 
-from custom_components.eebus.config_flow import EebusConfigFlow
-from custom_components.eebus.const import DOMAIN
+from homeassistant.data_entry_flow import FlowResultType
+
+from custom_components.eebus.config_flow import EebusConfigFlow, _normalize_ski
+from custom_components.eebus.const import CONF_DEVICE_SKI, DOMAIN
 
 
 def test_config_flow_domain():
@@ -15,6 +18,29 @@ def test_config_flow_domain():
 def test_config_flow_supports_zeroconf():
     """Test that the flow implements a zeroconf discovery step."""
     assert hasattr(EebusConfigFlow, "async_step_zeroconf")
+
+
+def test_normalize_ski_strips_colons_and_case():
+    """SKI normalization ignores colons, spaces, and casing."""
+    assert _normalize_ski("96:81:87:DB ") == "968187db"
+    assert _normalize_ski("ABCD") == "abcd"
+
+
+async def test_device_step_rejects_local_ski():
+    """Entering the bridge's own SKI is rejected, even with colons/casing."""
+    flow = EebusConfigFlow()
+    flow._local_ski = "968187db034cad41dab545c32a174ed7cc2fd8a5"
+    flow._host = "localhost"
+    flow._port = 50051
+
+    typed = "96:81:87:DB:03:4C:AD:41:DA:B5:45:C3:2A:17:4E:D7:CC:2F:D8:A5"
+    with patch.object(
+        flow, "_async_list_discovered_skis", AsyncMock(return_value=[])
+    ):
+        result = await flow.async_step_device({CONF_DEVICE_SKI: typed})
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["errors"][CONF_DEVICE_SKI] == "ski_is_local"
 
 
 def test_manifest_declares_ship_zeroconf():

--- a/custom_components/eebus/translations/de.json
+++ b/custom_components/eebus/translations/de.json
@@ -27,7 +27,8 @@
       }
     },
     "error": {
-      "cannot_connect": "Verbindung zur EEBUS Bridge fehlgeschlagen. Bitte Host und Port prüfen."
+      "cannot_connect": "Verbindung zur EEBUS Bridge fehlgeschlagen. Bitte Host und Port prüfen.",
+      "ski_is_local": "Das ist die eigene SKI der Bridge. Bitte die SKI der Wärmepumpe eingeben."
     },
     "abort": {
       "already_configured": "Dieses Gerät ist bereits konfiguriert.",

--- a/custom_components/eebus/translations/en.json
+++ b/custom_components/eebus/translations/en.json
@@ -27,7 +27,8 @@
       }
     },
     "error": {
-      "cannot_connect": "Cannot connect to EEBUS bridge. Check host and port."
+      "cannot_connect": "Cannot connect to EEBUS bridge. Check host and port.",
+      "ski_is_local": "That is the bridge's own SKI. Enter the heat pump's SKI instead."
     },
     "abort": {
       "already_configured": "This device is already configured.",


### PR DESCRIPTION
## Why

A user hit a permanent NotFound loop: the integration was configured with the **bridge's own Local SKI** (`968187db…`) instead of the heat pump's SKI (`682F708C…`). The device picker hides the local SKI, but `custom_value=True` lets it be pasted by hand — easy to do by copying the `Local SKI` line from the bridge log. The result never resolves to a remote entity:

```
Monitoring.GetPowerConsumption read failed: requested_ski=968187db… err=NotFound no remote entity found
```

## What

- `async_step_device` rejects an entered SKI that equals the bridge's local SKI, via a normalized compare (colons/whitespace/case-insensitive, mirroring the bridge's SKI normalization).
- New `ski_is_local` form error (strings.json + EN/DE translations).
- Tests: `_normalize_ski` + guard rejects local SKI even with colons/uppercase.

## Test

- `PYTHONPATH=. pytest` — 29 passed.
- `ruff check custom_components/` — clean.