### PR TITLE
Reach quality scale platinum: mypy --strict pass, CI type check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,9 +90,11 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pytest pytest-asyncio pytest-cov ruff homeassistant voluptuous grpcio protobuf pip-audit
+          pip install pytest pytest-asyncio pytest-cov ruff mypy grpc-stubs homeassistant voluptuous grpcio protobuf pip-audit
       - name: Lint with ruff
         run: ruff check custom_components/
+      - name: Type check with mypy
+        run: mypy custom_components/eebus
       - name: Audit production dependencies
         run: |
           pip-audit --requirement /dev/stdin <<'EOF'

--- a/custom_components/eebus/config_flow.py
+++ b/custom_components/eebus/config_flow.py
@@ -89,18 +89,18 @@ class EebusConfigFlow(ConfigFlow, domain=DOMAIN):
         try:
             from . import proto_stubs
 
-            stub = proto_stubs.DeviceServiceStub(channel)
+            stub = proto_stubs.device_service_stub(channel)
             status = await stub.GetStatus(
                 proto_stubs.Empty(), timeout=CONFIG_RPC_TIMEOUT
             )
-            return status.local_ski
+            return str(status.local_ski)
         except Exception:  # noqa: BLE001
             _LOGGER.debug(
                 "No EEBUS bridge reachable at %s:%s", host, port, exc_info=True
             )
             return None
         finally:
-            await channel.close()
+            await channel.close(None)
 
     async def _async_list_discovered_skis(self) -> list[SelectOptionDict]:
         """Fetch discovered devices from the bridge for the SKI picker."""
@@ -108,7 +108,7 @@ class EebusConfigFlow(ConfigFlow, domain=DOMAIN):
         try:
             from . import proto_stubs
 
-            stub = proto_stubs.DeviceServiceStub(channel)
+            stub = proto_stubs.device_service_stub(channel)
             response = await stub.ListDiscoveredDevices(
                 proto_stubs.Empty(), timeout=CONFIG_RPC_TIMEOUT
             )
@@ -126,7 +126,7 @@ class EebusConfigFlow(ConfigFlow, domain=DOMAIN):
             _LOGGER.debug("Listing discovered devices failed", exc_info=True)
             return []
         finally:
-            await channel.close()
+            await channel.close(None)
 
     async def async_step_zeroconf(
         self, discovery_info: ZeroconfServiceInfo

--- a/custom_components/eebus/coordinator.py
+++ b/custom_components/eebus/coordinator.py
@@ -6,7 +6,8 @@ import asyncio
 import logging
 import math
 from datetime import timedelta
-from typing import Any
+from types import ModuleType
+from typing import TYPE_CHECKING, Any
 
 import grpc
 import grpc.aio
@@ -21,8 +22,14 @@ from homeassistant.const import (
 )
 from homeassistant.core import Event, HomeAssistant
 from homeassistant.exceptions import ServiceValidationError
-from homeassistant.helpers.event import async_track_state_change_event
+from homeassistant.helpers.event import (
+    EventStateChangedData,
+    async_track_state_change_event,
+)
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+if TYPE_CHECKING:
+    from . import proto_stubs
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -134,7 +141,7 @@ class EebusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self.battery_discharged_energy_entity = battery_discharged_energy_entity
         self.battery_soc_entity = battery_soc_entity
         self._channel: grpc.aio.Channel | None = None
-        self._stream_tasks: list[asyncio.Task] = []
+        self._stream_tasks: list[asyncio.Task[None]] = []
         self._grid_unsub: Any = None
         self._pv_unsub: Any = None
         self._battery_unsub: Any = None
@@ -158,7 +165,7 @@ class EebusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             channel = await self._ensure_channel()
             from . import proto_stubs
 
-            device_stub = proto_stubs.DeviceServiceStub(channel)
+            device_stub = proto_stubs.device_service_stub(channel)
             status = await device_stub.GetStatus(proto_stubs.Empty())
 
             if not self._ski_registered:
@@ -179,7 +186,7 @@ class EebusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     self.ski,
                 )
 
