### PR TITLE
Replace OHPCF compressor switch with 3-state select

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,7 +61,7 @@ docker-compose up -d eebus-bridge        # ghcr.io image, host networking
 
 ### Python integration
 - `coordinator.py` (`EebusCoordinator`) — central hub. Primary path is gRPC **streaming** (push); on stream failure it falls back to **polling** (`POLL_INTERVAL = 5min`) and reconnects the stream in the background. Polling only reconciles state streams can't carry (scoped energy, heartbeat, support flags). `FLAT_MEASUREMENT_TYPE_TO_KEY` maps bridge `GetMeasurements` entry types to per-phase/grid sensor keys.
-- Platforms: `sensor`, `number`, `switch`, `binary_sensor` — all read coordinator data; `entity.py` is the shared base.
+- Platforms: `sensor`, `number`, `switch`, `select`, `binary_sensor` — all read coordinator data; `entity.py` is the shared base. `select.eebus_compressor_flexibility` exposes OHPCF's `on`/`paused`/`off` as three distinct options — a plain switch collapses PAUSED into the same state as AVAILABLE/COMPLETED/STOPPED, losing the running-vs-stopped distinction.
 - `config_flow.py` — bridge host/port + device SKI pairing. `iot_class: local_push`, `quality_scale: gold` (see `quality_scale.yaml`).
 - Tests use HA fixtures in `conftest.py`; protobuf messages must be real generated types, not duck-typed namespaces.
 

--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Die Integration nutzt **gRPC Streaming** (Server-Sent Events) fuer Echtzeit-Upda
 | `number.eebus_failsafe_limit` | number | Failsafe-Grenze (W), standardmaessig deaktiviert |
 | `switch.eebus_lpc_active` | switch | Limit aktivieren/deaktivieren |
 | `switch.eebus_heartbeat` | switch | Heartbeat an/aus, standardmaessig deaktiviert |
+| `select.eebus_compressor_flexibility` | select | OHPCF-Verdichter-Flexibilitaet: `on`/`paused`/`off`, nur vorhanden wenn WP ein Angebot meldet (experimentell) |
 
 ### Diagnose
 
@@ -122,6 +123,8 @@ Die Integration nutzt **gRPC Streaming** (Server-Sent Events) fuer Echtzeit-Upda
 |--------|-----|-------------|
 | `binary_sensor.eebus_connected` | binary_sensor | EEBUS-Verbindungsstatus |
 | `binary_sensor.eebus_heartbeat_ok` | binary_sensor | Heartbeat innerhalb Toleranz, standardmaessig deaktiviert |
+| `sensor.eebus_compressor_flexibility_power_estimate` | sensor | OHPCF geschaetzte Leistung des Angebots (W), standardmaessig deaktiviert |
+| `sensor.eebus_compressor_flexibility_power_max` | sensor | OHPCF maximale Leistung des Angebots (W), standardmaessig deaktiviert |
 
 ## Unterstuetzte Geraete
 

--- a/custom_components/eebus/const.py
+++ b/custom_components/eebus/const.py
@@ -33,6 +33,7 @@ CONF_BATTERY_SOC_ENTITY = "battery_soc_entity"
 PLATFORMS = [
     Platform.BINARY_SENSOR,
     Platform.NUMBER,
+    Platform.SELECT,
     Platform.SENSOR,
     Platform.SWITCH,
 ]

