### PR TITLE
fix(eebus): clear cached entity refs on disconnect

### DIFF
--- a/eebus-bridge/cmd/eebus-bridge/main.go
+++ b/eebus-bridge/cmd/eebus-bridge/main.go
@@ -56,6 +56,10 @@ func main() {
 		log.Fatalf("creating bridge service: %v", err)
 	}
 
+	// Let disconnect callbacks drop cached entity refs (set before service start,
+	// so no remote callback races the assignment).
+	bridgeSvc.Callbacks().SetRegistry(registry)
+
 	lpcWrapper := usecases.NewLPCWrapper(bus, registry, cfg.Logging.DebugEvents)
 	monitoringWrapper := usecases.NewMonitoringWrapper(bus, registry, cfg.Logging.DebugEvents)
 

--- a/eebus-bridge/internal/eebus/callbacks.go
+++ b/eebus-bridge/internal/eebus/callbacks.go
@@ -11,6 +11,7 @@ import (
 // Callbacks implements api.ServiceReaderInterface and dispatches events to the EventBus.
 type Callbacks struct {
 	bus            *EventBus
+	registry       *DeviceRegistry
 	mu             sync.RWMutex
 	discoveredSvcs []shipapi.RemoteMdnsService
 	debugEvents    bool
@@ -22,6 +23,13 @@ func NewCallbacks(bus *EventBus, debugEvents bool) *Callbacks {
 		bus:         bus,
 		debugEvents: debugEvents,
 	}
+}
+
+// SetRegistry attaches the device registry so disconnect events can drop cached
+// entity references. Call once at startup before the EEBUS service starts, so no
+// remote callback races the assignment.
+func (c *Callbacks) SetRegistry(registry *DeviceRegistry) {
+	c.registry = registry
 }
 
 // Compile-time assertion that Callbacks implements api.ServiceReaderInterface.
@@ -45,6 +53,12 @@ func (c *Callbacks) RemoteServiceDisconnected(_ api.ServiceInterface, identity s
 	ski := NormalizeSKI(identity.SKI)
 	if c.debugEvents {
 		log.Printf("[DEBUG] EEBUS callback: remote service disconnected: ski=%s", ski)
+	}
+
+	// Drop cached entity references so a later re-pair re-populates them from
+	// fresh observations instead of writing to an orphaned entity.
+	if c.registry != nil {
+		c.registry.ClearEntities(ski)
 	}
 
 	c.bus.Publish(Event{

--- a/eebus-bridge/internal/eebus/callbacks_test.go
+++ b/eebus-bridge/internal/eebus/callbacks_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	shipapi "github.com/enbility/ship-go/api"
+	spineapi "github.com/enbility/spine-go/api"
 	"github.com/volschin/eebus-bridge/internal/eebus"
 )
 
@@ -45,6 +46,30 @@ func TestCallbacksDispatchDisconnect(t *testing.T) {
 		}
 	case <-time.After(time.Second):
 		t.Fatal("timeout")
+	}
+}
+
+func TestCallbacksDisconnectClearsCachedEntities(t *testing.T) {
+	bus := eebus.NewEventBus()
+	reg := eebus.NewDeviceRegistry()
+	reg.AddDevice("test-ski-456", eebus.DeviceInfo{
+		Brand:          "Vaillant",
+		RemoteEntities: []spineapi.EntityRemoteInterface{nil},
+	})
+
+	cb := eebus.NewCallbacks(bus, false)
+	cb.SetRegistry(reg)
+	cb.RemoteServiceDisconnected(nil, shipapi.ServiceIdentity{SKI: "test-ski-456"})
+
+	info, ok := reg.GetDevice("test-ski-456")
+	if !ok {
+		t.Fatal("device metadata removed on disconnect; only entities should be cleared")
+	}
+	if len(info.RemoteEntities) != 0 {
+		t.Errorf("cached entities not cleared on disconnect: got %d", len(info.RemoteEntities))
+	}
+	if info.Brand != "Vaillant" {
+		t.Error("classification metadata must survive disconnect")
 	}
 }
 

--- a/eebus-bridge/internal/eebus/registry.go
+++ b/eebus-bridge/internal/eebus/registry.go
@@ -132,6 +132,27 @@ func (r *DeviceRegistry) RemoveDevice(ski string) {
 	r.mu.Unlock()
 }
 
+// ClearEntities drops the cached remote-device and remote-entity references for a
+// SKI on disconnect while keeping the discovered classification metadata
+// (brand/model/serial/type) and use-case list. Without this the registry would
+// keep serving stale EntityRemoteInterface pointers after a SHIP/SPINE
+// reconnect, so a subsequent OHPCF/LPC write would target an orphaned entity
+// instead of the one re-negotiated on re-pair. A later UseCaseEvent re-populates
+// the entities from fresh observations (cf. evcc-io/evcc#29628). No-op when the
+// SKI is unknown.
+func (r *DeviceRegistry) ClearEntities(ski string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	ski = NormalizeSKI(ski)
+	info, ok := r.devices[ski]
+	if !ok {
+		return
+	}
+	info.RemoteDevice = nil
+	info.RemoteEntities = nil
+	r.devices[ski] = info
+}
+
 func (r *DeviceRegistry) GetDevice(ski string) (DeviceInfo, bool) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()

--- a/eebus-bridge/internal/eebus/registry_test.go
+++ b/eebus-bridge/internal/eebus/registry_test.go
@@ -3,6 +3,7 @@ package eebus_test
 import (
 	"testing"
 
+	spineapi "github.com/enbility/spine-go/api"
 	"github.com/volschin/eebus-bridge/internal/eebus"
 )
 
@@ -32,6 +33,43 @@ func TestRegistryRemove(t *testing.T) {
 	_, ok := reg.GetDevice("ski-123")
 	if ok {
 		t.Error("device should have been removed")
+	}
+}
+
+func TestRegistryClearEntities(t *testing.T) {
+	reg := eebus.NewDeviceRegistry()
+	reg.AddDevice("ski-c", eebus.DeviceInfo{
+		Brand:          "Vaillant",
+		Model:          "VR940f",
+		UseCases:       []string{"ohpcf"},
+		RemoteEntities: []spineapi.EntityRemoteInterface{nil},
+	})
+
+	reg.ClearEntities("ski-c")
+
+	info, ok := reg.GetDevice("ski-c")
+	if !ok {
+		t.Fatal("device gone after ClearEntities; classification metadata must survive")
+	}
+	if len(info.RemoteEntities) != 0 {
+		t.Errorf("RemoteEntities = %d, want 0 (cleared)", len(info.RemoteEntities))
+	}
+	if info.RemoteDevice != nil {
+		t.Error("RemoteDevice not cleared")
+	}
+	if info.Brand != "Vaillant" || info.Model != "VR940f" {
+		t.Error("classification metadata must be preserved across disconnect")
+	}
+	if len(info.UseCases) != 1 {
+		t.Errorf("UseCases = %d, want 1 (preserved)", len(info.UseCases))
+	}
+}
+
+func TestRegistryClearEntitiesUnknownSKI(t *testing.T) {
+	reg := eebus.NewDeviceRegistry()
+	reg.ClearEntities("never-seen") // must not panic nor create an entry
+	if _, ok := reg.GetDevice("never-seen"); ok {
+		t.Error("ClearEntities must not create an entry for an unknown SKI")
 	}
 }
 


### PR DESCRIPTION
## Problem

`DeviceRegistry` cached `RemoteEntities`/`RemoteDevice` pointers indefinitely, and
`RemoteServiceDisconnected` only published a `device.disconnected` event. After a
SHIP/SPINE reconnect the registry kept serving stale `EntityRemoteInterface` pointers,
so an OHPCF/LPC write targeted an orphaned entity instead of the re-negotiated one.
This is the likely cause behind the "bridge restart drops trust → reload the HA
integration" symptom.

## Fix

Add `DeviceRegistry.ClearEntities(ski)`: it drops the device/entity pointers but keeps
the classification metadata (brand/model/serial/type) and the use-case list, so HA
device info survives and a later `UseCaseEvent` re-populates the entities from fresh
observations. Wired into the disconnect callback via a registry reference set once at
startup (before the EEBUS service starts, so no remote callback races the assignment).

Mirrors evcc's `meter: clear cached entity refs on disconnect` (evcc-io/evcc#29628),
found while reviewing evcc's eebus history.

## Tests

- `ClearEntities`: asserts entity/device pointers cleared while metadata + use-cases
  preserved; unknown-SKI is a no-op that creates no entry.
- Disconnect callback path: `RemoteServiceDisconnected` clears cached entities yet keeps
  device metadata.

`go build`/`go vet`/full suite green with `-race`.
