### PR TITLE
fix(streams): populate LPC/measurement event payloads in bridge

### DIFF
--- a/custom_components/eebus/coordinator.py
+++ b/custom_components/eebus/coordinator.py
@@ -835,6 +835,10 @@ class EebusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             return
         event_type = event.event_type
         if event_type == proto_stubs.LPCEventType.LPC_EVENT_LIMIT_UPDATED:
+            if not event.HasField("limit_update"):
+                # Bridge signalled a change but sent no payload; reconcile via poll.
+                self.hass.async_create_task(self.async_request_refresh())
+                return
             limit = event.limit_update
             self._push_data(
                 {
@@ -846,6 +850,9 @@ class EebusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 }
             )
         elif event_type == proto_stubs.LPCEventType.LPC_EVENT_FAILSAFE_UPDATED:
+            if not event.HasField("failsafe_update"):
+                self.hass.async_create_task(self.async_request_refresh())
+                return
             failsafe = event.failsafe_update
             self._push_data(
                 {
@@ -864,16 +871,17 @@ class EebusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         if not self._event_matches(event.ski):
             return
         event_type = event.event_type
-        if (
-            event_type == proto_stubs.MeasurementEventType.MEASUREMENT_EVENT_POWER_UPDATED
-            and event.HasField("power")
-        ):
-            self._push_data({"power_watts": event.power.watts})
-        elif (
-            event_type == proto_stubs.MeasurementEventType.MEASUREMENT_EVENT_ENERGY_UPDATED
-            and event.HasField("energy")
-        ):
-            self._push_data({"energy_consumed_kwh": event.energy.kilowatt_hours})
+        if event_type == proto_stubs.MeasurementEventType.MEASUREMENT_EVENT_POWER_UPDATED:
+            if event.HasField("power"):
+                self._push_data({"power_watts": event.power.watts})
+            else:
+                # Change signalled without a payload; reconcile via poll.
+                self.hass.async_create_task(self.async_request_refresh())
+        elif event_type == proto_stubs.MeasurementEventType.MEASUREMENT_EVENT_ENERGY_UPDATED:
+            if event.HasField("energy"):
+                self._push_data({"energy_consumed_kwh": event.energy.kilowatt_hours})
+            else:
+                self.hass.async_create_task(self.async_request_refresh())
 
     async def async_shutdown(self) -> None:
         """Close gRPC channel and cancel stream tasks."""

--- a/custom_components/eebus/tests/test_coordinator.py
+++ b/custom_components/eebus/tests/test_coordinator.py
@@ -163,6 +163,36 @@ def test_lpc_failsafe_event_pushes_data():
     }
 
 
+def test_lpc_limit_event_without_payload_refreshes():
+    """LIMIT_UPDATED without a payload must reconcile via poll, never zero the limit."""
+    coordinator, pushed = _make_coordinator(
+        data={"consumption_limit": {"value_watts": 4200.0, "is_active": True}}
+    )
+    coordinator.hass = MagicMock()
+    coordinator.async_request_refresh = MagicMock(return_value=None)
+    event = lpc_service_pb2.LPCEvent(
+        ski="test-ski",
+        event_type=lpc_service_pb2.LPC_EVENT_LIMIT_UPDATED,
+    )
+    coordinator._handle_lpc_event(event)
+    assert not pushed  # no zeroing push
+    coordinator.hass.async_create_task.assert_called_once()
+
+
+def test_measurement_power_event_without_payload_refreshes():
+    """POWER_UPDATED without a payload must reconcile via poll instead of dropping."""
+    coordinator, pushed = _make_coordinator(data={"power_watts": 100.0})
+    coordinator.hass = MagicMock()
+    coordinator.async_request_refresh = MagicMock(return_value=None)
+    event = monitoring_service_pb2.MeasurementEvent(
+        ski="test-ski",
+        event_type=monitoring_service_pb2.MEASUREMENT_EVENT_POWER_UPDATED,
+    )
+    coordinator._handle_measurement_event(event)
+    assert not pushed
+    coordinator.hass.async_create_task.assert_called_once()
+
+
 def test_fetch_device_info_uses_matching_ski():
     """Real brand/model/serial for the configured SKI is surfaced (issue #28)."""
     coordinator, _ = _make_coordinator(ski="bosch-ski")

--- a/eebus-bridge/internal/grpc/lpc_service.go
+++ b/eebus-bridge/internal/grpc/lpc_service.go
@@ -215,14 +215,42 @@ func (s *LPCService) SubscribeLPCEvents(req *pb.DeviceRequest, stream pb.LPCServ
 			default:
 				continue
 			}
-			if err := stream.Send(&pb.LPCEvent{
-				Ski:       evt.SKI,
-				EventType: eventType,
-			}); err != nil {
+			event := &pb.LPCEvent{Ski: evt.SKI, EventType: eventType}
+			s.attachLPCPayload(event, evt.SKI, eventType)
+			if err := stream.Send(event); err != nil {
 				return err
 			}
 		case <-stream.Context().Done():
 			return stream.Context().Err()
+		}
+	}
+}
+
+// attachLPCPayload best-effort fills the event's typed payload with the current
+// limit/failsafe values so subscribers receive data directly instead of having
+// to poll. If the use case is not ready or the entity/value cannot be read, the
+// event is sent without a payload and the client falls back to a refresh.
+func (s *LPCService) attachLPCPayload(event *pb.LPCEvent, ski string, eventType pb.LPCEventType) {
+	if s.lpc == nil {
+		return
+	}
+	entity, err := s.resolveEntity(ski)
+	if err != nil {
+		return
+	}
+	switch eventType {
+	case pb.LPCEventType_LPC_EVENT_LIMIT_UPDATED:
+		if limit, err := s.lpc.ConsumptionLimit(entity); err == nil {
+			event.Data = &pb.LPCEvent_LimitUpdate{LimitUpdate: convertLoadLimit(limit)}
+		}
+	case pb.LPCEventType_LPC_EVENT_FAILSAFE_UPDATED:
+		value, verr := s.lpc.FailsafeConsumptionActivePowerLimit(entity)
+		duration, derr := s.lpc.FailsafeDurationMinimum(entity)
+		if verr == nil && derr == nil {
+			event.Data = &pb.LPCEvent_FailsafeUpdate{FailsafeUpdate: &pb.FailsafeLimit{
+				ValueWatts:             value,
+				DurationMinimumSeconds: int64(duration / time.Second),
+			}}
 		}
 	}
 }