-            monitoring_stub = proto_stubs.MonitoringServiceStub(channel)
+            monitoring_stub = proto_stubs.monitoring_service_stub(channel)
             request = proto_stubs.DeviceRequest(ski=self.ski)
             fallback_request = proto_stubs.DeviceRequest(ski="")
             used_fallback = False
@@ -329,7 +336,7 @@ class EebusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 data["energy_consumed_kwh"] = None
 
             try:
-                lpc_stub = proto_stubs.LPCServiceStub(channel)
+                lpc_stub = proto_stubs.lpc_service_stub(channel)
                 limit = await lpc_stub.GetConsumptionLimit(
                     request, timeout=RPC_TIMEOUT
                 )
@@ -387,7 +394,7 @@ class EebusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                         self._lpc_supported = False
 
             try:
-                lpc_stub = proto_stubs.LPCServiceStub(channel)
+                lpc_stub = proto_stubs.lpc_service_stub(channel)
                 failsafe = await lpc_stub.GetFailsafeLimit(
                     request, timeout=RPC_TIMEOUT
                 )
@@ -441,7 +448,7 @@ class EebusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                         self._failsafe_supported = False
 
             try:
-                lpc_stub = proto_stubs.LPCServiceStub(channel)
+                lpc_stub = proto_stubs.lpc_service_stub(channel)
                 hb = await lpc_stub.GetHeartbeatStatus(
                     request, timeout=RPC_TIMEOUT
                 )
@@ -550,7 +557,7 @@ class EebusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             return data
         except grpc.aio.AioRpcError as err:
             if self._channel is not None:
-                await self._channel.close()
+                await self._channel.close(None)
                 self._channel = None
             self._not_found_streak = 0
 
@@ -609,18 +616,12 @@ class EebusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         return info or None
 
     async def _async_register_remote_ski(
-        self, device_stub: Any, proto_stubs: Any, force: bool
+        self, device_stub: Any, proto_stubs_module: ModuleType, force: bool
     ) -> None:
         """Register remote SKI with bridge, optionally forcing re-registration."""
         try:
-            register_request_cls = getattr(proto_stubs, "RegisterSKIRequest", None)
-            if register_request_cls is None:
-                from .generated.eebus.v1.device_service_pb2 import (
-                    RegisterSKIRequest as register_request_cls,
-                )
-
             await device_stub.RegisterRemoteSKI(
-                register_request_cls(ski=self.ski), timeout=RPC_TIMEOUT
+                proto_stubs_module.RegisterSKIRequest(ski=self.ski), timeout=RPC_TIMEOUT
             )
             self._ski_registered = True
             if force:
@@ -690,7 +691,7 @@ class EebusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         """Write LPC consumption limit via gRPC."""
         channel = await self._ensure_channel()
         from . import proto_stubs
