### PR TITLE
fix(ohpcf): await control-write results so device rejections reach HA

### DIFF
--- a/eebus-bridge/internal/usecases/ohpcf.go
+++ b/eebus-bridge/internal/usecases/ohpcf.go
@@ -2,6 +2,7 @@ package usecases
 
 import (
 	"errors"
+	"fmt"
 	"log"
 	"time"
 
@@ -199,16 +200,38 @@ func (w *OHPCFWrapper) MinimalPauseDuration(entity spineapi.EntityRemoteInterfac
 	return w.uc.PowerConsumptionMinimalPauseDuration(entity)
 }
 
-// logResult logs a non-zero SPINE result for an async OHPCF control command.
-func logResult(action string) func(model.ResultDataType) {
-	return func(r model.ResultDataType) {
+// ohpcfWriteTimeout bounds how long a control write waits for the heat pump's
+// result before giving up. It is a var, not a const, so tests can shorten it.
+var ohpcfWriteTimeout = 10 * time.Second
+
+// awaitWrite issues an OHPCF control write and blocks until the remote heat pump
+// returns its result, mapping a rejection or a missing result to an error. The
+// write closure must invoke the supplied callback exactly once with the device's
+// ResultDataType (eebus-go guarantees this for a successfully sent command).
+//
+// Without this the bridge would report success as soon as the command was *sent*,
+// masking a device-side rejection (e.g. an uncommissioned heat pump) from the HA
+// caller. Mirrors evcc's server/eebus.Await (evcc-io/evcc#31350).
+func awaitWrite(action string, write func(func(model.ResultDataType)) (*model.MsgCounterType, error)) error {
+	res := make(chan model.ResultDataType, 1)
+
+	if _, err := write(func(r model.ResultDataType) { res <- r }); err != nil {
+		return err
+	}
+
+	select {
+	case r := <-res:
 		if r.ErrorNumber != nil && uint(*r.ErrorNumber) != 0 {
-			desc := ""
-			if r.Description != nil {
-				desc = string(*r.Description)
+			err := fmt.Errorf("ohpcf %s rejected by device: error=%d", action, *r.ErrorNumber)
+			if r.Description != nil && *r.Description != "" {
+				err = fmt.Errorf("%w (%s)", err, *r.Description)
 			}
-			log.Printf("[OHPCF] %s rejected by device: error=%d %s", action, *r.ErrorNumber, desc)
+			log.Printf("[OHPCF] %v", err)
+			return err
 		}
+		return nil
+	case <-time.After(ohpcfWriteTimeout):
+		return fmt.Errorf("ohpcf %s: timed out waiting for device result", action)
 	}
 }
 
@@ -221,8 +244,9 @@ func (w *OHPCFWrapper) Schedule(entity spineapi.EntityRemoteInterface, start tim
 	if start.IsZero() {
 		start = time.Now()
 	}
-	_, err := w.uc.SchedulePowerConsumptionProcess(entity, start, logResult("schedule"))
-	return err
+	return awaitWrite("schedule", func(cb func(model.ResultDataType)) (*model.MsgCounterType, error) {
+		return w.uc.SchedulePowerConsumptionProcess(entity, start, cb)
+	})
 }
 
 // Pause pauses the running optional power-consumption process.
@@ -230,8 +254,9 @@ func (w *OHPCFWrapper) Pause(entity spineapi.EntityRemoteInterface) error {
 	if w.uc == nil {
 		return errOHPCFNotInitialized
 	}
-	_, err := w.uc.PausePowerConsumptionProcess(entity, logResult("pause"))
-	return err
+	return awaitWrite("pause", func(cb func(model.ResultDataType)) (*model.MsgCounterType, error) {
+		return w.uc.PausePowerConsumptionProcess(entity, cb)
+	})
 }
 
 // Resume resumes a paused optional power-consumption process.
@@ -239,8 +264,9 @@ func (w *OHPCFWrapper) Resume(entity spineapi.EntityRemoteInterface) error {
 	if w.uc == nil {
 		return errOHPCFNotInitialized
 	}
-	_, err := w.uc.ResumePowerConsumptionProcess(entity, logResult("resume"))
-	return err
+	return awaitWrite("resume", func(cb func(model.ResultDataType)) (*model.MsgCounterType, error) {
+		return w.uc.ResumePowerConsumptionProcess(entity, cb)
+	})
 }
 
 // Abort aborts the optional power-consumption process.
@@ -248,6 +274,7 @@ func (w *OHPCFWrapper) Abort(entity spineapi.EntityRemoteInterface) error {
 	if w.uc == nil {
 		return errOHPCFNotInitialized
 	}
-	_, err := w.uc.AbortPowerConsumptionProcess(entity, logResult("abort"))
-	return err
+	return awaitWrite("abort", func(cb func(model.ResultDataType)) (*model.MsgCounterType, error) {
+		return w.uc.AbortPowerConsumptionProcess(entity, cb)
+	})
 }

--- a/eebus-bridge/internal/usecases/ohpcf_await_test.go
+++ b/eebus-bridge/internal/usecases/ohpcf_await_test.go
@@ -1,0 +1,81 @@
+package usecases
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/enbility/spine-go/model"
+)
+
+func ptr[T any](v T) *T { return &v }
+
+// awaitWrite must return nil when the device replies with a zero (accepted) result.
+func TestAwaitWriteAccepted(t *testing.T) {
+	err := awaitWrite("schedule", func(cb func(model.ResultDataType)) (*model.MsgCounterType, error) {
+		cb(model.ResultDataType{}) // ErrorNumber nil == success
+		return ptr(model.MsgCounterType(1)), nil
+	})
+	if err != nil {
+		t.Fatalf("awaitWrite accepted = %v, want nil", err)
+	}
+}
+
+// awaitWrite must surface a device-side rejection (non-zero ErrorNumber) as an
+// error carrying the action, the error code, and the description.
+func TestAwaitWriteRejected(t *testing.T) {
+	err := awaitWrite("schedule", func(cb func(model.ResultDataType)) (*model.MsgCounterType, error) {
+		cb(model.ResultDataType{
+			ErrorNumber: ptr(model.ErrorNumberType(7)),
+			Description: ptr(model.DescriptionType("not commissioned")),
+		})
+		return ptr(model.MsgCounterType(1)), nil
+	})
+	if err == nil {
+		t.Fatal("awaitWrite rejected = nil, want error")
+	}
+	for _, want := range []string{"schedule", "7", "not commissioned"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q missing %q", err.Error(), want)
+		}
+	}
+}
+
+// A send-time failure (the write never reaches the device) must propagate verbatim
+// and must not block waiting for a result that will never arrive.
+func TestAwaitWriteSendError(t *testing.T) {
+	sentinel := errors.New("send failed")
+	called := false
+	err := awaitWrite("pause", func(cb func(model.ResultDataType)) (*model.MsgCounterType, error) {
+		_ = cb
+		called = true
+		return nil, sentinel
+	})
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("awaitWrite send error = %v, want %v", err, sentinel)
+	}
+	if !called {
+		t.Error("write closure was not invoked")
+	}
+}
+
+// If the device never returns a result, awaitWrite must time out instead of
+// blocking forever.
+func TestAwaitWriteTimeout(t *testing.T) {
+	prev := ohpcfWriteTimeout
+	ohpcfWriteTimeout = 20 * time.Millisecond
+	defer func() { ohpcfWriteTimeout = prev }()
+
+	start := time.Now()
+	err := awaitWrite("abort", func(cb func(model.ResultDataType)) (*model.MsgCounterType, error) {
+		_ = cb // never invoked: simulates an unresponsive device
+		return ptr(model.MsgCounterType(1)), nil
+	})
+	if err == nil || !strings.Contains(err.Error(), "timed out") {
+		t.Fatalf("awaitWrite timeout = %v, want timeout error", err)
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Errorf("awaitWrite blocked %v, expected ~timeout", elapsed)
+	}
+}


### PR DESCRIPTION
## Problem

OHPCF control writes (`Schedule`/`Pause`/`Resume`/`Abort`) returned as soon as the
command was **sent**. The heat pump's accept/reject result arrived later in a
fire-and-forget `logResult` callback that only logged. So HA's `CompressorFlexibility`
switch reported success even when the device rejected the command — the exact live
silent-failure seen against an uncommissioned VR940.

## Fix

Add `awaitWrite`: it blocks until the heat pump returns its `ResultDataType`, mapping a
non-zero `ErrorNumber` (or a missing result, 10s timeout) to an error. `ohpcf_service.go`
already wraps that error as a gRPC `Internal` status, so the rejection now reaches HA.

Mirrors evcc's `server/eebus.Await` (evcc-io/evcc#31350), found while reviewing evcc's
eebus history for portable improvements.

## Tests

White-box tests in `ohpcf_await_test.go` cover accept, reject (asserts action/code/
description surface), send-error (propagated verbatim, no block), and timeout (bounded).
Timeout is a `var` so tests run in ms. `go build`/`go vet`/full suite green.

## Notes

Control RPCs now block up to 10s awaiting device confirmation — intended; a control
write should confirm acceptance. No behavior change on the read/observe paths.