--- a/eebus-bridge/internal/grpc/monitoring_service.go
+++ b/eebus-bridge/internal/grpc/monitoring_service.go
@@ -145,14 +145,39 @@ func (s *MonitoringService) SubscribeMeasurements(req *pb.DeviceRequest, stream 
 			default:
 				continue
 			}
-			if err := stream.Send(&pb.MeasurementEvent{
-				Ski:       evt.SKI,
-				EventType: eventType,
-			}); err != nil {
+			event := &pb.MeasurementEvent{Ski: evt.SKI, EventType: eventType}
+			s.attachMeasurementPayload(event, evt.SKI, eventType)
+			if err := stream.Send(event); err != nil {
 				return err
 			}
 		case <-stream.Context().Done():
 			return stream.Context().Err()
+		}
+	}
+}
+
+// attachMeasurementPayload best-effort fills the event's typed payload with the
+// current value so subscribers receive data directly instead of polling. On any
+// read failure the event is sent without a payload and the client falls back to
+// a refresh. Reuses the SKI-resolve + nil-entity fallback of the Get* readers.
+func (s *MonitoringService) attachMeasurementPayload(event *pb.MeasurementEvent, ski string, eventType pb.MeasurementEventType) {
+	if s.monitoring == nil {
+		return
+	}
+	switch eventType {
+	case pb.MeasurementEventType_MEASUREMENT_EVENT_POWER_UPDATED:
+		if value, err := s.readPower(ski); err == nil {
+			event.Data = &pb.MeasurementEvent_Power{Power: &pb.PowerMeasurement{
+				Watts:     value,
+				Timestamp: timestamppb.Now(),
+			}}
+		}
+	case pb.MeasurementEventType_MEASUREMENT_EVENT_ENERGY_UPDATED:
+		if value, err := s.readEnergyConsumed(ski); err == nil {
+			event.Data = &pb.MeasurementEvent_Energy{Energy: &pb.EnergyMeasurement{
+				KilowattHours: value,
+				Timestamp:     timestamppb.Now(),
+			}}
 		}
 	}
 }


### PR DESCRIPTION
The bridge emitted LPC and measurement stream events carrying only ski + event_type, never the typed oneof payload the HA client reads. Effects:

- LPC LIMIT_UPDATED: client read the unset limit_update sub-message and pushed value_watts=0 / is_active=false over the real limit.
- Measurement POWER/ENERGY events: client's HasField guard dropped them silently, so the push path delivered no data and relied on the 5-min poll.

Populate the event payloads server-side (best-effort; sent without payload if the value can't be read) so the push path actually carries data, and make the client defensive: when a payload is absent, request a refresh instead of zeroing or dropping.