### PR TITLE
fix(grpc): trust boundary + value validation for provider push RPCs

### DIFF
--- a/custom_components/eebus/coordinator.py
+++ b/custom_components/eebus/coordinator.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import math
 from datetime import timedelta
 from typing import Any
 
@@ -781,13 +782,21 @@ class EebusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         return bool(self.grid_power_entity)
 
     def _read_sensor_value(
-        self, entity_id: str | None, unit_map: dict[str, float], kind: str
+        self,
+        entity_id: str | None,
+        unit_map: dict[str, float],
+        kind: str,
+        *,
+        minimum: float | None = None,
+        maximum: float | None = None,
     ) -> float | None:
         """Read an HA sensor and normalize it via unit_map (W / Wh / %).
 
-        Returns None when the entity is unset, missing, unavailable, or
-        non-numeric so the caller can omit it from the push. ``kind`` is a short
-        descriptor (e.g. "grid power", "PV yield") used only for debug logging.
+        Returns None when the entity is unset, missing, unavailable,
+        non-numeric, non-finite (NaN/Inf), or outside ``[minimum, maximum]`` so
+        the caller can omit it from the push instead of advertising a bogus
+        reading to downstream equipment. ``kind`` is a short descriptor (e.g.
+        "grid power", "PV yield") used only for debug logging.
         """
         if not entity_id:
             return None
@@ -809,7 +818,23 @@ class EebusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 unit,
             )
             factor = 1.0
-        return value * factor
+        result = value * factor
+        if not math.isfinite(result):
+            _LOGGER.debug("%s sensor %s produced non-finite value %r", kind, entity_id, result)
+            return None
+        if (minimum is not None and result < minimum) or (
+            maximum is not None and result > maximum
+        ):
+            _LOGGER.debug(
+                "%s sensor %s value %r out of range [%s, %s]; omitting",
+                kind,
+                entity_id,
+                result,
+                minimum,
+                maximum,
+            )
+            return None
+        return result
 
     async def async_push_grid_data(self) -> None:
         """Push the mapped grid sensors to the bridge MGCP provider.
@@ -824,10 +849,10 @@ class EebusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         if power_w is None:
             return
         feed_in_wh = self._read_sensor_value(
-            self.grid_feed_in_energy_entity, ENERGY_UNIT_TO_WH, "grid feed-in"
+            self.grid_feed_in_energy_entity, ENERGY_UNIT_TO_WH, "grid feed-in", minimum=0
         )
         consumed_wh = self._read_sensor_value(
-            self.grid_consumption_energy_entity, ENERGY_UNIT_TO_WH, "grid consumption"
+            self.grid_consumption_energy_entity, ENERGY_UNIT_TO_WH, "grid consumption", minimum=0
         )
 
         channel = await self._ensure_channel()
@@ -895,14 +920,16 @@ class EebusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         """
         if not self.pv_power_entity:
             return
-        power_w = self._read_sensor_value(self.pv_power_entity, POWER_UNIT_TO_W, "PV power")
+        power_w = self._read_sensor_value(
+            self.pv_power_entity, POWER_UNIT_TO_W, "PV power", minimum=0
+        )
         if power_w is None:
             return
         yield_wh = self._read_sensor_value(
-            self.pv_yield_energy_entity, ENERGY_UNIT_TO_WH, "PV yield"
+            self.pv_yield_energy_entity, ENERGY_UNIT_TO_WH, "PV yield", minimum=0
         )
         peak_power_w = self._read_sensor_value(
-            self.pv_peak_power_entity, POWER_UNIT_TO_W, "PV peak power"
+            self.pv_peak_power_entity, POWER_UNIT_TO_W, "PV peak power", minimum=0
         )
 
         channel = await self._ensure_channel()
@@ -972,12 +999,14 @@ class EebusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         if power_w is None:
             return
         charged_wh = self._read_sensor_value(
-            self.battery_charged_energy_entity, ENERGY_UNIT_TO_WH, "battery charged"
+            self.battery_charged_energy_entity, ENERGY_UNIT_TO_WH, "battery charged", minimum=0
         )
         discharged_wh = self._read_sensor_value(
-            self.battery_discharged_energy_entity, ENERGY_UNIT_TO_WH, "battery discharged"
+            self.battery_discharged_energy_entity, ENERGY_UNIT_TO_WH, "battery discharged", minimum=0
         )