--- a/custom_components/eebus/select.py
+++ b/custom_components/eebus/select.py
@@ -1,0 +1,116 @@
+"""Select entities for EEBUS integration."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.select import SelectEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .coordinator import EebusCoordinator
+from .entity import EebusEntity
+
+PARALLEL_UPDATES = 0  # Coordinator-based, no per-entity polling
+
+# Compressor-flexibility process states that count as "on" (consuming or about to).
+_OHPCF_ON_STATES = {"COMPRESSOR_STATE_RUNNING", "COMPRESSOR_STATE_SCHEDULED"}
+_OHPCF_PAUSED_STATE = "COMPRESSOR_STATE_PAUSED"
+
+OPTION_ON = "on"
+OPTION_PAUSED = "paused"
+OPTION_OFF = "off"
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up EEBUS select entities."""
+    coordinator: EebusCoordinator = entry.runtime_data
+    entities: list[SelectEntity] = []
+    # OHPCF compressor-flexibility control is only offered when the bridge's OHPCF
+    # client is active and a compatible heat pump was found.
+    if coordinator.data and coordinator.data.get("ohpcf_supported"):
+        entities.append(EebusCompressorFlexibilitySelect(coordinator))
+    async_add_entities(entities)
+
+
+class EebusCompressorFlexibilitySelect(EebusEntity, SelectEntity):
+    """Select driving the heat-pump compressor's optional power consumption (OHPCF).
+
+    A plain on/off switch collapses PAUSED into "off" alongside AVAILABLE,
+    COMPLETED and STOPPED, losing the distinction between a paused and a
+    stopped process. This select exposes it as a third option instead.
+
+    on     = schedule (or resume) the optional consumption to soak up PV surplus.
+    paused = pause the running process.
+    off    = abort the process (or the implicit state when no offer is running).
+
+    Gold: translation_key, entity_category CONFIG.
+    """
+
+    _attr_translation_key = "compressor_flexibility"
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_options = [OPTION_ON, OPTION_PAUSED, OPTION_OFF]
+
+    def __init__(self, coordinator: EebusCoordinator) -> None:
+        """Initialize."""
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{coordinator.ski}_compressor_flexibility"
+
+    def _flex(self) -> dict[str, Any] | None:
+        if self.coordinator.data is None:
+            return None
+        return self.coordinator.data.get("compressor_flexibility")
+
+    @property
+    def available(self) -> bool:
+        """Available only while the compressor advertises a flexibility offer."""
+        return super().available and self._flex() is not None
+
+    @property
+    def current_option(self) -> str | None:
+        """Return on/paused/off depending on the process state."""
+        flex = self._flex()
+        if flex is None:
+            return None
+        state = flex.get("state")
+        if state in _OHPCF_ON_STATES:
+            return OPTION_ON
+        if state == _OHPCF_PAUSED_STATE:
+            return OPTION_PAUSED
+        return OPTION_OFF
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any] | None:
+        """Expose the process constraints the CEM must honour once it acts."""
+        flex = self._flex()
+        if flex is None:
+            return None
+        return {
+            "is_stoppable": flex.get("is_stoppable"),
+            "minimal_run_seconds": flex.get("minimal_run_seconds"),
+            "minimal_pause_seconds": flex.get("minimal_pause_seconds"),
+        }
+
+    async def async_select_option(self, option: str) -> None:
+        """Schedule/resume, pause, or abort the optional power consumption."""
+        from . import proto_stubs
+
+        flex = self._flex() or {}
+        if option == OPTION_ON:
+            action = (
+                proto_stubs.OHPCFAction.OHPCF_ACTION_RESUME
+                if flex.get("state") == _OHPCF_PAUSED_STATE
+                else proto_stubs.OHPCFAction.OHPCF_ACTION_SCHEDULE
+            )
+        elif option == OPTION_PAUSED:
+            action = proto_stubs.OHPCFAction.OHPCF_ACTION_PAUSE
+        else:
+            action = proto_stubs.OHPCFAction.OHPCF_ACTION_ABORT
+        await self.coordinator.async_control_compressor(action)
+        await self.coordinator.async_request_refresh()

--- a/custom_components/eebus/sensor.py
+++ b/custom_components/eebus/sensor.py
@@ -172,6 +172,7 @@ async def async_setup_entry(
         EebusConsumptionLimitSensor(coordinator),
         EebusFailsafeLimitSensor(coordinator),
         EebusFailsafeDurationSensor(coordinator),
+        EebusCompressorFlexibilityStatusSensor(coordinator),
         EebusCompressorFlexibilityPowerEstimateSensor(coordinator),
         EebusCompressorFlexibilityPowerMaxSensor(coordinator),
     ]
@@ -390,6 +391,57 @@ class EebusFailsafeDurationSensor(EebusEntity, SensorEntity):
         if failsafe is None:
             return None
         return failsafe.get("duration_minimum_seconds")
