### PR TITLE
fix(ohpcf): surface control rejections as HomeAssistantError

### DIFF
--- a/custom_components/eebus/coordinator.py
+++ b/custom_components/eebus/coordinator.py
@@ -20,6 +20,7 @@ from homeassistant.const import (
     UnitOfPower,
 )
 from homeassistant.core import Event, HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.event import async_track_state_change_event
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
@@ -806,7 +807,12 @@ class EebusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     "OHPCF control unsupported for SKI %s: %s", self.ski, err.details()
                 )
                 return
-            raise
+            # Surface device-side rejections (e.g. "data not available" when the
+            # compressor advertises no writable offer) as a clean HA error instead
+            # of bubbling a raw AioRpcError into an aiohttp 500 traceback.
+            raise HomeAssistantError(
+                f"Compressor flexibility control failed: {err.details()}"
+            ) from err
 
     async def async_start_heartbeat(self) -> None:
         """Start EEBUS heartbeat via gRPC."""

--- a/custom_components/eebus/tests/test_ohpcf.py
+++ b/custom_components/eebus/tests/test_ohpcf.py
@@ -2,10 +2,12 @@
 
 import asyncio
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 import grpc
+import pytest
 from grpc.aio import AioRpcError, Metadata
+from homeassistant.exceptions import HomeAssistantError
 
 from custom_components.eebus import proto_stubs
 from custom_components.eebus.coordinator import EebusCoordinator
@@ -110,3 +112,37 @@ def test_switch_turn_off_pauses_or_aborts():
     sw.coordinator.async_control_compressor.assert_awaited_once_with(
         proto_stubs.OHPCFAction.OHPCF_ACTION_ABORT
     )
+
+
+def test_control_compressor_wraps_rpc_error_as_ha_error():
+    """A device-side control rejection surfaces as HomeAssistantError, not a raw 500."""
+    c = _coordinator()
+    c._ensure_channel = AsyncMock(return_value=None)
+    err = AioRpcError(
+        grpc.StatusCode.INTERNAL,
+        Metadata(),
+        Metadata(),
+        details="ohpcf control: data not available",
+    )
+    stub = SimpleNamespace(ControlCompressorFlexibility=AsyncMock(side_effect=err))
+    with patch.object(proto_stubs, "OHPCFServiceStub", lambda _channel: stub):
+        with pytest.raises(HomeAssistantError) as exc:
+            asyncio.run(
+                c.async_control_compressor(proto_stubs.OHPCFAction.OHPCF_ACTION_SCHEDULE)
+            )
+    assert "data not available" in str(exc.value)
+
+
+def test_control_compressor_unimplemented_is_swallowed():
+    """UNIMPLEMENTED marks OHPCF unsupported and returns without raising."""
+    c = _coordinator()
+    c._ensure_channel = AsyncMock(return_value=None)
+    err = AioRpcError(
+        grpc.StatusCode.UNIMPLEMENTED, Metadata(), Metadata(), details="no ohpcf"
+    )
+    stub = SimpleNamespace(ControlCompressorFlexibility=AsyncMock(side_effect=err))
+    with patch.object(proto_stubs, "OHPCFServiceStub", lambda _channel: stub):
+        asyncio.run(
+            c.async_control_compressor(proto_stubs.OHPCFAction.OHPCF_ACTION_PAUSE)
+        )
+    assert c._ohpcf_supported is False


### PR DESCRIPTION
## Problem
Live test: toggling the compressor-flexibility switch ON when heating-side OHPCF isn't commissioned in myVAILLANT made the bridge return gRPC `ohpcf control: data not available`. `coordinator.async_control_compressor` re-raised the raw `AioRpcError`, which HA rendered as an ugly `aiohttp.server` **500 traceback** instead of a user-facing failure.

```
File "custom_components/eebus/switch.py", line 157, in async_turn_on
File "custom_components/eebus/coordinator.py", line 798, in async_control_compressor
grpc.aio._call.AioRpcError: ... details = "ohpcf control: data not available"
```

## Change
Wrap non-`UNIMPLEMENTED` control errors in `HomeAssistantError` (with the device's detail string) so switch turn_on/off shows a clean notification. `UNIMPLEMENTED` still marks the use case unsupported and returns silently — unchanged.

Builds on #73 (await pattern), which is what makes these device rejections reach HA at all.

## Tests
- `test_control_compressor_wraps_rpc_error_as_ha_error` — INTERNAL "data not available" → `HomeAssistantError`
- `test_control_compressor_unimplemented_is_swallowed` — UNIMPLEMENTED → no raise, `_ohpcf_supported=False`
- Full suite: 51 passed; ruff clean.