-        stub = proto_stubs.LPCServiceStub(channel)
+        stub = proto_stubs.lpc_service_stub(channel)
         try:
             await stub.WriteConsumptionLimit(
                 proto_stubs.WriteLoadLimitRequest(
@@ -712,7 +713,7 @@ class EebusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         """Write failsafe limit via gRPC."""
         channel = await self._ensure_channel()
         from . import proto_stubs
-        stub = proto_stubs.LPCServiceStub(channel)
+        stub = proto_stubs.lpc_service_stub(channel)
         try:
             await stub.WriteFailsafeLimit(
                 proto_stubs.WriteFailsafeLimitRequest(
@@ -734,7 +735,7 @@ class EebusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         """Activate or deactivate LPC limit via gRPC."""
         channel = await self._ensure_channel()
         from . import proto_stubs
-        stub = proto_stubs.LPCServiceStub(channel)
+        stub = proto_stubs.lpc_service_stub(channel)
         current = await stub.GetConsumptionLimit(
             proto_stubs.DeviceRequest(ski=self.ski), timeout=RPC_TIMEOUT
         )
@@ -764,7 +765,7 @@ class EebusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         from .generated.eebus.v1 import ohpcf_service_pb2 as ohpcf_pb2
 
         try:
-            stub = proto_stubs.OHPCFServiceStub(channel)
+            stub = proto_stubs.ohpcf_service_stub(channel)
             flex = await stub.GetCompressorFlexibility(request, timeout=RPC_TIMEOUT)
         except grpc.aio.AioRpcError as err:
             if _is_unimplemented(err) or err.code() == grpc.StatusCode.UNAVAILABLE:
@@ -797,11 +798,11 @@ class EebusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             "minimal_pause_seconds": flex.minimal_pause_seconds,
         }
 
-    async def async_control_compressor(self, action: int) -> None:
+    async def async_control_compressor(self, action: proto_stubs.OHPCFAction) -> None:
         """Schedule/pause/resume/abort the compressor's optional consumption."""
         channel = await self._ensure_channel()
         from . import proto_stubs
-        stub = proto_stubs.OHPCFServiceStub(channel)
+        stub = proto_stubs.ohpcf_service_stub(channel)
         try:
             await stub.ControlCompressorFlexibility(
                 proto_stubs.ControlCompressorRequest(ski=self.ski, action=action),
@@ -826,7 +827,7 @@ class EebusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         """Start EEBUS heartbeat via gRPC."""
         channel = await self._ensure_channel()
         from . import proto_stubs
-        stub = proto_stubs.LPCServiceStub(channel)
+        stub = proto_stubs.lpc_service_stub(channel)
         try:
             await stub.StartHeartbeat(
                 proto_stubs.DeviceRequest(ski=self.ski), timeout=RPC_TIMEOUT
@@ -844,7 +845,7 @@ class EebusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         """Stop EEBUS heartbeat via gRPC."""
         channel = await self._ensure_channel()
         from . import proto_stubs
-        stub = proto_stubs.LPCServiceStub(channel)
+        stub = proto_stubs.lpc_service_stub(channel)
         try:
             await stub.StopHeartbeat(
                 proto_stubs.DeviceRequest(ski=self.ski), timeout=RPC_TIMEOUT
@@ -891,7 +892,7 @@ class EebusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             _LOGGER.debug("%s sensor %s has non-numeric state %r", kind, entity_id, state.state)
             return None
         unit = state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
-        factor = unit_map.get(unit)
+        factor = unit_map.get(unit) if isinstance(unit, str) else None
         if factor is None:
             _LOGGER.debug(
                 "%s sensor %s has unknown unit %r; assuming base unit",
@@ -940,7 +941,7 @@ class EebusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         channel = await self._ensure_channel()
         from . import proto_stubs
 
-        stub = proto_stubs.GridServiceStub(channel)
+        stub = proto_stubs.grid_service_stub(channel)
         request = proto_stubs.GridData(power_w=power_w)
         if feed_in_wh is not None:
             request.feed_in_wh = feed_in_wh
@@ -985,7 +986,7 @@ class EebusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             )
         )
 
-    async def _handle_grid_state_change(self, _event: Event) -> None:
+    async def _handle_grid_state_change(self, _event: Event[EventStateChangedData]) -> None:
         """Push grid data whenever a mapped sensor changes state."""
         await self.async_push_grid_data()
 
@@ -1017,7 +1018,7 @@ class EebusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         channel = await self._ensure_channel()
         from . import proto_stubs
 
-        stub = proto_stubs.VisualizationServiceStub(channel)
+        stub = proto_stubs.visualization_service_stub(channel)
         request = proto_stubs.PVData(power_w=power_w)
         if yield_wh is not None:
             request.yield_wh = yield_wh
@@ -1059,7 +1060,7 @@ class EebusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             )
         )
 
-    async def _handle_pv_state_change(self, _event: Event) -> None:
+    async def _handle_pv_state_change(self, _event: Event[EventStateChangedData]) -> None:
         """Push PV data whenever a mapped sensor changes state."""
         await self.async_push_pv_data()
 
@@ -1093,7 +1094,7 @@ class EebusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         channel = await self._ensure_channel()
         from . import proto_stubs
 
-        stub = proto_stubs.VisualizationServiceStub(channel)
+        stub = proto_stubs.visualization_service_stub(channel)
         request = proto_stubs.BatteryData(power_w=power_w)
         if charged_wh is not None:
             request.charged_wh = charged_wh
@@ -1139,7 +1140,7 @@ class EebusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             )
         )
 
-    async def _handle_battery_state_change(self, _event: Event) -> None:
+    async def _handle_battery_state_change(self, _event: Event[EventStateChangedData]) -> None:
         """Push battery data whenever a mapped sensor changes state."""
         await self.async_push_battery_data()
 
@@ -1187,7 +1188,7 @@ class EebusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         from . import proto_stubs
 
         async def consume(channel: grpc.aio.Channel) -> None:
-            stub = proto_stubs.DeviceServiceStub(channel)
+            stub = proto_stubs.device_service_stub(channel)
             async for event in stub.SubscribeDeviceEvents(proto_stubs.Empty()):
                 self._handle_device_event(event)
 
@@ -1197,7 +1198,7 @@ class EebusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         from . import proto_stubs
 
         async def consume(channel: grpc.aio.Channel) -> None:
-            stub = proto_stubs.LPCServiceStub(channel)
+            stub = proto_stubs.lpc_service_stub(channel)
             async for event in stub.SubscribeLPCEvents(
                 proto_stubs.DeviceRequest(ski=self.ski)
             ):
@@ -1209,7 +1210,7 @@ class EebusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         from . import proto_stubs
 
         async def consume(channel: grpc.aio.Channel) -> None:
-            stub = proto_stubs.MonitoringServiceStub(channel)
+            stub = proto_stubs.monitoring_service_stub(channel)
             async for event in stub.SubscribeMeasurements(
                 proto_stubs.DeviceRequest(ski=self.ski)
             ):
@@ -1316,5 +1317,5 @@ class EebusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             task.cancel()
         self._stream_tasks.clear()
         if self._channel is not None:
-            await self._channel.close()
+            await self._channel.close(None)
             self._channel = None

--- a/custom_components/eebus/number.py
+++ b/custom_components/eebus/number.py
@@ -55,7 +55,8 @@ class EebusLPCLimitNumber(EebusEntity, NumberEntity):
         limit = self.coordinator.data.get("consumption_limit")
         if limit is None:
             return None
-        return limit.get("value_watts")
+        value = limit.get("value_watts")
+        return None if value is None else float(value)
 
     @property
     def available(self) -> bool:
@@ -101,7 +102,8 @@ class EebusFailsafeLimitNumber(EebusEntity, NumberEntity):
         failsafe = self.coordinator.data.get("failsafe_limit")
         if failsafe is None:
             return None
-        return failsafe.get("value_watts")
+        value = failsafe.get("value_watts")
+        return None if value is None else float(value)
 
     @property
     def available(self) -> bool:

--- a/custom_components/eebus/proto_stubs.py
+++ b/custom_components/eebus/proto_stubs.py
@@ -1,7 +1,14 @@
 """Convenience re-exports for generated protobuf stubs.
 
 Run `generate_proto.sh` to regenerate after proto changes.
+
+mypy's `--strict` implies `no_implicit_reexport`: a plain `from x import y`
+here does not make `y` part of this module's public API as far as mypy is
+concerned, so callers importing it back out get `attr-defined` errors. The
+explicit `__all__` below is what actually re-exports these names.
 """
+
+import grpc.aio
 
 from .generated.eebus.v1.common_pb2 import (  # noqa: F401
     DeviceRequest,
@@ -41,3 +48,62 @@ from .generated.eebus.v1.ohpcf_service_pb2 import (  # noqa: F401
     OHPCFEventType,
 )
 from .generated.eebus.v1.ohpcf_service_pb2_grpc import OHPCFServiceStub  # noqa: F401
+
+
+def device_service_stub(channel: grpc.aio.Channel) -> DeviceServiceStub:
+    """Build a DeviceServiceStub.
+
+    grpcio-tools emits untyped stub classes (no mypy_grpc plugin in
+    generate_proto.sh), so the constructor call is untyped from mypy's
+    point of view. Contained here instead of at each of the ~20 call
+    sites in coordinator.py/config_flow.py.
+    """
+    return DeviceServiceStub(channel)  # type: ignore[no-untyped-call]
+
+
+def monitoring_service_stub(channel: grpc.aio.Channel) -> MonitoringServiceStub:
+    return MonitoringServiceStub(channel)  # type: ignore[no-untyped-call]
+
+
+def lpc_service_stub(channel: grpc.aio.Channel) -> LPCServiceStub:
+    return LPCServiceStub(channel)  # type: ignore[no-untyped-call]
+
+
+def ohpcf_service_stub(channel: grpc.aio.Channel) -> OHPCFServiceStub:
+    return OHPCFServiceStub(channel)  # type: ignore[no-untyped-call]
+
+
+def grid_service_stub(channel: grpc.aio.Channel) -> GridServiceStub:
+    return GridServiceStub(channel)  # type: ignore[no-untyped-call]
+
+
+def visualization_service_stub(channel: grpc.aio.Channel) -> VisualizationServiceStub:
+    return VisualizationServiceStub(channel)  # type: ignore[no-untyped-call]
+
+
+__all__ = [
+    "BatteryData",
+    "CompressorPowerConsumptionState",
+    "ControlCompressorRequest",
+    "DeviceEventType",
+    "DeviceRequest",
+    "DeviceServiceStub",
+    "Empty",
+    "GridData",
+    "GridServiceStub",
+    "LPCEventType",
+    "LPCServiceStub",
+    "LoadLimit",
+    "MeasurementEntry",
+    "MeasurementEventType",
+    "MonitoringServiceStub",
+    "OHPCFAction",
+    "OHPCFEventType",
+    "OHPCFServiceStub",
+    "PVData",
+    "PowerMeasurement",
+    "RegisterSKIRequest",
+    "VisualizationServiceStub",
+    "WriteFailsafeLimitRequest",
+    "WriteLoadLimitRequest",
+]

--- a/custom_components/eebus/quality_scale.yaml
+++ b/custom_components/eebus/quality_scale.yaml
@@ -66,3 +66,8 @@ rules:
   stale-devices:
     status: exempt
     comment: One device per config entry, removed on unload.
+  async-dependency: done
+  inject-websession:
+    status: exempt
+    comment: No aiohttp/HTTP client used; talks to the bridge over gRPC only.
+  strict-typing: done

--- a/custom_components/eebus/sensor.py
+++ b/custom_components/eebus/sensor.py
@@ -312,7 +312,8 @@ class EebusConsumptionLimitSensor(EebusEntity, SensorEntity):
         limit = self.coordinator.data.get("consumption_limit")
         if limit is None:
             return None
-        return limit.get("value_watts")
+        value = limit.get("value_watts")
+        return None if value is None else float(value)
 
 
 class EebusFailsafeLimitSensor(EebusEntity, SensorEntity):
@@ -352,7 +353,8 @@ class EebusFailsafeLimitSensor(EebusEntity, SensorEntity):
         failsafe = self.coordinator.data.get("failsafe_limit")
         if failsafe is None:
             return None
-        return failsafe.get("value_watts")
+        value = failsafe.get("value_watts")
+        return None if value is None else float(value)
 
 
 class EebusFailsafeDurationSensor(EebusEntity, SensorEntity):
@@ -390,7 +392,8 @@ class EebusFailsafeDurationSensor(EebusEntity, SensorEntity):
         failsafe = self.coordinator.data.get("failsafe_limit")
         if failsafe is None:
             return None
-        return failsafe.get("duration_minimum_seconds")
+        value = failsafe.get("duration_minimum_seconds")
+        return None if value is None else float(value)
 
 
 _OHPCF_STATUS_OPTIONS = [
@@ -481,7 +484,8 @@ class EebusCompressorFlexibilityPowerEstimateSensor(EebusEntity, SensorEntity):
         flex = self.coordinator.data.get("compressor_flexibility")
         if flex is None:
             return None
-        return flex.get("requested_power_estimate_w")
+        value = flex.get("requested_power_estimate_w")
+        return None if value is None else float(value)
 
 
 class EebusCompressorFlexibilityPowerMaxSensor(EebusEntity, SensorEntity):
@@ -516,4 +520,5 @@ class EebusCompressorFlexibilityPowerMaxSensor(EebusEntity, SensorEntity):
         flex = self.coordinator.data.get("compressor_flexibility")
         if flex is None:
             return None
-        return flex.get("requested_power_max_w")
+        value = flex.get("requested_power_max_w")
+        return None if value is None else float(value)

--- a/custom_components/eebus/switch.py
+++ b/custom_components/eebus/switch.py
@@ -52,7 +52,8 @@ class EebusLPCActiveSwitch(EebusEntity, SwitchEntity):
         limit = self.coordinator.data.get("consumption_limit")
         if limit is None:
             return None
-        return limit.get("is_active")
+        is_active = limit.get("is_active")
+        return None if is_active is None else bool(is_active)
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Activate LPC limit."""
@@ -88,7 +89,8 @@ class EebusHeartbeatSwitch(EebusEntity, SwitchEntity):
         hb = self.coordinator.data.get("heartbeat_status")
         if hb is None:
             return None
-        return hb.get("running")
+        running = hb.get("running")
+        return None if running is None else bool(running)
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Start heartbeat."""

--- a/custom_components/eebus/tests/test_ohpcf.py
+++ b/custom_components/eebus/tests/test_ohpcf.py
@@ -24,7 +24,7 @@ def _coordinator(ski="test-ski"):
 
 
 def _fake_proto(stub):
-    return SimpleNamespace(OHPCFServiceStub=lambda _channel: stub)
+    return SimpleNamespace(ohpcf_service_stub=lambda _channel: stub)
 
 
 def test_read_compressor_flexibility_maps_fields():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,3 +20,15 @@ exclude_lines = [
 target-version = "py312"
 line-length = 120
 exclude = ["custom_components/eebus/generated"]
+
+[tool.mypy]
+python_version = "3.13"
+strict = true
+exclude = ["custom_components/eebus/tests"]
+
+[[tool.mypy.overrides]]
+# grpcio-tools/mypy-protobuf generated code; not hand-maintained, no point
+# holding it to --strict (untyped grpc stub classes, Message subclasses
+# mypy can't fully resolve without the mypy-protobuf grpc plugin).
+module = "eebus.generated.*"
+ignore_errors = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,10 @@ line-length = 120
 exclude = ["custom_components/eebus/generated"]
 
 [tool.mypy]
-python_version = "3.13"
+# Must track the newest Python in CI's test matrix (not this repo's own
+# target-version): mypy parses installed third-party sources like
+# homeassistant, which use syntax gated to whatever CPython they require.
+python_version = "3.14"
 strict = true
 exclude = ["custom_components/eebus/tests"]
 


### PR DESCRIPTION
## Summary
- Adds platinum's 3 rules to `quality_scale.yaml`: `async-dependency` (done), `inject-websession` (exempt, gRPC-only), `strict-typing` (done)
- `strict-typing` was the real gap: `mypy --strict` on `custom_components/eebus` started at 189 errors, ends at 0
- `proto_stubs.py` gets an explicit `__all__` (strict implies `no_implicit_reexport`) and typed factory functions for the untyped generated grpc Stub classes, containing the necessary `type: ignore[no-untyped-call]` to one place per stub instead of scattering it across ~20 call sites
- Real type errors fixed along the way: `Task[None]` generic, `Event[EventStateChangedData]` callback typing on 3 state-change handlers, `channel.close(None)` (grpc-stubs requires explicit `grace`), several `dict.get()` no-any-return sites, dropped a dead getattr/fallback-import dance in SKI registration
- CI now runs `mypy` alongside `ruff` so this doesn't regress silently

## Test plan
- [x] `mypy custom_components/eebus` — clean
- [x] `ruff check custom_components/` — clean
- [x] `PYTHONPATH=. pytest custom_components/eebus/tests` — 58/58 pass (one test's `proto_stubs` fake mock updated to match the new factory-function API)