+
+
+_OHPCF_STATUS_OPTIONS = [
+    "available",
+    "scheduled",
+    "running",
+    "paused",
+    "completed",
+    "stopped",
+]
+_OHPCF_STATE_PREFIX = "COMPRESSOR_STATE_"
+
+
+class EebusCompressorFlexibilityStatusSensor(EebusEntity, SensorEntity):
+    """Diagnostic sensor for the OHPCF compressor's raw process status.
+
+    The compressor_flexibility select folds five of the six process states
+    into on/paused/off for control purposes; this exposes the raw state
+    (available/scheduled/running/paused/completed/stopped) for visibility.
+    """
+
+    _attr_device_class = SensorDeviceClass.ENUM
+    _attr_options = _OHPCF_STATUS_OPTIONS
+    _attr_translation_key = "compressor_flexibility_status"
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(self, coordinator: EebusCoordinator) -> None:
+        """Initialize."""
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{coordinator.ski}_compressor_flexibility_status"
+
+    @property
+    def available(self) -> bool:
+        """Available only while the compressor advertises a flexibility offer."""
+        if not super().available:
+            return False
+        if self.coordinator.data is None:
+            return False
+        return self.coordinator.data.get("compressor_flexibility") is not None
+
+    @property
+    def native_value(self) -> str | None:
+        """Return the raw process state, lower-cased and without the enum prefix."""
+        if self.coordinator.data is None:
+            return None
+        flex = self.coordinator.data.get("compressor_flexibility")
+        if flex is None:
+            return None
+        state = flex.get("state", "")
+        option = state.removeprefix(_OHPCF_STATE_PREFIX).lower()
+        return option if option in _OHPCF_STATUS_OPTIONS else None
 
 
 class EebusCompressorFlexibilityPowerEstimateSensor(EebusEntity, SensorEntity):

--- a/custom_components/eebus/sensor.py
+++ b/custom_components/eebus/sensor.py
@@ -172,6 +172,8 @@ async def async_setup_entry(
         EebusConsumptionLimitSensor(coordinator),
         EebusFailsafeLimitSensor(coordinator),
         EebusFailsafeDurationSensor(coordinator),
+        EebusCompressorFlexibilityPowerEstimateSensor(coordinator),
+        EebusCompressorFlexibilityPowerMaxSensor(coordinator),
     ]
     entities.extend(
         EebusMeasurementSensor(coordinator, description)
@@ -388,3 +390,78 @@ class EebusFailsafeDurationSensor(EebusEntity, SensorEntity):
         if failsafe is None:
             return None
         return failsafe.get("duration_minimum_seconds")
+
+
+class EebusCompressorFlexibilityPowerEstimateSensor(EebusEntity, SensorEntity):
+    """Diagnostic sensor for the OHPCF compressor's estimated optional power draw.
+
+    Read by the coordinator alongside the flexibility state used to drive the
+    compressor_flexibility select, but otherwise unused; surfaced here so the
+    offer's power estimate isn't silently discarded.
+    """
+
+    _attr_device_class = SensorDeviceClass.POWER
+    _attr_native_unit_of_measurement = UnitOfPower.WATT
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_translation_key = "compressor_flexibility_power_estimate"
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_entity_registry_enabled_default = False
+
+    def __init__(self, coordinator: EebusCoordinator) -> None:
+        """Initialize."""
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{coordinator.ski}_compressor_flexibility_power_estimate"
+
+    @property
+    def available(self) -> bool:
+        """Available only while the compressor advertises a flexibility offer."""
+        if not super().available:
+            return False
+        if self.coordinator.data is None:
+            return False
+        return self.coordinator.data.get("compressor_flexibility") is not None
+
+    @property
+    def native_value(self) -> float | None:
+        """Return the offer's estimated power draw in watts."""
+        if self.coordinator.data is None:
+            return None
+        flex = self.coordinator.data.get("compressor_flexibility")
+        if flex is None:
+            return None
+        return flex.get("requested_power_estimate_w")
+
+
+class EebusCompressorFlexibilityPowerMaxSensor(EebusEntity, SensorEntity):
+    """Diagnostic sensor for the OHPCF compressor's maximum optional power draw."""
+
+    _attr_device_class = SensorDeviceClass.POWER
+    _attr_native_unit_of_measurement = UnitOfPower.WATT
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_translation_key = "compressor_flexibility_power_max"
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_entity_registry_enabled_default = False
+
+    def __init__(self, coordinator: EebusCoordinator) -> None:
+        """Initialize."""
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{coordinator.ski}_compressor_flexibility_power_max"
+
+    @property
+    def available(self) -> bool:
+        """Available only while the compressor advertises a flexibility offer."""
+        if not super().available:
+            return False
+        if self.coordinator.data is None:
+            return False
+        return self.coordinator.data.get("compressor_flexibility") is not None
+
+    @property
+    def native_value(self) -> float | None:
+        """Return the offer's maximum power draw in watts."""
+        if self.coordinator.data is None:
+            return None
+        flex = self.coordinator.data.get("compressor_flexibility")
+        if flex is None:
+            return None
+        return flex.get("requested_power_max_w")

--- a/custom_components/eebus/strings.json
+++ b/custom_components/eebus/strings.json
@@ -91,16 +91,27 @@
       "frequency": { "name": "Grid Frequency" },
       "energy_produced": { "name": "Energy Produced" },
       "failsafe_limit": { "name": "Failsafe Limit" },
-      "failsafe_duration": { "name": "Failsafe Minimum Duration" }
+      "failsafe_duration": { "name": "Failsafe Minimum Duration" },
+      "compressor_flexibility_power_estimate": { "name": "Compressor Flexibility Power Estimate" },
+      "compressor_flexibility_power_max": { "name": "Compressor Flexibility Power Max" }
     },
     "number": {
       "lpc_limit": { "name": "LPC Limit" },
       "failsafe_limit": { "name": "Failsafe Limit" }
     },
