### PR TITLE
docs: live VR940 use-case map + PV feed-in analysis; fix CLAUDE.md HVAC note

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,5 +76,5 @@ docker-compose up -d eebus-bridge        # ghcr.io image, host networking
 
 - Releases are tag-triggered: pushing a `v*` tag builds multi-arch (amd64/arm64/armv7) Docker images to GHCR. `release-drafter` drafts notes on merge to main. Bump `version` in `manifest.json` for HA releases.
 - CI skips Go/proto jobs via path filters when only the other side changed. `paths-ignore` skips `**/*.md`.
-- Vaillant exposes no HVAC control (modes/setpoints) over EEBUS — out of scope by design; LPC + measurement only.
+- HVAC control (modes/setpoints) is out of scope for now — LPC + measurement only. Note: the Vaillant VR940 *does* expose HVAC/DHW config+setpoint use cases over EEBUS (confirmed via live discovery, `docs/vr940-usecase-dump.txt`); the blocker is that `enbility/eebus-go` ships no HVAC/setpoint use cases, only the energy domain. It also advertises MGCP/VAPD/VABD/OSCF (PV/grid/battery feed-in) but only as the *consumer* role, so feeding HA PV data would need custom SPINE *provider* features — see `docs/eebus-vaillant-improvements.md`.
 - Follow YAGNI: build only what a current use case needs. No speculative abstractions, config knobs, or use-case scaffolding for hardware/features not yet supported.