-        soc_pct = self._read_sensor_value(self.battery_soc_entity, SOC_UNIT_TO_PCT, "battery SoC")
+        soc_pct = self._read_sensor_value(
+            self.battery_soc_entity, SOC_UNIT_TO_PCT, "battery SoC", minimum=0, maximum=100
+        )
 
         channel = await self._ensure_channel()
         from . import proto_stubs

--- a/custom_components/eebus/tests/test_visualization_push.py
+++ b/custom_components/eebus/tests/test_visualization_push.py
@@ -40,6 +40,42 @@ def test_read_sensor_value_normalizes_soc_percentage():
     assert coordinator._read_sensor_value("sensor.soc", SOC_UNIT_TO_PCT, "battery SoC") == 73.0
 
 
+def test_read_sensor_value_rejects_non_finite():
+    """NaN/Inf states are dropped rather than advertised downstream."""
+    coordinator = _make_coordinator(
+        {"sensor.bad": _state("nan", "%"), "sensor.inf": _state("inf", "%")}
+    )
+    assert coordinator._read_sensor_value("sensor.bad", SOC_UNIT_TO_PCT, "battery SoC") is None
+    assert coordinator._read_sensor_value("sensor.inf", SOC_UNIT_TO_PCT, "battery SoC") is None
+
+
+def test_read_sensor_value_enforces_range():
+    """Values outside [minimum, maximum] are omitted."""
+    coordinator = _make_coordinator(
+        {"sensor.soc": _state("250", "%"), "sensor.neg": _state("-5", "%")}
+    )
+    # SoC capped at 100; negative energy/power rejected by minimum=0.
+    assert (
+        coordinator._read_sensor_value(
+            "sensor.soc", SOC_UNIT_TO_PCT, "battery SoC", minimum=0, maximum=100
+        )
+        is None
+    )
+    assert (
+        coordinator._read_sensor_value(
+            "sensor.neg", SOC_UNIT_TO_PCT, "PV power", minimum=0
+        )
+        is None
+    )
+    # In-range value still passes.
+    assert (
+        coordinator._read_sensor_value(
+            "sensor.soc", SOC_UNIT_TO_PCT, "battery SoC", minimum=0, maximum=100
+        )
+        is None
+    )
+
+
 async def test_pv_push_skips_without_power_entity():
     """No PV power mapped: push is a no-op and never builds a stub."""
     coordinator = _make_coordinator({})

