### PR TITLE
ci(release): auto-publish GitHub release on tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,18 @@ permissions:
   packages: write
 
 jobs:
+  create-release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Publish GitHub release
+        # HACS reads published releases, not tags. Without this the integration
+        # never sees a new version even though the tag and image exist.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release create "${GITHUB_REF_NAME}" --repo "${GITHUB_REPOSITORY}" --title "${GITHUB_REF_NAME}" --generate-notes --latest --verify-tag
+
   publish-image:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Problem

`release.yml` triggers on `v*` tags but **only builds/pushes the Docker image** — it never creates a GitHub Release.

HACS reads *published releases*, not tags. So the HA integration stayed on the last hand-published release (v0.6.0) even after v0.7.0 was tagged. Symptom: VAPD/VABD sensor fields (added in #66 / v0.7.0) never showed in the integration's Configure flow.

## Fix

Add a `create-release` job (`contents: write`) that runs `gh release create "${GITHUB_REF_NAME}" --generate-notes --latest --verify-tag` on tag push. Now tag → image **and** published release in one shot; HACS picks up the new version.

## Notes
- v0.7.0 release published manually as part of this fix; stale mis-numbered `v0.6.1` release-drafter draft deleted.
- Injection-safe: uses `GITHUB_REF_NAME`/`GITHUB_REPOSITORY` env vars, no `github.event.*` interpolation.