+    "select": {
+      "compressor_flexibility": {
+        "name": "Compressor Flexibility",
+        "state": {
+          "on": "On",
+          "paused": "Paused",
+          "off": "Off"
+        }
+      }
+    },
     "switch": {
       "lpc_active": { "name": "LPC Active" },
-      "heartbeat": { "name": "Heartbeat" },
-      "compressor_flexibility": { "name": "Compressor Flexibility" }
+      "heartbeat": { "name": "Heartbeat" }
     },
     "binary_sensor": {
       "connected": { "name": "Connected" },

--- a/custom_components/eebus/strings.json
+++ b/custom_components/eebus/strings.json
@@ -92,6 +92,17 @@
       "energy_produced": { "name": "Energy Produced" },
       "failsafe_limit": { "name": "Failsafe Limit" },
       "failsafe_duration": { "name": "Failsafe Minimum Duration" },
+      "compressor_flexibility_status": {
+        "name": "Compressor Flexibility Status",
+        "state": {
+          "available": "Available",
+          "scheduled": "Scheduled",
+          "running": "Running",
+          "paused": "Paused",
+          "completed": "Completed",
+          "stopped": "Stopped"
+        }
+      },
       "compressor_flexibility_power_estimate": { "name": "Compressor Flexibility Power Estimate" },
       "compressor_flexibility_power_max": { "name": "Compressor Flexibility Power Max" }
     },

--- a/custom_components/eebus/switch.py
+++ b/custom_components/eebus/switch.py
@@ -27,10 +27,6 @@ async def async_setup_entry(
         EebusLPCActiveSwitch(coordinator),
         EebusHeartbeatSwitch(coordinator),
     ]
-    # OHPCF compressor-flexibility control is only offered when the bridge's OHPCF
-    # client is active and a compatible heat pump was found.
-    if coordinator.data and coordinator.data.get("ohpcf_supported"):
-        entities.append(EebusCompressorFlexibilitySwitch(coordinator))
     async_add_entities(entities)
 
 
