### PR TITLE
chore: add uv.lock

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,3 @@
+version = 1
+revision = 3
+requires-python = ">=3.13"


### PR DESCRIPTION
Adds the uv lockfile so `uv` resolves reproducibly. Pins format (v1) and requires-python floor (>=3.13); no dependencies resolved yet (pyproject declares none). Was untracked in the working tree.