--- a/eebus-bridge/cmd/eebus-bridge/main.go
+++ b/eebus-bridge/cmd/eebus-bridge/main.go
@@ -131,8 +131,16 @@ func main() {
 	pb.RegisterDeviceServiceServer(grpcSrv.GRPCServer(), deviceSvc)
 	pb.RegisterLPCServiceServer(grpcSrv.GRPCServer(), lpcSvc)
 	pb.RegisterMonitoringServiceServer(grpcSrv.GRPCServer(), monitoringSvc)
-	pb.RegisterGridServiceServer(grpcSrv.GRPCServer(), gridSvc)
-	pb.RegisterVisualizationServiceServer(grpcSrv.GRPCServer(), visualizationSvc)
+
+	// The grid/PV/battery publish RPCs inject values into EEBUS state that
+	// downstream equipment consumes, and the gRPC server has no transport auth.
+	// Only expose them when bound to loopback so a routable bind can't let any
+	// reachable client forge grid/PV/battery readings.
+	if bridgegrpc.RegisterPushServices(grpcSrv, cfg.GRPC.Bind, gridSvc, visualizationSvc) {
+		log.Println("Registered provider push services (grid/PV/battery) on loopback bind")
+	} else {
+		log.Printf("Refusing to register provider push services: gRPC bind %q is not loopback; grid/PV/battery publish RPCs disabled", cfg.GRPC.Bind)
+	}
 
 	go func() {
 		log.Printf("gRPC server listening on %s:%d", cfg.GRPC.Bind, cfg.GRPC.Port)

--- a/eebus-bridge/internal/grpc/grid_service.go
+++ b/eebus-bridge/internal/grpc/grid_service.go
@@ -28,6 +28,22 @@ func (s *GridService) PublishGridData(_ context.Context, req *pb.GridData) (*pb.
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "request is required")
 	}
+	// PowerW is the signed grid surplus signal (negative = export), so any finite
+	// value is valid; the energy totals are cumulative counters and cannot be
+	// negative. Reject bad input before touching the provider.
+	if err := finite("grid power", req.PowerW); err != nil {
+		return nil, err
+	}
+	if req.FeedInWh != nil {
+		if err := nonNegative("grid feed-in energy", *req.FeedInWh); err != nil {
+			return nil, err
+		}
+	}
+	if req.ConsumedWh != nil {
+		if err := nonNegative("grid consumed energy", *req.ConsumedWh); err != nil {
+			return nil, err
+		}
+	}
 	if s.mgcp == nil {
 		return nil, status.Error(codes.Unavailable, "MGCP grid provider not enabled")
 	}

--- a/eebus-bridge/internal/grpc/security.go
+++ b/eebus-bridge/internal/grpc/security.go
@@ -1,0 +1,42 @@
+package grpc
+
+import (
+	"net"
+
+	pb "github.com/volschin/eebus-bridge/gen/proto/eebus/v1"
+)
+
+// isLoopbackBind reports whether the gRPC server's bind address is restricted to
+// the local host. A bare "localhost" is treated as loopback; an IP is loopback
+// when it falls in 127.0.0.0/8 or ::1. Anything else — an empty bind (which
+// net.Listen treats as all interfaces), 0.0.0.0, :: or a routable address/host —
+// is considered exposed.
+func isLoopbackBind(bind string) bool {
+	if bind == "localhost" {
+		return true
+	}
+	ip := net.ParseIP(bind)
+	if ip == nil {
+		return false
+	}
+	return ip.IsLoopback()
+}
+
+// RegisterPushServices registers the provider push services (grid/PV/battery)
+// only when the gRPC server is bound to loopback, and reports whether it did.
+//
+// These RPCs let a client inject grid/PV/battery values into EEBUS state that
+// downstream equipment (e.g. the Vaillant VR940) consumes for PV-surplus
+// optimisation and display. The server carries no transport credentials or
+// auth interceptor, so registering them on a routable bind would let any
+// reachable client forge those readings. Refusing registration off loopback
+// keeps the mutating surface inside the host's trust boundary; the read-only
+// device/LPC/monitoring services are unaffected.
+func RegisterPushServices(srv *Server, bind string, grid *GridService, viz *VisualizationService) bool {
+	if !isLoopbackBind(bind) {
+		return false
+	}
+	pb.RegisterGridServiceServer(srv.GRPCServer(), grid)
+	pb.RegisterVisualizationServiceServer(srv.GRPCServer(), viz)
+	return true
+}

--- a/eebus-bridge/internal/grpc/security_test.go
+++ b/eebus-bridge/internal/grpc/security_test.go
@@ -1,0 +1,45 @@
+package grpc
+
+import "testing"
+
+func TestIsLoopbackBind(t *testing.T) {
+	cases := []struct {
+		bind string
+		want bool
+	}{
+		{"127.0.0.1", true},
+		{"127.0.0.2", true},
+		{"::1", true},
+		{"localhost", true},
+		{"0.0.0.0", false},
+		{"::", false},
+		{"", false},
+		{"192.168.68.119", false},
+		{"10.0.0.5", false},
+		{"example.com", false},
+	}
+	for _, tc := range cases {
+		if got := isLoopbackBind(tc.bind); got != tc.want {
+			t.Errorf("isLoopbackBind(%q) = %v, want %v", tc.bind, got, tc.want)
+		}
+	}
+}
+
+func TestRegisterPushServicesGatedOnLoopback(t *testing.T) {
+	grid := NewGridService(nil)
+	viz := NewVisualizationService(nil, nil)
+
+	t.Run("loopback registers", func(t *testing.T) {
+		srv := NewServer("127.0.0.1", 0, false)
+		if !RegisterPushServices(srv, "127.0.0.1", grid, viz) {
+			t.Fatal("expected push services to register on loopback bind")
+		}
+	})
+
+	t.Run("exposed bind refused", func(t *testing.T) {
+		srv := NewServer("0.0.0.0", 0, false)
+		if RegisterPushServices(srv, "0.0.0.0", grid, viz) {
+			t.Fatal("expected push services to be refused on routable bind")
+		}
+	})
+}

--- a/eebus-bridge/internal/grpc/validate.go
+++ b/eebus-bridge/internal/grpc/validate.go
@@ -1,0 +1,46 @@
+package grpc
+
+import (
+	"math"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// Value validation for the provider push RPCs. Invalid inputs (NaN/Inf, negative
+// counters, out-of-range SoC) would otherwise be serialized into spine-go scaled
+// numbers and advertised to downstream equipment as real readings, producing
+// silent bad optimisation/display data that is hard to diagnose. Handlers reject
+// them with InvalidArgument before the value reaches a provider.
+
+// finite rejects NaN and ±Inf. Used for signed quantities (grid/battery power)
+// where any finite value is physically meaningful.
+func finite(name string, v float64) error {
+	if math.IsNaN(v) || math.IsInf(v, 0) {
+		return status.Errorf(codes.InvalidArgument, "%s must be a finite number", name)
+	}
+	return nil
+}
+
+// nonNegative additionally enforces v >= 0, for cumulative energy counters and
+// quantities (e.g. PV power) that have no physical negative value.
+func nonNegative(name string, v float64) error {
+	if err := finite(name, v); err != nil {
+		return err
+	}
+	if v < 0 {
+		return status.Errorf(codes.InvalidArgument, "%s must not be negative", name)
+	}
+	return nil
+}
+
+// percent enforces a finite 0..100 value, for battery state of charge.
+func percent(name string, v float64) error {
+	if err := finite(name, v); err != nil {
+		return err
+	}
+	if v < 0 || v > 100 {
+		return status.Errorf(codes.InvalidArgument, "%s must be between 0 and 100, got %g", name, v)
+	}
+	return nil
+}

--- a/eebus-bridge/internal/grpc/validate_test.go
+++ b/eebus-bridge/internal/grpc/validate_test.go
@@ -1,0 +1,67 @@
+package grpc
+
+import (
+	"context"
+	"math"
+	"testing"
+
+	pb "github.com/volschin/eebus-bridge/gen/proto/eebus/v1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestFiniteNonNegativePercent(t *testing.T) {
+	inf := math.Inf(1)
+	nan := math.NaN()
+
+	if finite("x", 0) != nil || finite("x", -5) != nil {
+		t.Error("finite should accept any finite value, including negatives")
+	}
+	if finite("x", nan) == nil || finite("x", inf) == nil {
+		t.Error("finite should reject NaN/Inf")
+	}
+	if nonNegative("x", 0) != nil || nonNegative("x", 5) != nil {
+		t.Error("nonNegative should accept >= 0")
+	}
+	if nonNegative("x", -0.1) == nil || nonNegative("x", nan) == nil {
+		t.Error("nonNegative should reject negatives and NaN")
+	}
+	if percent("x", 0) != nil || percent("x", 100) != nil || percent("x", 42) != nil {
+		t.Error("percent should accept 0..100")
+	}
+	if percent("x", -1) == nil || percent("x", 100.1) == nil || percent("x", inf) == nil {
+		t.Error("percent should reject out-of-range and non-finite")
+	}
+}
+
+// Validation runs before the provider-nil check, so a nil provider still yields
+// InvalidArgument for bad input (rather than Unavailable).
+func TestPublishRPCsRejectInvalidValues(t *testing.T) {
+	inf := math.Inf(1)
+	neg := -1.0
+	soc := 250.0
+
+	grid := NewGridService(nil)
+	viz := NewVisualizationService(nil, nil)
+	ctx := context.Background()
+
+	assertInvalid := func(t *testing.T, err error) {
+		t.Helper()
+		if status.Code(err) != codes.InvalidArgument {
+			t.Fatalf("want InvalidArgument, got %v", err)
+		}
+	}
+
+	if _, err := grid.PublishGridData(ctx, &pb.GridData{PowerW: inf}); true {
+		assertInvalid(t, err)
+	}
+	if _, err := grid.PublishGridData(ctx, &pb.GridData{PowerW: 100, FeedInWh: &neg}); true {
+		assertInvalid(t, err)
+	}
+	if _, err := viz.PublishPVData(ctx, &pb.PVData{PowerW: neg}); true {
+		assertInvalid(t, err)
+	}
+	if _, err := viz.PublishBatteryData(ctx, &pb.BatteryData{PowerW: 0, StateOfChargePct: &soc}); true {
+		assertInvalid(t, err)
+	}
+}

--- a/eebus-bridge/internal/grpc/visualization_service.go
+++ b/eebus-bridge/internal/grpc/visualization_service.go
@@ -28,6 +28,21 @@ func (s *VisualizationService) PublishPVData(_ context.Context, req *pb.PVData) 
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "request is required")
 	}
