### PR TITLE
Promote OHPCF client from experimental to default-enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Die Integration nutzt **gRPC Streaming** (Server-Sent Events) fuer Echtzeit-Upda
 | `number.eebus_failsafe_limit` | number | Failsafe-Grenze (W), standardmaessig deaktiviert |
 | `switch.eebus_lpc_active` | switch | Limit aktivieren/deaktivieren |
 | `switch.eebus_heartbeat` | switch | Heartbeat an/aus, standardmaessig deaktiviert |
-| `select.eebus_compressor_flexibility` | select | OHPCF-Verdichter-Flexibilitaet: `on`/`paused`/`off`, nur vorhanden wenn WP ein Angebot meldet (experimentell) |
+| `select.eebus_compressor_flexibility` | select | OHPCF-Verdichter-Flexibilitaet: `on`/`paused`/`off`, nur vorhanden wenn WP ein Angebot meldet |
 
 ### Diagnose
 

--- a/eebus-bridge/cmd/eebus-bridge/main.go
+++ b/eebus-bridge/cmd/eebus-bridge/main.go
@@ -114,15 +114,15 @@ func main() {
 			log.Println("[VABD] experimental battery-system provider registered; awaiting battery data via VisualizationService")
 		}
 	}
-	// SPIKE: experimental OHPCF (heat-pump compressor flexibility) CEM client.
-	// Off by default. Reads the remote heat pump's optional-consumption offer and
-	// drives schedule/pause/resume/abort via OHPCFService.
+	// OHPCF (heat-pump compressor flexibility) CEM client. On by default; reads
+	// the remote heat pump's optional-consumption offer and drives
+	// schedule/pause/resume/abort via OHPCFService.
 	var ohpcfWrapper *usecases.OHPCFWrapper
-	if cfg.Experimental.OHPCFClient {
+	if *cfg.OHPCF.Enabled {
 		ohpcfWrapper = usecases.NewOHPCFWrapper(bus, registry, cfg.Logging.DebugEvents)
 		ohpcfWrapper.Setup(localEntity)
 		bridgeSvc.Service().AddUseCase(ohpcfWrapper.UseCase())
-		log.Println("[OHPCF] experimental CEM client registered; awaiting remote compressor SmartEnergyManagementPs")
+		log.Println("[OHPCF] CEM client registered; awaiting remote compressor SmartEnergyManagementPs")
 	}
 
 	// Controllable systems revert an active LPC limit to its failsafe value when

--- a/eebus-bridge/cmd/eebus-bridge/main.go
+++ b/eebus-bridge/cmd/eebus-bridge/main.go
@@ -73,8 +73,12 @@ func main() {
 	}
 	lpcWrapper.Setup(localEntity)
 	monitoringWrapper.Setup(localEntity)
-	bridgeSvc.Service().AddUseCase(lpcWrapper.UseCase())
-	bridgeSvc.Service().AddUseCase(monitoringWrapper.UseCase())
+	if err := bridgeSvc.Service().AddUseCase(lpcWrapper.UseCase()); err != nil {
+		log.Fatalf("adding LPC use case: %v", err)
+	}
+	if err := bridgeSvc.Service().AddUseCase(monitoringWrapper.UseCase()); err != nil {
+		log.Fatalf("adding monitoring use case: %v", err)
+	}
 
 	// SPIKE: experimental MGCP grid-connection-point provider. Off by default.
 	var mgcpProvider *usecases.MGCPProvider
@@ -84,7 +88,9 @@ func main() {
 			log.Println("[MGCP] experimental provider enabled but grid entity is unavailable; skipping")
 		} else {
 			mgcpProvider = usecases.NewMGCPProvider(gridEntity, bus, cfg.Logging.DebugEvents)
-			bridgeSvc.Service().AddUseCase(mgcpProvider.UseCase())
+			if err := bridgeSvc.Service().AddUseCase(mgcpProvider.UseCase()); err != nil {
+				log.Fatalf("adding MGCP use case: %v", err)
+			}
 			log.Println("[MGCP] experimental grid-connection-point provider registered; awaiting grid data via GridService")
 		}
 	}
@@ -97,7 +103,9 @@ func main() {
 			log.Println("[VAPD] experimental provider enabled but PV entity is unavailable; skipping")
 		} else {
 			vapdProvider = usecases.NewVAPDProvider(pvEntity, bus, cfg.Logging.DebugEvents)
-			bridgeSvc.Service().AddUseCase(vapdProvider.UseCase())
+			if err := bridgeSvc.Service().AddUseCase(vapdProvider.UseCase()); err != nil {
+				log.Fatalf("adding VAPD use case: %v", err)
+			}
 			log.Println("[VAPD] experimental PV-system provider registered; awaiting PV data via VisualizationService")
 		}
 	}
