### PR TITLE
fix(ohpcf): raise ServiceValidationError for control rejections (HTTP 400)

### DIFF
--- a/custom_components/eebus/coordinator.py
+++ b/custom_components/eebus/coordinator.py
@@ -20,7 +20,7 @@ from homeassistant.const import (
     UnitOfPower,
 )
 from homeassistant.core import Event, HomeAssistant
-from homeassistant.exceptions import HomeAssistantError
+from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers.event import async_track_state_change_event
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
@@ -808,9 +808,10 @@ class EebusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 )
                 return
             # Surface device-side rejections (e.g. "data not available" when the
-            # compressor advertises no writable offer) as a clean HA error instead
+            # compressor advertises no writable offer — heating-side OHPCF not yet
+            # commissioned) as a clean validation error (HTTP 400 + message) instead
             # of bubbling a raw AioRpcError into an aiohttp 500 traceback.
-            raise HomeAssistantError(
+            raise ServiceValidationError(
                 f"Compressor flexibility control failed: {err.details()}"
             ) from err
 

--- a/custom_components/eebus/tests/test_ohpcf.py
+++ b/custom_components/eebus/tests/test_ohpcf.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, patch
 import grpc
 import pytest
 from grpc.aio import AioRpcError, Metadata
-from homeassistant.exceptions import HomeAssistantError
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 
 from custom_components.eebus import proto_stubs
 from custom_components.eebus.coordinator import EebusCoordinator
@@ -114,8 +114,8 @@ def test_switch_turn_off_pauses_or_aborts():
     )
 
 
-def test_control_compressor_wraps_rpc_error_as_ha_error():
-    """A device-side control rejection surfaces as HomeAssistantError, not a raw 500."""
+def test_control_compressor_wraps_rpc_error_as_validation_error():
+    """A device-side control rejection surfaces as ServiceValidationError (HTTP 400)."""
     c = _coordinator()
     c._ensure_channel = AsyncMock(return_value=None)
     err = AioRpcError(
@@ -126,10 +126,12 @@ def test_control_compressor_wraps_rpc_error_as_ha_error():
     )
     stub = SimpleNamespace(ControlCompressorFlexibility=AsyncMock(side_effect=err))
     with patch.object(proto_stubs, "OHPCFServiceStub", lambda _channel: stub):
-        with pytest.raises(HomeAssistantError) as exc:
+        with pytest.raises(ServiceValidationError) as exc:
             asyncio.run(
                 c.async_control_compressor(proto_stubs.OHPCFAction.OHPCF_ACTION_SCHEDULE)
             )
+    # ServiceValidationError is a HomeAssistantError subclass; message carries the detail.
+    assert isinstance(exc.value, HomeAssistantError)
     assert "data not available" in str(exc.value)
 
 


### PR DESCRIPTION
Follow-up to #77.

`HomeAssistantError` thrown from a service handler still renders as a generic **aiohttp 500** on the raw REST `/api/services` path (confirmed on the live deploy). `ServiceValidationError` — a `HomeAssistantError` subclass — maps to **HTTP 400 + the message**, and semantically fits: the compressor advertises no writable OHPCF offer until heating-side flexibility is commissioned in myVAILLANT (a usage/state gate, not a server fault).

UI toast behaviour unchanged (still shows the message). Test updated to assert `ServiceValidationError` (and that it remains a `HomeAssistantError`). 7 ohpcf tests pass, ruff clean.