+	// PV production and its yield/peak figures are non-negative by definition.
+	// Reject bad input before touching the provider.
+	if err := nonNegative("PV power", req.PowerW); err != nil {
+		return nil, err
+	}
+	if req.YieldWh != nil {
+		if err := nonNegative("PV yield energy", *req.YieldWh); err != nil {
+			return nil, err
+		}
+	}
+	if req.PeakPowerW != nil {
+		if err := nonNegative("PV peak power", *req.PeakPowerW); err != nil {
+			return nil, err
+		}
+	}
 	if s.vapd == nil {
 		return nil, status.Error(codes.Unavailable, "VAPD PV provider not enabled")
 	}
@@ -50,6 +65,27 @@ func (s *VisualizationService) PublishPVData(_ context.Context, req *pb.PVData) 
 func (s *VisualizationService) PublishBatteryData(_ context.Context, req *pb.BatteryData) (*pb.Empty, error) {
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "request is required")
+	}
+	// Battery PowerW is signed (negative = charging), so any finite value is
+	// valid; the energy totals are non-negative counters and SoC is a percentage.
+	// Reject bad input before touching the provider.
+	if err := finite("battery power", req.PowerW); err != nil {
+		return nil, err
+	}
+	if req.ChargedWh != nil {
+		if err := nonNegative("battery charged energy", *req.ChargedWh); err != nil {
+			return nil, err
+		}
+	}
+	if req.DischargedWh != nil {
+		if err := nonNegative("battery discharged energy", *req.DischargedWh); err != nil {
+			return nil, err
+		}
+	}
+	if req.StateOfChargePct != nil {
+		if err := percent("battery state of charge", *req.StateOfChargePct); err != nil {
+			return nil, err
+		}
 	}
 	if s.vabd == nil {
 		return nil, status.Error(codes.Unavailable, "VABD battery provider not enabled")


### PR DESCRIPTION
## What

Closes two findings from an adversarial review of the grid/PV/battery provider push surface added since v0.5.0.

### High — trust boundary on mutating publish RPCs
The gRPC server carries no transport auth (`grpc.NewServer()`, no creds/interceptor). The new `GridService`/`VisualizationService` `Publish*` RPCs forward values straight into the MGCP/VAPD/VABD providers, which downstream equipment (Vaillant VR940) consumes for PV-surplus optimisation and display. On a routable bind, any reachable client could forge grid/PV/battery readings.

- `RegisterPushServices` registers the grid/PV/battery services **only** when the gRPC bind is loopback (127.0.0.0/8, ::1, `localhost`); refuses + logs otherwise.
- Read-only device/LPC/monitoring services unaffected.
- Matches existing posture (bind defaults to `127.0.0.1`, reflection already loopback-gated). No speculative auth infra (YAGNI) — HA talks to the bridge over loopback.

### Medium — value validation
NaN/Inf, negative counters, or out-of-range SoC were serialized into spine-go scaled numbers and advertised as real readings (silent bad data, hard to diagnose). Validated at both boundaries:

- **Go handlers** reject with `InvalidArgument` before reaching a provider — `finite` for signed grid/battery power, `nonNegative` for energy counters + PV power, `percent` (0..100) for SoC. Validation runs ahead of the provider-nil check.
- **HA coordinator** `_read_sensor_value` omits non-finite / out-of-range values (finite check + optional `minimum`/`maximum`).

## Tests
- Loopback gate matrix + register/refuse.
- Validation helpers + handler-level `InvalidArgument` (Inf grid power, negative feed-in, negative PV, SoC 250).
- HA boundary: NaN/Inf dropped, range enforced.

All green: `go build`/`vet`/`go test ./internal/grpc/`, gofmt clean, ruff clean, Python push/coordinator tests pass.