@@ -102,70 +98,4 @@ class EebusHeartbeatSwitch(EebusEntity, SwitchEntity):
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Stop heartbeat."""
         await self.coordinator.async_stop_heartbeat()
-        await self.coordinator.async_request_refresh()
-
-
-# Compressor-flexibility process states that count as "on" (consuming or about to).
-_OHPCF_ON_STATES = {"COMPRESSOR_STATE_RUNNING", "COMPRESSOR_STATE_SCHEDULED"}
-
-
-class EebusCompressorFlexibilitySwitch(EebusEntity, SwitchEntity):
-    """Switch driving the heat-pump compressor's optional power consumption (OHPCF).
-
-    On  = schedule (or resume) the optional consumption to soak up PV surplus.
-    Off = pause the running process, or abort it when pausing is not supported.
-
-    Gold: translation_key, entity_category CONFIG.
-    """
-
-    _attr_translation_key = "compressor_flexibility"
-    _attr_entity_category = EntityCategory.CONFIG
-
-    def __init__(self, coordinator: EebusCoordinator) -> None:
-        """Initialize."""
-        super().__init__(coordinator)
-        self._attr_unique_id = f"{coordinator.ski}_compressor_flexibility"
-
-    def _flex(self) -> dict[str, Any] | None:
-        if self.coordinator.data is None:
-            return None
-        return self.coordinator.data.get("compressor_flexibility")
-
-    @property
-    def available(self) -> bool:
-        """Available only while the compressor advertises a flexibility offer."""
-        return super().available and self._flex() is not None
-
-    @property
-    def is_on(self) -> bool | None:
-        """Return True while the optional consumption is scheduled or running."""
-        flex = self._flex()
-        if flex is None:
-            return None
-        return flex.get("state") in _OHPCF_ON_STATES
-
-    async def async_turn_on(self, **kwargs: Any) -> None:
-        """Schedule (or resume) the optional power consumption."""
-        from . import proto_stubs
-
-        flex = self._flex() or {}
-        action = (
-            proto_stubs.OHPCFAction.OHPCF_ACTION_RESUME
-            if flex.get("state") == "COMPRESSOR_STATE_PAUSED"
-            else proto_stubs.OHPCFAction.OHPCF_ACTION_SCHEDULE
-        )
-        await self.coordinator.async_control_compressor(action)
-        await self.coordinator.async_request_refresh()
-
-    async def async_turn_off(self, **kwargs: Any) -> None:
-        """Pause the optional power consumption, or abort it when not pausable."""
-        from . import proto_stubs
-
-        flex = self._flex() or {}
-        action = (
-            proto_stubs.OHPCFAction.OHPCF_ACTION_PAUSE
-            if flex.get("is_pausable")
-            else proto_stubs.OHPCFAction.OHPCF_ACTION_ABORT
-        )
-        await self.coordinator.async_control_compressor(action)
         await self.coordinator.async_request_refresh()

--- a/custom_components/eebus/tests/test_ohpcf.py
+++ b/custom_components/eebus/tests/test_ohpcf.py
@@ -12,7 +12,7 @@ from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from custom_components.eebus import proto_stubs
 from custom_components.eebus.coordinator import EebusCoordinator
 from custom_components.eebus.generated.eebus.v1 import ohpcf_service_pb2 as ohpcf_pb2
-from custom_components.eebus.switch import EebusCompressorFlexibilitySwitch
+from custom_components.eebus.select import EebusCompressorFlexibilitySelect
 
 
 def _coordinator(ski="test-ski"):
@@ -66,52 +66,71 @@ def test_read_compressor_flexibility_unavailable_marks_unsupported():
     assert c._ohpcf_supported is False
 
 
-def _switch_with(flex):
-    sw = EebusCompressorFlexibilitySwitch.__new__(EebusCompressorFlexibilitySwitch)
-    sw.coordinator = SimpleNamespace(
+def _select_with(flex):
+    sel = EebusCompressorFlexibilitySelect.__new__(EebusCompressorFlexibilitySelect)
+    sel.coordinator = SimpleNamespace(
         data={"compressor_flexibility": flex},
         async_control_compressor=AsyncMock(),
         async_request_refresh=AsyncMock(),
     )
-    return sw
+    return sel
 
 
-def test_switch_is_on_for_running_state():
-    """Switch reports on while scheduled or running."""
-    assert _switch_with({"state": "COMPRESSOR_STATE_RUNNING"}).is_on is True
-    assert _switch_with({"state": "COMPRESSOR_STATE_SCHEDULED"}).is_on is True
-    assert _switch_with({"state": "COMPRESSOR_STATE_AVAILABLE"}).is_on is False
-    assert _switch_with(None).is_on is None
+def test_select_current_option_distinguishes_paused_from_off():
+    """Select reports on/paused/off as three distinct options, not a binary collapse."""
+    assert _select_with({"state": "COMPRESSOR_STATE_RUNNING"}).current_option == "on"
+    assert _select_with({"state": "COMPRESSOR_STATE_SCHEDULED"}).current_option == "on"
+    assert _select_with({"state": "COMPRESSOR_STATE_PAUSED"}).current_option == "paused"
+    assert _select_with({"state": "COMPRESSOR_STATE_AVAILABLE"}).current_option == "off"
+    assert _select_with({"state": "COMPRESSOR_STATE_STOPPED"}).current_option == "off"
+    assert _select_with(None).current_option is None
 
 
-def test_switch_turn_on_schedules():
-    """Turn-on schedules when not paused, resumes when paused."""
-    sw = _switch_with({"state": "COMPRESSOR_STATE_AVAILABLE"})
-    asyncio.run(sw.async_turn_on())
-    sw.coordinator.async_control_compressor.assert_awaited_once_with(
+def test_select_option_on_schedules_or_resumes():
+    """Selecting 'on' schedules when not paused, resumes when paused."""
+    sel = _select_with({"state": "COMPRESSOR_STATE_AVAILABLE"})
+    asyncio.run(sel.async_select_option("on"))
+    sel.coordinator.async_control_compressor.assert_awaited_once_with(
         proto_stubs.OHPCFAction.OHPCF_ACTION_SCHEDULE
     )
 
-    sw = _switch_with({"state": "COMPRESSOR_STATE_PAUSED"})
-    asyncio.run(sw.async_turn_on())
-    sw.coordinator.async_control_compressor.assert_awaited_once_with(
+    sel = _select_with({"state": "COMPRESSOR_STATE_PAUSED"})
+    asyncio.run(sel.async_select_option("on"))
+    sel.coordinator.async_control_compressor.assert_awaited_once_with(
         proto_stubs.OHPCFAction.OHPCF_ACTION_RESUME
     )
 
 
-def test_switch_turn_off_pauses_or_aborts():
-    """Turn-off pauses when pausable, otherwise aborts."""
-    sw = _switch_with({"is_pausable": True})
-    asyncio.run(sw.async_turn_off())
-    sw.coordinator.async_control_compressor.assert_awaited_once_with(
+def test_select_option_paused_pauses():
+    """Selecting 'paused' issues a pause regardless of is_pausable (device rejects if unsupported)."""
+    sel = _select_with({"is_pausable": True})
+    asyncio.run(sel.async_select_option("paused"))
+    sel.coordinator.async_control_compressor.assert_awaited_once_with(
         proto_stubs.OHPCFAction.OHPCF_ACTION_PAUSE
     )
 
-    sw = _switch_with({"is_pausable": False})
-    asyncio.run(sw.async_turn_off())
-    sw.coordinator.async_control_compressor.assert_awaited_once_with(
+
+def test_select_option_off_aborts():
+    """Selecting 'off' aborts the process."""
+    sel = _select_with({"state": "COMPRESSOR_STATE_RUNNING"})
+    asyncio.run(sel.async_select_option("off"))
+    sel.coordinator.async_control_compressor.assert_awaited_once_with(
         proto_stubs.OHPCFAction.OHPCF_ACTION_ABORT
     )
+
+
+def test_select_extra_state_attributes_exposes_constraints():
+    """Process constraints (stoppable, min run/pause) surface as attributes."""
+    sel = _select_with(
+        {"is_stoppable": False, "minimal_run_seconds": 600, "minimal_pause_seconds": 300}
+    )
+    attrs = sel.extra_state_attributes
+    assert attrs == {
+        "is_stoppable": False,
+        "minimal_run_seconds": 600,
+        "minimal_pause_seconds": 300,
+    }
+    assert _select_with(None).extra_state_attributes is None
 
 
 def test_control_compressor_wraps_rpc_error_as_validation_error():

--- a/custom_components/eebus/tests/test_ohpcf.py
+++ b/custom_components/eebus/tests/test_ohpcf.py
@@ -13,6 +13,7 @@ from custom_components.eebus import proto_stubs
 from custom_components.eebus.coordinator import EebusCoordinator
 from custom_components.eebus.generated.eebus.v1 import ohpcf_service_pb2 as ohpcf_pb2
 from custom_components.eebus.select import EebusCompressorFlexibilitySelect
+from custom_components.eebus.sensor import EebusCompressorFlexibilityStatusSensor
 
 
 def _coordinator(ski="test-ski"):
@@ -131,6 +132,23 @@ def test_select_extra_state_attributes_exposes_constraints():
         "minimal_pause_seconds": 300,
     }
     assert _select_with(None).extra_state_attributes is None
+
+
+def _status_sensor_with(flex):
+    sensor = EebusCompressorFlexibilityStatusSensor.__new__(EebusCompressorFlexibilityStatusSensor)
+    sensor.coordinator = SimpleNamespace(data={"compressor_flexibility": flex})
+    return sensor
+
+
+def test_status_sensor_maps_raw_states():
+    """Status sensor surfaces all six raw states, unlike the collapsed select."""
+    assert _status_sensor_with({"state": "COMPRESSOR_STATE_AVAILABLE"}).native_value == "available"
+    assert _status_sensor_with({"state": "COMPRESSOR_STATE_SCHEDULED"}).native_value == "scheduled"
+    assert _status_sensor_with({"state": "COMPRESSOR_STATE_RUNNING"}).native_value == "running"
+    assert _status_sensor_with({"state": "COMPRESSOR_STATE_PAUSED"}).native_value == "paused"
+    assert _status_sensor_with({"state": "COMPRESSOR_STATE_COMPLETED"}).native_value == "completed"
+    assert _status_sensor_with({"state": "COMPRESSOR_STATE_STOPPED"}).native_value == "stopped"
+    assert _status_sensor_with(None).native_value is None
 
 
 def test_control_compressor_wraps_rpc_error_as_validation_error():

--- a/custom_components/eebus/translations/de.json
+++ b/custom_components/eebus/translations/de.json
@@ -92,6 +92,17 @@
       "energy_produced": { "name": "Eingespeiste Energie" },
       "failsafe_limit": { "name": "Failsafe-Limit" },
       "failsafe_duration": { "name": "Failsafe-Mindestdauer" },
+      "compressor_flexibility_status": {
+        "name": "Verdichter-Flexibilität Status",
+        "state": {
+          "available": "Verfügbar",
+          "scheduled": "Geplant",
+          "running": "Läuft",
+          "paused": "Pausiert",
+          "completed": "Abgeschlossen",
+          "stopped": "Gestoppt"
+        }
+      },
       "compressor_flexibility_power_estimate": { "name": "Verdichter-Flexibilität Geschätzte Leistung" },
       "compressor_flexibility_power_max": { "name": "Verdichter-Flexibilität Maximale Leistung" }
     },

--- a/custom_components/eebus/translations/de.json
+++ b/custom_components/eebus/translations/de.json
@@ -91,16 +91,27 @@
       "frequency": { "name": "Netzfrequenz" },
       "energy_produced": { "name": "Eingespeiste Energie" },
       "failsafe_limit": { "name": "Failsafe-Limit" },
-      "failsafe_duration": { "name": "Failsafe-Mindestdauer" }
+      "failsafe_duration": { "name": "Failsafe-Mindestdauer" },
+      "compressor_flexibility_power_estimate": { "name": "Verdichter-Flexibilität Geschätzte Leistung" },
+      "compressor_flexibility_power_max": { "name": "Verdichter-Flexibilität Maximale Leistung" }
     },
     "number": {
       "lpc_limit": { "name": "LPC Limit" },
       "failsafe_limit": { "name": "Failsafe Limit" }
     },
+    "select": {
+      "compressor_flexibility": {
+        "name": "Verdichter-Flexibilität",
+        "state": {
+          "on": "Ein",
+          "paused": "Pausiert",
+          "off": "Aus"
+        }
+      }
+    },
     "switch": {
       "lpc_active": { "name": "LPC aktiv" },
-      "heartbeat": { "name": "Heartbeat" },
-      "compressor_flexibility": { "name": "Verdichter-Flexibilität" }
+      "heartbeat": { "name": "Heartbeat" }
     },
     "binary_sensor": {
       "connected": { "name": "Verbunden" },

--- a/custom_components/eebus/translations/en.json
+++ b/custom_components/eebus/translations/en.json
@@ -91,16 +91,27 @@
       "frequency": { "name": "Grid Frequency" },
       "energy_produced": { "name": "Energy Produced" },
       "failsafe_limit": { "name": "Failsafe Limit" },
-      "failsafe_duration": { "name": "Failsafe Minimum Duration" }
+      "failsafe_duration": { "name": "Failsafe Minimum Duration" },
+      "compressor_flexibility_power_estimate": { "name": "Compressor Flexibility Power Estimate" },
+      "compressor_flexibility_power_max": { "name": "Compressor Flexibility Power Max" }
     },
     "number": {
       "lpc_limit": { "name": "LPC Limit" },
       "failsafe_limit": { "name": "Failsafe Limit" }
     },
+    "select": {
+      "compressor_flexibility": {
+        "name": "Compressor Flexibility",
+        "state": {
+          "on": "On",
+          "paused": "Paused",
+          "off": "Off"
+        }
+      }
+    },
     "switch": {
       "lpc_active": { "name": "LPC Active" },
-      "heartbeat": { "name": "Heartbeat" },
-      "compressor_flexibility": { "name": "Compressor Flexibility" }
+      "heartbeat": { "name": "Heartbeat" }
     },
     "binary_sensor": {
       "connected": { "name": "Connected" },

--- a/custom_components/eebus/translations/en.json
+++ b/custom_components/eebus/translations/en.json
@@ -92,6 +92,17 @@
       "energy_produced": { "name": "Energy Produced" },
       "failsafe_limit": { "name": "Failsafe Limit" },
       "failsafe_duration": { "name": "Failsafe Minimum Duration" },
+      "compressor_flexibility_status": {
+        "name": "Compressor Flexibility Status",
+        "state": {
+          "available": "Available",
+          "scheduled": "Scheduled",
+          "running": "Running",
+          "paused": "Paused",
+          "completed": "Completed",
+          "stopped": "Stopped"
+        }
+      },
       "compressor_flexibility_power_estimate": { "name": "Compressor Flexibility Power Estimate" },
       "compressor_flexibility_power_max": { "name": "Compressor Flexibility Power Max" }
     },


### PR DESCRIPTION
## Summary
- Plain on/off switch collapsed PAUSED into the same "off" bucket as AVAILABLE/COMPLETED/STOPPED, hiding whether the compressor's optional power-consumption process is paused vs stopped.
- New `select.eebus_compressor_flexibility` exposes on/paused/off as three distinct options; process constraints (`is_stoppable`, `minimal_run_seconds`, `minimal_pause_seconds`) surfaced as attributes.
- Added diagnostic sensor `compressor_flexibility_status` — surfaces the raw OHPCF process state (available/scheduled/running/paused/completed/stopped) that the select collapses for control purposes.
- Added diagnostic sensors `compressor_flexibility_power_estimate`/`_max` — the coordinator already read `requested_power_estimate_w`/`requested_power_max_w` from OHPCF but never surfaced them.
- Updated README/CLAUDE.md entity docs.

## Test plan
- [x] `PYTHONPATH=. pytest` — 58 passed
- [x] `ruff check custom_components/` — clean
- [x] Live check on stack 93 against VR940 — select shows correct state, new status sensor reports `stopped` matching select's `off`, power sensors present (unknown until an offer is active)