--- a/docs/eebus-vaillant-improvements.md
+++ b/docs/eebus-vaillant-improvements.md
@@ -81,9 +81,42 @@ doesn't expose it." Update the wording.
    ```
    Read the dump → decide whether the HP advertises an MGCP / VAPD / energy-mgmt
    path before building any provider-side use case.
-2. If MGCP/VAPD provider is the path: spike a provider-side use case (grid
-   connection point measurements fed from HA via a new gRPC `SetGridData` /
-   `SetPVData` RPC streamed from the coordinator).
-3. New proto RPCs both sides (regen Go + Python per CLAUDE.md proto contract).
-4. HA side: config option to map existing PV/grid power sensors → push stream.
-5. Skip display-only PV. Skip HVAC setpoints until eebus-go gains the UCs.
+
+   **Result (captured 2026-06-27, full dump: `docs/vr940-usecase-dump.txt`):**
+   confirmed against the live VR940 (SKI 682F708C…, 10 entities). The gateway
+   advertises **all three** target paths as `available=true`. The `actor` field
+   is the role *the VR940 plays*, so for the data-feed use cases it is the
+   consumer/reader — the bridge must implement the complementary **provider**.
+
+   | Use case | VR940 actor (role it plays) | Bridge must provide | In eebus-go v0.7.0? |
+   |----------|-----------------------------|---------------------|---------------------|
+   | `monitoringOfGridConnectionPoint` (MGCP), scen 1-7 | MonitoringAppliance (reader) | Grid-connection-point **server** | only reader `ma/mgcp` → **no provider** |
+   | `visualizationOfAggregatedPhotovoltaicData` (VAPD), scen 1-3 | VisualizationAppliance (reader) | PV-system **server** | only reader `cem/vapd` → **no provider** |
+   | `visualizationOfAggregatedBatteryData` (VABD), scen 1-4 | VisualizationAppliance (reader) | Battery-system **server** | only reader `cem/vabd` → **no provider** |
+   | `optimizationOfSelfConsumptionByHeatPumpCompressorFlexibility` (OSCF), scen 1,2 | Compressor (flexibility provider) | EM/optimizer side | **not in eebus-go at all** |
+
+   Plus a major surprise: the VR940 exposes **full HVAC/DHW control** —
+   `configurationOfDhw{SystemFunction,Temperature}`,
+   `configurationOfRoomHeating{SystemFunction,Temperature}` and their monitoring
+   counterparts, backed by `HVAC/server` + `Setpoint/server` features on the
+   `DHWCircuit` (addr=4) and `HVACRoom` (addr=5:1:1) entities. **This directly
+   confirms the CLAUDE.md correction above is needed** — Vaillant does speak
+   HVAC; eebus-go simply lacks those use cases.
+
+2. **Pick the lever.** Two distinct goals, both now confirmed possible:
+   - *Functional PV-surplus* (§1.3.1, the high-value goal): the real control
+     lever is **OSCF** (`…CompressorFlexibility`). It is the §1.3.1 mechanism
+     but is **absent from eebus-go** → fully custom SPINE. **MGCP** (grid power,
+     negative = export) is the data the HP's own optimizer reads to act on
+     surplus — lower-effort than OSCF and reuses the Measurement/
+     ElectricalConnection server features. **Recommend MGCP provider first.**
+   - *Display PV/battery* (§1.3.3): VAPD/VABD provider. Cosmetic (myVAILLANT
+     app); low priority but cheap once the provider-server scaffolding exists.
+3. **Spike the provider-server side** (none ship in eebus-go): a local
+   GridConnectionPoint / PVSystem entity exposing Measurement +
+   ElectricalConnection + DeviceConfiguration server features, fed from HA.
+4. New proto RPCs (`SetGridData` / `SetPVData`) both sides, regen Go + Python
+   per CLAUDE.md proto contract.
+5. HA side: config option to map existing PV/grid power sensors → push stream.
+6. HVAC/DHW setpoint control is a *separate, larger* track (needs four custom
+   SPINE use cases). Out of scope for the PV work; note it as a future milestone.

--- a/docs/vr940-usecase-dump.txt
+++ b/docs/vr940-usecase-dump.txt
@@ -1,0 +1,38 @@
+# VR940 EEBUS use-case discovery dump
+# Captured 2026-06-27 via internal/eebus/discovery.go (bridge v0.5.3), device paired over SHIP.
+# Device SKI 682F708CEBA5DF9ADCB9E6787EA911D9FC3AC490, type=Generic, 10 entities.
+# actor = the role THE VR940 plays in each use case (i.e. for MGCP/VAPD it is the
+# *consumer/reader*, so the bridge must implement the complementary *provider* role).
+
+[DISCOVERY] device ski=682F708CEBA5DF9ADCB9E6787EA911D9FC3AC490 type=Generic entities=10
+[DISCOVERY]   entity addr=0     type=DeviceInformation  features=[DeviceClassification/server, NodeManagement/special]
+[DISCOVERY]   entity addr=1     type=CEM                features=[Generic/client]
+[DISCOVERY]   entity addr=2     type=CEM                features=[Generic/client]
+[DISCOVERY]   entity addr=3     type=HeatPumpAppliance  features=[DeviceClassification/server, DeviceConfiguration/server, DeviceDiagnosis/server, ElectricalConnection/server, Generic/client, LoadControl/server, Measurement/server]
+[DISCOVERY]   entity addr=3:1   type=Compressor         features=[ElectricalConnection/server, Measurement/server, SmartEnergyManagementPs/server]
+[DISCOVERY]   entity addr=4     type=DHWCircuit         features=[HVAC/server, Measurement/server, Setpoint/server]
+[DISCOVERY]   entity addr=5     type=HeatingCircuit     features=[DeviceClassification/server]
+[DISCOVERY]   entity addr=5:1   type=HeatingZone        features=[DeviceClassification/server]
+[DISCOVERY]   entity addr=5:1:1 type=HVACRoom           features=[DeviceClassification/server, HVAC/server, Measurement/server, Setpoint/server]
+[DISCOVERY]   entity addr=6     type=TemperatureSensor  features=[Measurement/server]
+
+[DISCOVERY]   usecase actor=ControllableSystem      name=limitationOfPowerConsumption                                  v1.0.0 available=true  scenarios=[1,2,3,4]
+[DISCOVERY]   usecase actor=IdentifiableNode        name=nodeIdentification                                            v1.0.0 available=true  scenarios=[1]
+[DISCOVERY]   usecase actor=MonitoredUnit           name=monitoringOfPowerConsumption                                  v1.0.0 available=true  scenarios=[1,2,3,4,5]
+[DISCOVERY]   usecase actor=Compressor              name=optimizationOfSelfConsumptionByHeatPumpCompressorFlexibility  v1.0.0 available=true  scenarios=[1,2]
+[DISCOVERY]   usecase actor=MonitoredUnit           name=monitoringOfPowerConsumption                                  v1.0.0 available=true  scenarios=[1]
+[DISCOVERY]   usecase actor=DHWCircuit              name=configurationOfDhwSystemFunction                              v1.0.0 available=true  scenarios=[1,2,3]
+[DISCOVERY]   usecase actor=DHWCircuit              name=configurationOfDhwTemperature                                 v1.0.0 available=true  scenarios=[1]
+[DISCOVERY]   usecase actor=DHWCircuit              name=monitoringOfDhwSystemFunction                                 v1.0.0 available=true  scenarios=[1,2]
+[DISCOVERY]   usecase actor=DHWCircuit              name=monitoringOfDhwTemperature                                    v1.0.0 available=true  scenarios=[1]
+[DISCOVERY]   usecase actor=HVACRoom                name=configurationOfRoomHeatingSystemFunction                      v1.0.0 available=true  scenarios=[1]
+[DISCOVERY]   usecase actor=HVACRoom                name=configurationOfRoomHeatingTemperature                         v1.0.0 available=true  scenarios=[1]
+[DISCOVERY]   usecase actor=HVACRoom                name=monitoringOfRoomHeatingSystemFunction                         v1.0.0 available=true  scenarios=[1]
+[DISCOVERY]   usecase actor=HVACRoom                name=monitoringOfRoomTemperature                                   v1.0.0 available=true  scenarios=[1]
+[DISCOVERY]   usecase actor=HVACRoom                name=visualizationOfHeatingAreaName                                v1.0.0 available=false scenarios=[3]
+[DISCOVERY]   usecase actor=HeatingCircuit          name=visualizationOfHeatingAreaName                                v1.0.0 available=false scenarios=[1]
+[DISCOVERY]   usecase actor=HeatingZone             name=visualizationOfHeatingAreaName                                v1.0.0 available=false scenarios=[2]
+[DISCOVERY]   usecase actor=OutdoorTemperatureSensor name=monitoringOfOutdoorTemperature                              v1.0.0 available=true  scenarios=[1]
+[DISCOVERY]   usecase actor=MonitoringAppliance     name=monitoringOfGridConnectionPoint                               v1.0.0 available=true  scenarios=[1,2,3,4,5,6,7]
+[DISCOVERY]   usecase actor=VisualizationAppliance  name=visualizationOfAggregatedBatteryData                          v1.0.0 available=true  scenarios=[1,2,3,4]
+[DISCOVERY]   usecase actor=VisualizationAppliance  name=visualizationOfAggregatedPhotovoltaicData                     v1.0.0 available=true  scenarios=[1,2,3]


### PR DESCRIPTION
## What

- **`docs/vr940-usecase-dump.txt`** — discovery dump captured from the live VR940 (SKI 682F708C…) via `internal/eebus/discovery.go` (bridge v0.5.3).
- **`docs/eebus-vaillant-improvements.md`** — updated with the data-backed verdict + build order.
- **`CLAUDE.md`** — corrected the HVAC-out-of-scope note.

## Key findings (live capture)

VR940 advertises, all `available=true`:

| Use case | VR940 role | Bridge must provide | eebus-go v0.7.0 |
|---|---|---|---|
| MGCP grid connection point (scen 1-7) | reader | Grid-point **server** | reader only |
| VAPD PV data (scen 1-3) | reader | PV-system **server** | reader only |
| VABD battery data (scen 1-4) | reader | Battery **server** | reader only |
| OSCF compressor flexibility (scen 1,2) | Compressor | EM/optimizer | **absent** |

Plus **full HVAC/DHW control** (DHW + room-heating config/temp + monitoring, `HVAC/server` + `Setpoint/server` features).

## Conclusions

- **Providing PV data over EEBUS makes sense** — the VR940 actively wants it as the consumer. Highest-value functional path = MGCP provider (grid power, surplus). Display-only VAPD/VABD is cheap follow-up.
- All feed-in paths need **custom SPINE provider-server** features — eebus-go ships only the reader sides.
- **CLAUDE.md was wrong**: Vaillant *does* expose HVAC control over EEBUS; the blocker is eebus-go lacking those use cases.

Docs-only (no code). Follows the discovery tooling merged in #60.