### PR TITLE
refactor(eebus): name MGCP/VAPD/VABD scenario numbers

### DIFF
--- a/eebus-bridge/internal/usecases/mgcp.go
+++ b/eebus-bridge/internal/usecases/mgcp.go
@@ -18,6 +18,15 @@ import (
 // such as the Vaillant VR940 discovers and binds to our grid-connection-point).
 const mgcpUseCaseSupportUpdate eebusapi.EventType = "bridge-mgcp-provider-support-update"
 
+// MGCP scenario numbers (UseCaseScenarioSupportType). Scenario indices are
+// use-case-scoped per the EEBUS UC spec — the same integer means different things
+// in another use case — so name them here rather than passing magic numbers.
+const (
+	mgcpScenarioMomentaryPower model.UseCaseScenarioSupportType = 2 // momentary AC total power at the grid connection point
+	mgcpScenarioFeedInEnergy   model.UseCaseScenarioSupportType = 3 // total energy fed into the grid (export)
+	mgcpScenarioConsumedEnergy model.UseCaseScenarioSupportType = 4 // total energy consumed from the grid (import)
+)
+
 var errMGCPNotInitialized = errors.New("mgcp provider not initialized")
 
 // MGCPProvider is a SPIKE provider implementation of the EEBUS "Monitoring of Grid
@@ -62,9 +71,9 @@ func NewMGCPProvider(gridEntity spineapi.EntityLocalInterface, bus *eebus.EventB
 		model.FeatureTypeTypeElectricalConnection,
 	}
 	scenarios := []eebusapi.UseCaseScenario{
-		{Scenario: model.UseCaseScenarioSupportType(2), Mandatory: true, ServerFeatures: mandatoryFeatures},
-		{Scenario: model.UseCaseScenarioSupportType(3), Mandatory: true, ServerFeatures: mandatoryFeatures},
-		{Scenario: model.UseCaseScenarioSupportType(4), Mandatory: true, ServerFeatures: mandatoryFeatures},
+		{Scenario: mgcpScenarioMomentaryPower, Mandatory: true, ServerFeatures: mandatoryFeatures},
+		{Scenario: mgcpScenarioFeedInEnergy, Mandatory: true, ServerFeatures: mandatoryFeatures},
+		{Scenario: mgcpScenarioConsumedEnergy, Mandatory: true, ServerFeatures: mandatoryFeatures},
 	}
 
 	p.UseCaseBase = usecase.NewUseCaseBase(

--- a/eebus-bridge/internal/usecases/vabd.go
+++ b/eebus-bridge/internal/usecases/vabd.go
@@ -18,6 +18,16 @@ import (
 // local battery system.
 const vabdUseCaseSupportUpdate eebusapi.EventType = "bridge-vabd-provider-support-update"
 
+// VABD scenario numbers (UseCaseScenarioSupportType). Scenario indices are
+// use-case-scoped per the EEBUS UC spec, so name them rather than passing magic
+// numbers into the scenario declarations.
+const (
+	vabdScenarioMomentaryPower   model.UseCaseScenarioSupportType = 1 // momentary total AC power at the battery
+	vabdScenarioChargedEnergy    model.UseCaseScenarioSupportType = 2 // total energy charged into the battery
+	vabdScenarioDischargedEnergy model.UseCaseScenarioSupportType = 3 // total energy discharged from the battery
+	vabdScenarioStateOfCharge    model.UseCaseScenarioSupportType = 4 // state of charge as a percentage
+)
+
 var errVABDNotInitialized = errors.New("vabd provider not initialized")
 
 // VABDProvider is a SPIKE provider implementation of the EEBUS "Visualization of
@@ -62,10 +72,10 @@ func NewVABDProvider(batteryEntity spineapi.EntityLocalInterface, bus *eebus.Eve
 		model.FeatureTypeTypeElectricalConnection,
 	}
 	scenarios := []eebusapi.UseCaseScenario{
-		{Scenario: model.UseCaseScenarioSupportType(1), Mandatory: true, ServerFeatures: measFeatures},
-		{Scenario: model.UseCaseScenarioSupportType(2), ServerFeatures: measFeatures},
-		{Scenario: model.UseCaseScenarioSupportType(3), ServerFeatures: measFeatures},
-		{Scenario: model.UseCaseScenarioSupportType(4), Mandatory: true, ServerFeatures: measFeatures},
+		{Scenario: vabdScenarioMomentaryPower, Mandatory: true, ServerFeatures: measFeatures},
+		{Scenario: vabdScenarioChargedEnergy, ServerFeatures: measFeatures},
+		{Scenario: vabdScenarioDischargedEnergy, ServerFeatures: measFeatures},
+		{Scenario: vabdScenarioStateOfCharge, Mandatory: true, ServerFeatures: measFeatures},
 	}
 
 	p.UseCaseBase = usecase.NewUseCaseBase(

--- a/eebus-bridge/internal/usecases/vapd.go
+++ b/eebus-bridge/internal/usecases/vapd.go
@@ -18,6 +18,15 @@ import (
 // local PV system.
 const vapdUseCaseSupportUpdate eebusapi.EventType = "bridge-vapd-provider-support-update"
 
+// VAPD scenario numbers (UseCaseScenarioSupportType). Scenario indices are
+// use-case-scoped per the EEBUS UC spec, so name them rather than passing magic
+// numbers into the scenario declarations.
+const (
+	vapdScenarioPeakPower      model.UseCaseScenarioSupportType = 1 // nominal peak power of the PV system (DeviceConfiguration)
+	vapdScenarioMomentaryPower model.UseCaseScenarioSupportType = 2 // momentary total AC power produced by the PV system
+	vapdScenarioYieldEnergy    model.UseCaseScenarioSupportType = 3 // total AC yield energy produced over the system's lifetime
+)
+
 var errVAPDNotInitialized = errors.New("vapd provider not initialized")
 
 // VAPDProvider is a SPIKE provider implementation of the EEBUS "Visualization of
@@ -61,9 +70,9 @@ func NewVAPDProvider(pvEntity spineapi.EntityLocalInterface, bus *eebus.EventBus
 		model.FeatureTypeTypeElectricalConnection,
 	}
 	scenarios := []eebusapi.UseCaseScenario{
-		{Scenario: model.UseCaseScenarioSupportType(1), Mandatory: true, ServerFeatures: []model.FeatureTypeType{model.FeatureTypeTypeDeviceConfiguration}},
-		{Scenario: model.UseCaseScenarioSupportType(2), Mandatory: true, ServerFeatures: measFeatures},
-		{Scenario: model.UseCaseScenarioSupportType(3), Mandatory: true, ServerFeatures: measFeatures},
+		{Scenario: vapdScenarioPeakPower, Mandatory: true, ServerFeatures: []model.FeatureTypeType{model.FeatureTypeTypeDeviceConfiguration}},
+		{Scenario: vapdScenarioMomentaryPower, Mandatory: true, ServerFeatures: measFeatures},
+		{Scenario: vapdScenarioYieldEnergy, Mandatory: true, ServerFeatures: measFeatures},
 	}
 
 	p.UseCaseBase = usecase.NewUseCaseBase(


### PR DESCRIPTION
Third evcc-inspired improvement (evcc PR #29701). Pure readability/safety hardening — no behaviour change.

## Problem
Provider use-case declarations passed bare `model.UseCaseScenarioSupportType(N)` literals. Scenario indices are **use-case-scoped** per the EEBUS UC spec — the same integer means a different thing in another use case (e.g. MGCP S2 = momentary grid power vs VABD S2 = charged energy). Magic numbers make cross-use-case index mixups easy and silent.

## Change
Named constants per use case, used in the scenario slices:
- **MGCP** — `mgcpScenarioMomentaryPower` (2), `…FeedInEnergy` (3), `…ConsumedEnergy` (4)
- **VAPD** — `vapdScenarioPeakPower` (1), `…MomentaryPower` (2), `…YieldEnergy` (3)
- **VABD** — `vabdScenarioMomentaryPower` (1), `…ChargedEnergy` (2), `…DischargedEnergy` (3), `…StateOfCharge` (4)

LPC/OHPCF iterate `RemoteEntitiesScenarios()` and use no literals — untouched.

## Verify
`go build ./...`, `go vet ./internal/usecases/`, `go test ./internal/usecases/` all green.