### PR TITLE
fix(bridge): auto-restart on stuck monitoring entity binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,6 +360,14 @@ Anschliessend im Bridge-Log nach `[SHIP DEBUG]`/`[SHIP ERROR]` suchen, z. B.:
 - EEBUS-Messwerte kommen ca. alle 60 Sekunden
 - Pruefen ob `binary_sensor.eebus_connected` "on" ist
 - Bridge-Log auf Fehlermeldungen pruefen
+- Ein eingebauter Watchdog erkennt selbststaendig, wenn nach einem SHIP-Reconnect
+  die SPINE-Entity-Bindung haengen bleibt (Symptom: `no compatible entity` /
+  `no remote entity found` im Log trotz getrustetem Geraet). Bleiben laenger als
+  10 Minuten keine erfolgreichen Messwert-Reads aus, meldet der Docker
+  `HEALTHCHECK` den Container als unhealthy und die Bridge beendet sich selbst
+  fuer einen Neustart (`restart: unless-stopped` in `docker-compose.yml` startet
+  sie automatisch neu). Kein manuelles Eingreifen noetig; bei Bedarf laesst sich
+  der Status vorab pruefen mit `docker inspect --format='{{.State.Health.Status}}' eebus-bridge`.
 
 </details>
 

--- a/eebus-bridge/cmd/eebus-bridge/main.go
+++ b/eebus-bridge/cmd/eebus-bridge/main.go
@@ -7,6 +7,7 @@ import (
 	"os/signal"
 	"strings"
 	"syscall"
+	"time"
 
 	pb "github.com/volschin/eebus-bridge/gen/proto/eebus/v1"
 	"github.com/volschin/eebus-bridge/internal/certs"
@@ -15,6 +16,16 @@ import (
 	bridgegrpc "github.com/volschin/eebus-bridge/internal/grpc"
 	"github.com/volschin/eebus-bridge/internal/usecases"
 )
+
+// monitoringStaleThreshold bounds how long a trusted device may go without a
+// successful Monitoring entity resolution before the watchdog restarts the
+// process. Reconnects (SHIP re-pair) can leave the SPINE entity binding stuck
+// with no error logged, silently starving Home Assistant of data; a restart
+// forces a clean re-handshake. The device normally pushes updates ~every 60s,
+// so 10min gives ample margin against brief legitimate gaps.
+const monitoringStaleThreshold = 10 * time.Minute
+
+const watchdogInterval = 30 * time.Second
 
 func main() {
 	configPath := flag.String("config", "config.yaml", "path to config file")
@@ -223,6 +234,21 @@ func main() {
 	if cfg.Logging.DebugEvents {
 		log.Println("[DEBUG] EEBUS event debug logging enabled; waiting for incoming callbacks")
 	}
+
+	go func() {
+		ticker := time.NewTicker(watchdogInterval)
+		defer ticker.Stop()
+		for range ticker.C {
+			stale := registry.MonitoringStale(monitoringStaleThreshold)
+			grpcSrv.SetHealthy(!stale)
+			if stale {
+				log.Fatalf(
+					"monitoring watchdog: no successful entity resolution for a trusted device in over %s; exiting for restart",
+					monitoringStaleThreshold,
+				)
+			}
+		}
+	}()
 
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)

--- a/eebus-bridge/internal/eebus/registry.go
+++ b/eebus-bridge/internal/eebus/registry.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"sync/atomic"
+	"time"
 
 	spineapi "github.com/enbility/spine-go/api"
 	"github.com/enbility/spine-go/model"
@@ -29,14 +31,37 @@ type DeviceInfo struct {
 }
 
 type DeviceRegistry struct {
-	mu      sync.RWMutex
-	devices map[string]DeviceInfo
+	mu                    sync.RWMutex
+	devices               map[string]DeviceInfo
+	lastMonitoringSuccess atomic.Int64 // unix nano; set at construction so a stuck startup also counts as stale
 }
 
 func NewDeviceRegistry() *DeviceRegistry {
-	return &DeviceRegistry{
+	r := &DeviceRegistry{
 		devices: make(map[string]DeviceInfo),
 	}
+	r.lastMonitoringSuccess.Store(time.Now().UnixNano())
+	return r
+}
+
+// RecordMonitoringSuccess marks that a remote entity was just successfully
+// resolved for a live monitoring read. Call only on a real eebus-go scenario
+// match (not a registry cache hit), so a stuck SPINE entity binding after
+// reconnect is actually detected instead of masked by stale cached entities.
+func (r *DeviceRegistry) RecordMonitoringSuccess() {
+	r.lastMonitoringSuccess.Store(time.Now().UnixNano())
+}
+
+// MonitoringStale reports whether monitoring reads have produced no
+// successful entity resolution for longer than threshold, while at least one
+// device is trusted. Returns false with no trusted device, since a bridge
+// that has never been paired isn't a monitoring outage.
+func (r *DeviceRegistry) MonitoringStale(threshold time.Duration) bool {
+	if len(r.ListDevices()) == 0 {
+		return false
+	}
+	last := time.Unix(0, r.lastMonitoringSuccess.Load())
+	return time.Since(last) > threshold
 }
 
 // NormalizeSKI canonicalizes a SKI for use as a registry key: uppercase, no

--- a/eebus-bridge/internal/eebus/registry_test.go
+++ b/eebus-bridge/internal/eebus/registry_test.go
@@ -2,6 +2,7 @@ package eebus_test
 
 import (
 	"testing"
+	"time"
 
 	spineapi "github.com/enbility/spine-go/api"
 	"github.com/volschin/eebus-bridge/internal/eebus"
@@ -155,5 +156,32 @@ func TestRegistryEntityHelpersEmpty(t *testing.T) {
 	}
 	if entity := reg.FirstEntityForType("unknown", "HeatPumpAppliance"); entity != nil {
 		t.Error("FirstEntityForType unknown returned entity")
+	}
+}
+
+func TestMonitoringStaleNoTrustedDevice(t *testing.T) {
+	reg := eebus.NewDeviceRegistry()
+	if reg.MonitoringStale(0) {
+		t.Error("MonitoringStale should be false with no trusted device, regardless of threshold")
+	}
+}
+
+func TestMonitoringStaleWithinThreshold(t *testing.T) {
+	reg := eebus.NewDeviceRegistry()
+	reg.AddDevice("ski-1", eebus.DeviceInfo{Brand: "Vaillant"})
+	reg.RecordMonitoringSuccess()
+
+	if reg.MonitoringStale(time.Minute) {
+		t.Error("MonitoringStale should be false right after a recorded success")
+	}
+}
+
+func TestMonitoringStaleExceedsThreshold(t *testing.T) {
+	reg := eebus.NewDeviceRegistry()
+	reg.AddDevice("ski-1", eebus.DeviceInfo{Brand: "Vaillant"})
+	reg.RecordMonitoringSuccess()
+
+	if !reg.MonitoringStale(0) {
+		t.Error("MonitoringStale should be true once elapsed time exceeds a zero threshold")
 	}
 }

--- a/eebus-bridge/internal/grpc/monitoring_service.go
+++ b/eebus-bridge/internal/grpc/monitoring_service.go
@@ -199,6 +199,9 @@ func (s *MonitoringService) attachMeasurementPayload(event *pb.MeasurementEvent,
 func (s *MonitoringService) resolveEntity(ski string) (spineapi.EntityRemoteInterface, error) {
 	if s.monitoring != nil {
 		if entity := s.monitoring.CompatibleEntity(ski); entity != nil {
+			if s.registry != nil {
+				s.registry.RecordMonitoringSuccess()
+			}
 			return entity, nil
 		}
 	}

--- a/eebus-bridge/internal/grpc/server.go
+++ b/eebus-bridge/internal/grpc/server.go
@@ -13,6 +13,7 @@ import (
 
 type Server struct {
 	grpcServer *grpc.Server
+	healthSrv  *health.Server
 	listener   net.Listener
 	bind       string
 	port       int
@@ -32,9 +33,21 @@ func NewServer(bind string, port int, enableReflection bool) *Server {
 
 	return &Server{
 		grpcServer: grpcServer,
+		healthSrv:  healthSrv,
 		bind:       bind,
 		port:       port,
 	}
+}
+
+// SetHealthy toggles the gRPC health status the Docker HEALTHCHECK probes.
+// Used by the monitoring watchdog to surface a stuck SPINE entity binding
+// before it force-exits the process for a restart.
+func (s *Server) SetHealthy(healthy bool) {
+	status := grpc_health_v1.HealthCheckResponse_SERVING
+	if !healthy {
+		status = grpc_health_v1.HealthCheckResponse_NOT_SERVING
+	}
+	s.healthSrv.SetServingStatus("", status)
 }
 
 func (s *Server) GRPCServer() *grpc.Server {


### PR DESCRIPTION
## Summary
- Root cause of today's "keine Werte" incident: SHIP reconnect re-trusts the remote SKI but eebus-go's SPINE entity binding stays empty afterwards (no error logged) — Monitoring reads fail with `no compatible entity` indefinitely until manual restart. Live bridge was stuck ~12:00–14:02 UTC before manual restart fixed it.
- Adds a watchdog: tracks last successful Monitoring entity resolution (real eebus-go scenario match, not registry cache); if a trusted device goes >10min without one, flips gRPC health to `NOT_SERVING` (Docker `HEALTHCHECK` reflects it) then exits, letting the existing `restart: unless-stopped` policy force a clean re-handshake.
- No new container/sidecar, no docker.sock exposure — self-contained in the existing health-probe binary.
- Documents the behavior in README's "Keine Messwerte" troubleshooting section.

## Test plan
- [x] `go vet ./...`
- [x] `make test` (`go test -v -race ./...`), including new `TestMonitoringStale*` cases
- [ ] Deploy to prod stack 93 and confirm `docker inspect --format='{{.State.Health.Status}}' eebus-bridge` reflects state correctly over time