@@ -110,7 +118,9 @@ func main() {
 			log.Println("[VABD] experimental provider enabled but battery entity is unavailable; skipping")
 		} else {
 			vabdProvider = usecases.NewVABDProvider(batteryEntity, bus, cfg.Logging.DebugEvents)
-			bridgeSvc.Service().AddUseCase(vabdProvider.UseCase())
+			if err := bridgeSvc.Service().AddUseCase(vabdProvider.UseCase()); err != nil {
+				log.Fatalf("adding VABD use case: %v", err)
+			}
 			log.Println("[VABD] experimental battery-system provider registered; awaiting battery data via VisualizationService")
 		}
 	}
@@ -121,7 +131,9 @@ func main() {
 	if *cfg.OHPCF.Enabled {
 		ohpcfWrapper = usecases.NewOHPCFWrapper(bus, registry, cfg.Logging.DebugEvents)
 		ohpcfWrapper.Setup(localEntity)
-		bridgeSvc.Service().AddUseCase(ohpcfWrapper.UseCase())
+		if err := bridgeSvc.Service().AddUseCase(ohpcfWrapper.UseCase()); err != nil {
+			log.Fatalf("adding OHPCF use case: %v", err)
+		}
 		log.Println("[OHPCF] CEM client registered; awaiting remote compressor SmartEnergyManagementPs")
 	}
 

--- a/eebus-bridge/config.yaml
+++ b/eebus-bridge/config.yaml
@@ -18,6 +18,11 @@ certificates:
   auto_generate: true
   storage_path: "/data/certs"
 
+ohpcf:
+  # enabled turns on the CEM client for Optimization of Self-Consumption by Heat
+  # Pump Compressor Flexibility (OHPCF). On by default; set to false to disable.
+  enabled: true
+
 experimental:
   # mgcp_provider exposes a local grid-connection-point so a heat pump (e.g.
   # Vaillant VR940) can read the live grid / PV-surplus situation and run its

--- a/eebus-bridge/internal/config/config.go
+++ b/eebus-bridge/internal/config/config.go
@@ -13,7 +13,18 @@ type Config struct {
 	EEBUS        EEBUSConfig        `yaml:"eebus"`
 	Certificates CertificatesConfig `yaml:"certificates"`
 	Logging      LoggingConfig      `yaml:"logging"`
+	OHPCF        OHPCFConfig        `yaml:"ohpcf"`
 	Experimental ExperimentalConfig `yaml:"experimental"`
+}
+
+// OHPCFConfig controls the Optimization of Self-Consumption by Heat Pump
+// Compressor Flexibility (OHPCF, a.k.a. OSCF) CEM client, which subscribes to a
+// remote heat pump's Compressor / SmartEnergyManagementPs feature (e.g. Vaillant
+// VR940) and drives schedule/pause/resume/abort via OHPCFService.
+type OHPCFConfig struct {
+	// Enabled turns the OHPCF client on or off. On by default; set to false to
+	// disable.
+	Enabled *bool `yaml:"enabled"`
 }
 
 // ExperimentalConfig gates spike / not-yet-stable features. Everything here is
@@ -37,13 +48,6 @@ type ExperimentalConfig struct {
 	// VR940, which advertises the VABD VisualizationAppliance role) can display the
 	// home's battery state. SPIKE: see docs/eebus-vaillant-improvements.md.
 	VABDProvider bool `yaml:"vabd_provider"`
-	// OHPCFClient enables the CEM-client side of the Optimization of
-	// Self-Consumption by Heat Pump Compressor Flexibility (OHPCF, a.k.a. OSCF)
-	// use case. The bridge subscribes to a remote heat pump's Compressor /
-	// SmartEnergyManagementPs feature (e.g. Vaillant VR940). SPIKE: read-only
-	// observer to confirm the device binds + serves the feature before building
-	// the schedule/pause control path. See docs/eebus-vaillant-improvements.md.
-	OHPCFClient bool `yaml:"ohpcf_client"`
 	// TrustSKI, when set, makes the bridge trust (RegisterRemoteSKI) this remote
 	// SKI at startup instead of waiting for Home Assistant to send it via gRPC.
 	// Lets a spike container complete the SHIP handshake with a known device
@@ -123,6 +127,10 @@ func applyDefaults(cfg *Config) {
 	if !cfg.Certificates.AutoGenerate && cfg.Certificates.CertFile == "" {
 		cfg.Certificates.AutoGenerate = true
 	}
+	if cfg.OHPCF.Enabled == nil {
+		enabled := true
+		cfg.OHPCF.Enabled = &enabled
+	}
 }
 
 func applyEnvOverrides(cfg *Config) {
@@ -195,9 +203,9 @@ func applyEnvOverrides(cfg *Config) {
 			cfg.Experimental.VABDProvider = enabled
 		}
 	}
-	if v := os.Getenv("EEBUS_EXP_OHPCF_CLIENT"); v != "" {
+	if v := os.Getenv("EEBUS_OHPCF_ENABLED"); v != "" {
 		if enabled, err := strconv.ParseBool(v); err == nil {
-			cfg.Experimental.OHPCFClient = enabled
+			cfg.OHPCF.Enabled = &enabled
 		}
 	}
 	if v := os.Getenv("EEBUS_EXP_TRUST_SKI"); v != "" {

--- a/eebus-bridge/internal/config/config_test.go
+++ b/eebus-bridge/internal/config/config_test.go
@@ -75,6 +75,50 @@ func TestDefaults(t *testing.T) {
 	if !cfg.Certificates.AutoGenerate {
 		t.Error("default Certificates.AutoGenerate = false, want true")
 	}
+	if cfg.OHPCF.Enabled == nil || !*cfg.OHPCF.Enabled {
+		t.Error("default OHPCF.Enabled = false, want true")
+	}
+}
+
+func TestOHPCFDisable(t *testing.T) {
+	yaml := `
+ohpcf:
+  enabled: false
+`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(path, []byte(yaml), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := config.LoadFromFile(path)
+	if err != nil {
+		t.Fatalf("LoadFromFile failed: %v", err)
+	}
+
+	if cfg.OHPCF.Enabled == nil || *cfg.OHPCF.Enabled {
+		t.Error("OHPCF.Enabled = true, want false")
+	}
+}
+
+func TestOHPCFEnvOverride(t *testing.T) {
+	yaml := `{}`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(path, []byte(yaml), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("EEBUS_OHPCF_ENABLED", "false")
+
+	cfg, err := config.LoadFromFile(path)
+	if err != nil {
+		t.Fatalf("LoadFromFile failed: %v", err)
+	}
+
+	if cfg.OHPCF.Enabled == nil || *cfg.OHPCF.Enabled {
+		t.Error("env override OHPCF.Enabled = true, want false")
+	}
 }
 
 func TestEnvOverride(t *testing.T) {

--- a/eebus-bridge/internal/usecases/ohpcf.go
+++ b/eebus-bridge/internal/usecases/ohpcf.go
@@ -19,10 +19,9 @@ import (
 // EventBus. The bridge plays the CEM (controller/client) actor; the remote heat
 // pump's Compressor entity is the flexibility provider.
 //
-// SPIKE: this is the CEM-client side of §1.3.1 PV-surplus compressor control.
-// Currently a read-only observer used to confirm whether the VR940 actually binds
-// and serves its SmartEnergyManagementPs feature. The schedule/pause/resume/abort
-// control path is intentionally not wired yet (see docs/eebus-vaillant-improvements.md).
+// This is the CEM-client side of §1.3.1 PV-surplus compressor control: it reads
+// the remote offer/state and drives schedule/pause/resume/abort via OHPCFService
+// (see docs/eebus-vaillant-improvements.md).
 type OHPCFWrapper struct {
 	uc          *cemohpcf.OHPCF
 	bus         *eebus.EventBus


### PR DESCRIPTION
## Summary
- OHPCF compressor-flexibility CEM client moves out of `experimental` config into its own `ohpcf.enabled` flag, defaulting to `true`.
- New env override `EEBUS_OHPCF_ENABLED` replaces old `EEBUS_EXP_OHPCF_CLIENT`.
- Dropped stale "SPIKE/experimental" wording in `main.go`/`ohpcf.go` (control path is live, validated on VR940 since v0.9.x).
- README drops "(experimentell)" tag on the compressor-flexibility select.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `go test ./...` in `eebus-bridge/`
- [x] Added config tests: default-on, yaml disable, env override
- [ ] Redeploy prod stack 93 and drop the now-unused `EEBUS_EXP_OHPCF_CLIENT` env var (OHPCF is on by default now, so leaving it set is harmless but dead)