### PR TITLE
feat(bridge): experimental HVAC/DHW control spike (read probe, bind, write validation)

### DIFF
--- a/eebus-bridge/cmd/eebus-bridge/main.go
+++ b/eebus-bridge/cmd/eebus-bridge/main.go
@@ -166,6 +166,12 @@ func main() {
 			if cfg.Experimental.HvacProbeWrite {
 				eebus.DefaultHvacProbe().EnableWrite()
 				log.Println("[HVACPROBE] stage-3 write armed; will echo-write current setpoint data after accepted bind (values unchanged)")
+				if cfg.Experimental.HvacProbeWriteDelta {
+					eebus.DefaultHvacProbe().EnableWriteDelta()
+					log.Println("[HVACPROBE] stage-3b delta armed; will change DHW setpoint one step, confirm, and restore")
+				}
+			} else if cfg.Experimental.HvacProbeWriteDelta {
+				log.Println("[HVACPROBE] hvac_probe_write_delta requires hvac_probe_write; delta stage not armed")
 			}
 		} else if cfg.Experimental.HvacProbeWrite {
 			log.Println("[HVACPROBE] hvac_probe_write requires hvac_probe_bind; write stage not armed")

--- a/eebus-bridge/cmd/eebus-bridge/main.go
+++ b/eebus-bridge/cmd/eebus-bridge/main.go
@@ -166,12 +166,12 @@ func main() {
 			if cfg.Experimental.HvacProbeWrite {
 				eebus.DefaultHvacProbe().EnableWrite()
 				log.Println("[HVACPROBE] stage-3 write armed; will echo-write current setpoint data after accepted bind (values unchanged)")
-				if cfg.Experimental.HvacProbeWriteDelta {
-					eebus.DefaultHvacProbe().EnableWriteDelta()
-					log.Println("[HVACPROBE] stage-3b delta armed; will change DHW setpoint one step, confirm, and restore")
+				if ski := cfg.Experimental.HvacProbeWriteDeltaSKI; ski != "" {
+					eebus.DefaultHvacProbe().EnableWriteDelta(ski)
+					log.Printf("[HVACPROBE] stage-3b delta armed for SKI %s; will change DHW setpoint one step, confirm, and restore", ski)
 				}
-			} else if cfg.Experimental.HvacProbeWriteDelta {
-				log.Println("[HVACPROBE] hvac_probe_write_delta requires hvac_probe_write; delta stage not armed")
+			} else if cfg.Experimental.HvacProbeWriteDeltaSKI != "" {
+				log.Println("[HVACPROBE] hvac_probe_write_delta_ski requires hvac_probe_write; delta stage not armed")
 			}
 		} else if cfg.Experimental.HvacProbeWrite {
 			log.Println("[HVACPROBE] hvac_probe_write requires hvac_probe_bind; write stage not armed")

--- a/eebus-bridge/cmd/eebus-bridge/main.go
+++ b/eebus-bridge/cmd/eebus-bridge/main.go
@@ -154,6 +154,14 @@ func main() {
 		registeredUseCases = append(registeredUseCases, "OHPCF")
 	}
 
+	// SPIKE: experimental read-only HVAC/DHW probe. Off by default. Must be armed
+	// before Start so its Setpoint/HVAC client features are part of the announced
+	// feature map.
+	if cfg.Experimental.HvacProbe {
+		eebus.DefaultHvacProbe().Setup(localEntity)
+		log.Println("[HVACPROBE] experimental HVAC/DHW read probe armed; will dump Setpoint/HVAC data on device connect")
+	}
+
 	// Controllable systems revert an active LPC limit to its failsafe value when
 	// heartbeats stop arriving, so keep the local heartbeat running for the
 	// lifetime of the bridge.

--- a/eebus-bridge/cmd/eebus-bridge/main.go
+++ b/eebus-bridge/cmd/eebus-bridge/main.go
@@ -160,6 +160,12 @@ func main() {
 	if cfg.Experimental.HvacProbe {
 		eebus.DefaultHvacProbe().Setup(localEntity)
 		log.Println("[HVACPROBE] experimental HVAC/DHW read probe armed; will dump Setpoint/HVAC data on device connect")
+		if cfg.Experimental.HvacProbeBind {
+			eebus.DefaultHvacProbe().EnableBind()
+			log.Println("[HVACPROBE] stage-2 bind armed; will request Setpoint/HVAC bindings on device connect")
+		}
+	} else if cfg.Experimental.HvacProbeBind {
+		log.Println("[HVACPROBE] hvac_probe_bind requires hvac_probe; bind stage not armed")
 	}
 
 	// Controllable systems revert an active LPC limit to its failsafe value when

--- a/eebus-bridge/cmd/eebus-bridge/main.go
+++ b/eebus-bridge/cmd/eebus-bridge/main.go
@@ -163,9 +163,15 @@ func main() {
 		if cfg.Experimental.HvacProbeBind {
 			eebus.DefaultHvacProbe().EnableBind()
 			log.Println("[HVACPROBE] stage-2 bind armed; will request Setpoint/HVAC bindings on device connect")
+			if cfg.Experimental.HvacProbeWrite {
+				eebus.DefaultHvacProbe().EnableWrite()
+				log.Println("[HVACPROBE] stage-3 write armed; will echo-write current setpoint data after accepted bind (values unchanged)")
+			}
+		} else if cfg.Experimental.HvacProbeWrite {
+			log.Println("[HVACPROBE] hvac_probe_write requires hvac_probe_bind; write stage not armed")
 		}
-	} else if cfg.Experimental.HvacProbeBind {
-		log.Println("[HVACPROBE] hvac_probe_bind requires hvac_probe; bind stage not armed")
+	} else if cfg.Experimental.HvacProbeBind || cfg.Experimental.HvacProbeWrite {
+		log.Println("[HVACPROBE] hvac_probe_bind/hvac_probe_write require hvac_probe; not armed")
 	}
 
 	// Controllable systems revert an active LPC limit to its failsafe value when

--- a/eebus-bridge/internal/config/config.go
+++ b/eebus-bridge/internal/config/config.go
@@ -65,6 +65,13 @@ type ExperimentalConfig struct {
 	// command. Values are not modified, so no temperature changes. Requires
 	// HvacProbe and HvacProbeBind.
 	HvacProbeWrite bool `yaml:"hvac_probe_write"`
+	// HvacProbeWriteDelta is stage 3b of the HVAC control spike: on the
+	// DHWCircuit entity, instead of the echo write, change the DHW setpoint by
+	// one constraint step, re-read to confirm the device applied it, then
+	// restore the original value and confirm again. The setpoint deviates from
+	// its original value only for the few seconds between the two writes.
+	// Requires HvacProbe, HvacProbeBind and HvacProbeWrite.
+	HvacProbeWriteDelta bool `yaml:"hvac_probe_write_delta"`
 	// TrustSKI, when set, makes the bridge trust (RegisterRemoteSKI) this remote
 	// SKI at startup instead of waiting for Home Assistant to send it via gRPC.
 	// Lets a spike container complete the SHIP handshake with a known device
@@ -233,6 +240,11 @@ func applyEnvOverrides(cfg *Config) {
 	if v := os.Getenv("EEBUS_EXP_HVAC_PROBE_WRITE"); v != "" {
 		if enabled, err := strconv.ParseBool(v); err == nil {
 			cfg.Experimental.HvacProbeWrite = enabled
+		}
+	}
+	if v := os.Getenv("EEBUS_EXP_HVAC_PROBE_WRITE_DELTA"); v != "" {
+		if enabled, err := strconv.ParseBool(v); err == nil {
+			cfg.Experimental.HvacProbeWriteDelta = enabled
 		}
 	}
 	if v := os.Getenv("EEBUS_OHPCF_ENABLED"); v != "" {

--- a/eebus-bridge/internal/config/config.go
+++ b/eebus-bridge/internal/config/config.go
@@ -59,6 +59,12 @@ type ExperimentalConfig struct {
 	// feature (the precondition for writes) and log whether the device accepts
 	// it. Requires HvacProbe. Still performs no writes.
 	HvacProbeBind bool `yaml:"hvac_probe_bind"`
+	// HvacProbeWrite is stage 3 of the HVAC control spike: after a Setpoint
+	// binding was accepted, write the device's own current SetpointListData
+	// back unchanged (echo write) and log whether the device accepts the write
+	// command. Values are not modified, so no temperature changes. Requires
+	// HvacProbe and HvacProbeBind.
+	HvacProbeWrite bool `yaml:"hvac_probe_write"`
 	// TrustSKI, when set, makes the bridge trust (RegisterRemoteSKI) this remote
 	// SKI at startup instead of waiting for Home Assistant to send it via gRPC.
 	// Lets a spike container complete the SHIP handshake with a known device
@@ -222,6 +228,11 @@ func applyEnvOverrides(cfg *Config) {
 	if v := os.Getenv("EEBUS_EXP_HVAC_PROBE_BIND"); v != "" {
 		if enabled, err := strconv.ParseBool(v); err == nil {
 			cfg.Experimental.HvacProbeBind = enabled
+		}
+	}
+	if v := os.Getenv("EEBUS_EXP_HVAC_PROBE_WRITE"); v != "" {
+		if enabled, err := strconv.ParseBool(v); err == nil {
+			cfg.Experimental.HvacProbeWrite = enabled
 		}
 	}
 	if v := os.Getenv("EEBUS_OHPCF_ENABLED"); v != "" {

--- a/eebus-bridge/internal/config/config.go
+++ b/eebus-bridge/internal/config/config.go
@@ -48,6 +48,12 @@ type ExperimentalConfig struct {
 	// VR940, which advertises the VABD VisualizationAppliance role) can display the
 	// home's battery state. SPIKE: see docs/eebus-vaillant-improvements.md.
 	VABDProvider bool `yaml:"vabd_provider"`
+	// HvacProbe enables the read-only HVAC/DHW diagnostic probe: on device
+	// connect it requests all Setpoint/HVAC data from remote DHWCircuit/HVACRoom
+	// entities and logs values plus advertised read/write operations, to map
+	// which setpoints/modes a gateway (e.g. Vaillant VR940) exposes for control.
+	// Stage 1 of the HVAC control spike; sends SPINE reads only, never writes.
+	HvacProbe bool `yaml:"hvac_probe"`
 	// TrustSKI, when set, makes the bridge trust (RegisterRemoteSKI) this remote
 	// SKI at startup instead of waiting for Home Assistant to send it via gRPC.
 	// Lets a spike container complete the SHIP handshake with a known device
@@ -201,6 +207,11 @@ func applyEnvOverrides(cfg *Config) {
 	if v := os.Getenv("EEBUS_EXP_VABD_PROVIDER"); v != "" {
 		if enabled, err := strconv.ParseBool(v); err == nil {
 			cfg.Experimental.VABDProvider = enabled
+		}
+	}
+	if v := os.Getenv("EEBUS_EXP_HVAC_PROBE"); v != "" {
+		if enabled, err := strconv.ParseBool(v); err == nil {
+			cfg.Experimental.HvacProbe = enabled
 		}
 	}
 	if v := os.Getenv("EEBUS_OHPCF_ENABLED"); v != "" {

--- a/eebus-bridge/internal/config/config.go
+++ b/eebus-bridge/internal/config/config.go
@@ -65,13 +65,16 @@ type ExperimentalConfig struct {
 	// command. Values are not modified, so no temperature changes. Requires
 	// HvacProbe and HvacProbeBind.
 	HvacProbeWrite bool `yaml:"hvac_probe_write"`
-	// HvacProbeWriteDelta is stage 3b of the HVAC control spike: on the
-	// DHWCircuit entity, instead of the echo write, change the DHW setpoint by
-	// one constraint step, re-read to confirm the device applied it, then
-	// restore the original value and confirm again. The setpoint deviates from
-	// its original value only for the few seconds between the two writes.
-	// Requires HvacProbe, HvacProbeBind and HvacProbeWrite.
-	HvacProbeWriteDelta bool `yaml:"hvac_probe_write_delta"`
+	// HvacProbeWriteDeltaSKI is stage 3b of the HVAC control spike, scoped to
+	// exactly the device with this SKI: on its DHWCircuit entity, instead of
+	// the echo write, change the dhwTemperature setpoint by one advertised
+	// constraint step, re-read to confirm the device applied it, then restore
+	// the original value and confirm again. The setpoint deviates from its
+	// original value only for the few seconds between the two writes.
+	// Fail-closed: without a matching SKI, a dhwTemperature-scoped setpoint
+	// description, complete constraints and writable operations, nothing is
+	// written. Requires HvacProbe, HvacProbeBind and HvacProbeWrite.
+	HvacProbeWriteDeltaSKI string `yaml:"hvac_probe_write_delta_ski"`
 	// TrustSKI, when set, makes the bridge trust (RegisterRemoteSKI) this remote
 	// SKI at startup instead of waiting for Home Assistant to send it via gRPC.
 	// Lets a spike container complete the SHIP handshake with a known device
@@ -242,10 +245,8 @@ func applyEnvOverrides(cfg *Config) {
 			cfg.Experimental.HvacProbeWrite = enabled
 		}
 	}
-	if v := os.Getenv("EEBUS_EXP_HVAC_PROBE_WRITE_DELTA"); v != "" {
-		if enabled, err := strconv.ParseBool(v); err == nil {
-			cfg.Experimental.HvacProbeWriteDelta = enabled
-		}
+	if v := os.Getenv("EEBUS_EXP_HVAC_PROBE_WRITE_DELTA_SKI"); v != "" {
+		cfg.Experimental.HvacProbeWriteDeltaSKI = v
 	}
 	if v := os.Getenv("EEBUS_OHPCF_ENABLED"); v != "" {
 		if enabled, err := strconv.ParseBool(v); err == nil {

--- a/eebus-bridge/internal/config/config.go
+++ b/eebus-bridge/internal/config/config.go
@@ -54,6 +54,11 @@ type ExperimentalConfig struct {
 	// which setpoints/modes a gateway (e.g. Vaillant VR940) exposes for control.
 	// Stage 1 of the HVAC control spike; sends SPINE reads only, never writes.
 	HvacProbe bool `yaml:"hvac_probe"`
+	// HvacProbeBind is stage 2 of the HVAC control spike: in addition to the
+	// reads, request a SPINE binding to each remote Setpoint/HVAC server
+	// feature (the precondition for writes) and log whether the device accepts
+	// it. Requires HvacProbe. Still performs no writes.
+	HvacProbeBind bool `yaml:"hvac_probe_bind"`
 	// TrustSKI, when set, makes the bridge trust (RegisterRemoteSKI) this remote
 	// SKI at startup instead of waiting for Home Assistant to send it via gRPC.
 	// Lets a spike container complete the SHIP handshake with a known device
@@ -212,6 +217,11 @@ func applyEnvOverrides(cfg *Config) {
 	if v := os.Getenv("EEBUS_EXP_HVAC_PROBE"); v != "" {
 		if enabled, err := strconv.ParseBool(v); err == nil {
 			cfg.Experimental.HvacProbe = enabled
+		}
+	}
+	if v := os.Getenv("EEBUS_EXP_HVAC_PROBE_BIND"); v != "" {
+		if enabled, err := strconv.ParseBool(v); err == nil {
+			cfg.Experimental.HvacProbeBind = enabled
 		}
 	}
 	if v := os.Getenv("EEBUS_OHPCF_ENABLED"); v != "" {

--- a/eebus-bridge/internal/eebus/hvacprobe.go
+++ b/eebus-bridge/internal/eebus/hvacprobe.go
@@ -87,10 +87,27 @@ var defaultHvacProbe = NewHvacProbe(nil)
 // wrappers, mirroring DefaultUseCaseDiscovery.
 func DefaultHvacProbe() *HvacProbe { return defaultHvacProbe }
 
+// hvacProbeUseCases lists the client-side (ConfigurationAppliance actor)
+// counterparts of the configurationOf* use cases the VR940 advertises on its
+// DHWCircuit/HVACRoom entities (docs/vr940-usecase-dump.txt). Stage 2b:
+// announcing these in the bridge's NodeManagement use-case data tests whether
+// the VR940 gates bind acceptance on the partner declaring matching client
+// use cases. Scenario lists mirror what the device advertises.
+var hvacProbeUseCases = []struct {
+	name      model.UseCaseNameType
+	scenarios []model.UseCaseScenarioSupportType
+}{
+	{model.UseCaseNameTypeConfigurationOfDhwSystemFunction, []model.UseCaseScenarioSupportType{1, 2, 3}},
+	{model.UseCaseNameTypeConfigurationOfDhwTemperature, []model.UseCaseScenarioSupportType{1}},
+	{model.UseCaseNameTypeConfigurationOfRoomHeatingSystemFunction, []model.UseCaseScenarioSupportType{1}},
+	{model.UseCaseNameTypeConfigurationOfRoomHeatingTemperature, []model.UseCaseScenarioSupportType{1}},
+}
+
 // Setup arms the probe: it registers Setpoint and HVAC client features on the
 // local entity (required as SPINE sender addresses for the read requests) and
-// must therefore run before the EEBUS service starts announcing its feature
-// map. Not calling Setup leaves ProbeOnce a no-op.
+// advertises the matching ConfigurationAppliance client use cases. Both change
+// the announced NodeManagement data, so Setup must run before the EEBUS
+// service starts. Not calling Setup leaves ProbeOnce a no-op.
 func (p *HvacProbe) Setup(localEntity spineapi.EntityLocalInterface) {
 	if p == nil || localEntity == nil {
 		return
@@ -100,6 +117,16 @@ func (p *HvacProbe) Setup(localEntity spineapi.EntityLocalInterface) {
 	p.localEntity = localEntity
 	localEntity.GetOrAddFeature(model.FeatureTypeTypeSetpoint, model.RoleTypeClient)
 	localEntity.GetOrAddFeature(model.FeatureTypeTypeHvac, model.RoleTypeClient)
+	for _, uc := range hvacProbeUseCases {
+		localEntity.AddUseCaseSupport(
+			model.UseCaseActorTypeConfigurationAppliance,
+			uc.name,
+			model.SpecificationVersionType("1.0.0"),
+			"release",
+			true,
+			uc.scenarios,
+		)
+	}
 }
 
 // ProbeOnce probes a remote device the first time it appears with at least one

--- a/eebus-bridge/internal/eebus/hvacprobe.go
+++ b/eebus-bridge/internal/eebus/hvacprobe.go
@@ -59,6 +59,13 @@ type HvacProbe struct {
 	writeEnabled   bool
 	featureResults map[uint64]int64
 
+	// writeDeltaEnabled turns on the stage-3b value-changing test: on the
+	// DHWCircuit entity the echo write is replaced by write(current±1) →
+	// re-read to confirm the device applied it → write(original) → re-read.
+	// The setpoint is off its original value only for the seconds between the
+	// two writes.
+	writeDeltaEnabled bool
+
 	// pollInterval/pollTimeout control how long collectData waits for read
 	// responses to land in the remote feature caches. Overridden in tests.
 	pollInterval time.Duration
@@ -214,6 +221,19 @@ func (p *HvacProbe) EnableWrite() {
 	}
 	p.mu.Lock()
 	p.writeEnabled = true
+	p.mu.Unlock()
+}
+
+// EnableWriteDelta arms stage 3b: on the DHWCircuit entity, instead of the
+// echo write, change the DHW setpoint by one step (clamped to the advertised
+// constraints), re-read to confirm the device applied it, then write the
+// original value back and confirm the restore. Requires EnableWrite.
+func (p *HvacProbe) EnableWriteDelta() {
+	if p == nil {
+		return
+	}
+	p.mu.Lock()
+	p.writeDeltaEnabled = true
 	p.mu.Unlock()
 }
 
@@ -445,24 +465,38 @@ func (p *HvacProbe) attemptSetpointEchoWrite(ski string, b pendingBind) {
 		return
 	}
 
+	p.mu.Lock()
+	delta := p.writeDeltaEnabled
+	p.mu.Unlock()
+	if delta && b.target.entityType == model.EntityTypeTypeDHWCircuit {
+		p.runSetpointDeltaTest(ski, b, data)
+		return
+	}
+
 	payload, err := json.Marshal(data)
 	if err != nil {
 		payload = []byte(fmt.Sprintf("%+v", data))
 	}
 	p.logf("[HVACPROBE] ski=%s entity=%s echo-writing current setpointListData (values unchanged): %s",
 		ski, b.target.entityAddr, payload)
+	p.sendSetpointWriteAndAwait(ski, b, data, "write")
+}
 
+// sendSetpointWriteAndAwait sends one SetpointListData write and waits for the
+// device's result. Returns the errorNumber and whether a result arrived at
+// all; label distinguishes echo/delta/restore writes in the log.
+func (p *HvacProbe) sendSetpointWriteAndAwait(ski string, b pendingBind, data *model.SetpointListDataType, label string) (int64, bool) {
 	cmd := model.CmdType{SetpointListData: data}
 	msgCounter, werr := b.target.feature.Device().Sender().Write(b.localFeature.Address(), b.target.feature.Address(), cmd)
 	if werr != nil {
-		p.logf("[HVACPROBE] ski=%s entity=%s write Setpoint send failed: %v", ski, b.target.entityAddr, werr)
-		return
+		p.logf("[HVACPROBE] ski=%s entity=%s %s Setpoint send failed: %v", ski, b.target.entityAddr, label, werr)
+		return -1, false
 	}
 	counter := uint64(0)
 	if msgCounter != nil {
 		counter = uint64(*msgCounter)
 	}
-	p.logf("[HVACPROBE] ski=%s entity=%s write Setpoint sent (msgCounter=%d)", ski, b.target.entityAddr, counter)
+	p.logf("[HVACPROBE] ski=%s entity=%s %s Setpoint sent (msgCounter=%d)", ski, b.target.entityAddr, label, counter)
 
 	deadline := time.Now().Add(p.pollTimeout)
 	for time.Now().Before(deadline) {
@@ -478,16 +512,144 @@ func (p *HvacProbe) attemptSetpointEchoWrite(ski string, b pendingBind) {
 			continue
 		}
 		if errno == 0 {
-			p.logf("[HVACPROBE] ski=%s entity=%s write Setpoint ACCEPTED (msgCounter=%d)",
-				ski, b.target.entityAddr, counter)
+			p.logf("[HVACPROBE] ski=%s entity=%s %s Setpoint ACCEPTED (msgCounter=%d)",
+				ski, b.target.entityAddr, label, counter)
 		} else {
-			p.logf("[HVACPROBE] ski=%s entity=%s write Setpoint DENIED errorNumber=%d (msgCounter=%d)",
-				ski, b.target.entityAddr, errno, counter)
+			p.logf("[HVACPROBE] ski=%s entity=%s %s Setpoint DENIED errorNumber=%d (msgCounter=%d)",
+				ski, b.target.entityAddr, label, errno, counter)
 		}
+		return errno, true
+	}
+	p.logf("[HVACPROBE] ski=%s entity=%s %s Setpoint NOT answered within %s",
+		ski, b.target.entityAddr, label, p.pollTimeout)
+	return -1, false
+}
+
+// runSetpointDeltaTest is stage 3b: prove the device APPLIES writes, not just
+// ACKs them. It changes the first valued setpoint by one constraint step
+// (default +1, clamped to the advertised range), re-reads until the device
+// reports the new value, then writes the original value back and confirms the
+// restore. A failed restore is logged loudly — that is the one outcome
+// needing manual attention (device keeps the changed setpoint).
+func (p *HvacProbe) runSetpointDeltaTest(ski string, b pendingBind, data *model.SetpointListDataType) {
+	idx := -1
+	for i, sp := range data.SetpointData {
+		if sp.SetpointId != nil && sp.Value != nil {
+			idx = i
+			break
+		}
+	}
+	if idx < 0 {
+		p.logf("[HVACPROBE] ski=%s entity=%s delta test skipped: no setpoint entry with a value", ski, b.target.entityAddr)
 		return
 	}
-	p.logf("[HVACPROBE] ski=%s entity=%s write Setpoint NOT answered within %s",
-		ski, b.target.entityAddr, p.pollTimeout)
+	id := *data.SetpointData[idx].SetpointId
+	orig := data.SetpointData[idx].Value.GetValue()
+
+	step, minV, maxV := p.setpointConstraints(b.target, id)
+	target := orig + step
+	if maxV != nil && target > *maxV {
+		target = orig - step
+	}
+	if minV != nil && target < *minV {
+		p.logf("[HVACPROBE] ski=%s entity=%s delta test skipped: no room within constraints [%v..%v]",
+			ski, b.target.entityAddr, *minV, *maxV)
+		return
+	}
+
+	p.logf("[HVACPROBE] ski=%s entity=%s DELTA TEST setpointId=%d: %v -> %v (restore follows)",
+		ski, b.target.entityAddr, id, orig, target)
+	if errno, ok := p.sendSetpointWriteAndAwait(ski, b, setpointListWithValue(data, idx, target), "delta-write"); !ok || errno != 0 {
+		p.logf("[HVACPROBE] ski=%s entity=%s DELTA TEST aborted: delta write not accepted; device should still be at %v",
+			ski, b.target.entityAddr, orig)
+		return
+	}
+	if p.confirmSetpointValue(b, id, target) {
+		p.logf("[HVACPROBE] ski=%s entity=%s DELTA TEST setpointId=%d APPLIED: device now reports %v",
+			ski, b.target.entityAddr, id, target)
+	} else {
+		p.logf("[HVACPROBE] ski=%s entity=%s DELTA TEST setpointId=%d NOT CONFIRMED: device never reported %v (ACK without apply?)",
+			ski, b.target.entityAddr, id, target)
+	}
+
+	// Restore unconditionally — even an unconfirmed delta may have been applied.
+	if errno, ok := p.sendSetpointWriteAndAwait(ski, b, setpointListWithValue(data, idx, orig), "restore"); !ok || errno != 0 {
+		p.logf("[HVACPROBE] ski=%s entity=%s RESTORE FAILED: setpointId=%d may still be at %v instead of %v — fix manually (myVAILLANT)!",
+			ski, b.target.entityAddr, id, target, orig)
+		return
+	}
+	if p.confirmSetpointValue(b, id, orig) {
+		p.logf("[HVACPROBE] ski=%s entity=%s DELTA TEST complete: setpointId=%d RESTORED to %v",
+			ski, b.target.entityAddr, id, orig)
+	} else {
+		p.logf("[HVACPROBE] ski=%s entity=%s RESTORE NOT CONFIRMED: device never reported %v again — verify manually (myVAILLANT)!",
+			ski, b.target.entityAddr, orig)
+	}
+}
+
+// setpointListWithValue returns a copy of the list with entry idx's value
+// replaced — the original stays untouched for the later restore write.
+func setpointListWithValue(data *model.SetpointListDataType, idx int, value float64) *model.SetpointListDataType {
+	entries := make([]model.SetpointDataType, len(data.SetpointData))
+	copy(entries, data.SetpointData)
+	entries[idx].Value = model.NewScaledNumberType(value)
+	return &model.SetpointListDataType{SetpointData: entries}
+}
+
+// setpointConstraints returns the advertised step/min/max for a setpoint from
+// the cached constraints data. Step defaults to 1 when unavailable.
+func (p *HvacProbe) setpointConstraints(t probeTarget, id model.SetpointIdType) (step float64, minV, maxV *float64) {
+	step = 1
+	raw := t.feature.DataCopy(model.FunctionTypeSetpointConstraintsListData)
+	constraints, ok := raw.(*model.SetpointConstraintsListDataType)
+	if !ok || constraints == nil {
+		return step, nil, nil
+	}
+	for _, c := range constraints.SetpointConstraintsData {
+		if c.SetpointId == nil || *c.SetpointId != id {
+			continue
+		}
+		if c.SetpointStepSize != nil {
+			if s := c.SetpointStepSize.GetValue(); s > 0 {
+				step = s
+			}
+		}
+		if c.SetpointRangeMin != nil {
+			v := c.SetpointRangeMin.GetValue()
+			minV = &v
+		}
+		if c.SetpointRangeMax != nil {
+			v := c.SetpointRangeMax.GetValue()
+			maxV = &v
+		}
+		break
+	}
+	return step, minV, maxV
+}
+
+// confirmSetpointValue re-reads SetpointListData until the device reports the
+// expected value for the setpoint or the poll timeout passes. Each poll
+// issues a fresh read request: the probe holds no subscription, so the remote
+// cache only updates when the device answers a read.
+func (p *HvacProbe) confirmSetpointValue(b pendingBind, id model.SetpointIdType, want float64) bool {
+	deadline := time.Now().Add(p.pollTimeout)
+	for time.Now().Before(deadline) {
+		if _, err := b.localFeature.RequestRemoteData(model.FunctionTypeSetpointListData, nil, nil, b.target.feature); err != nil {
+			return false
+		}
+		time.Sleep(p.pollInterval)
+		raw := b.target.feature.DataCopy(model.FunctionTypeSetpointListData)
+		data, ok := raw.(*model.SetpointListDataType)
+		if !ok || data == nil {
+			continue
+		}
+		for _, sp := range data.SetpointData {
+			if sp.SetpointId != nil && *sp.SetpointId == id && sp.Value != nil && sp.Value.GetValue() == want {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // waitForSetpointData polls the remote feature cache until SetpointListData is

--- a/eebus-bridge/internal/eebus/hvacprobe.go
+++ b/eebus-bridge/internal/eebus/hvacprobe.go
@@ -24,12 +24,21 @@ import (
 // declares writable before we attempt any write.
 //
 // Gated behind experimental.hvac_probe; sends only SPINE read commands, never
-// writes, subscribes or binds.
+// writes or subscribes. Stage 2 (experimental.hvac_probe_bind, EnableBind)
+// additionally requests a binding to each remote Setpoint/HVAC server feature
+// — the precondition for any SPINE write — and reports whether the device
+// accepts it. Still no writes.
 type HvacProbe struct {
 	mu          sync.Mutex
 	localEntity spineapi.EntityLocalInterface
 	probed      map[string]bool
 	logf        func(format string, args ...any)
+
+	// bindEnabled turns on the stage-2 binding attempt. resultHooked tracks
+	// which local client features already log incoming SPINE result messages
+	// (accept/deny replies to the bind requests).
+	bindEnabled  bool
+	resultHooked map[model.FeatureTypeType]bool
 
 	// pollInterval/pollTimeout control how long collectData waits for read
 	// responses to land in the remote feature caches. Overridden in tests.
@@ -65,6 +74,7 @@ func NewHvacProbe(logf func(format string, args ...any)) *HvacProbe {
 	}
 	return &HvacProbe{
 		probed:       make(map[string]bool),
+		resultHooked: make(map[model.FeatureTypeType]bool),
 		logf:         logf,
 		pollInterval: 2 * time.Second,
 		pollTimeout:  30 * time.Second,
@@ -124,6 +134,27 @@ func (p *HvacProbe) ProbeOnce(ski string, device spineapi.DeviceRemoteInterface)
 	if len(pending) > 0 {
 		go p.collectData(ski, pending)
 	}
+
+	p.mu.Lock()
+	bind := p.bindEnabled
+	p.mu.Unlock()
+	if bind {
+		if requested := p.bindAll(ski, local, targets); len(requested) > 0 {
+			go p.collectBindResults(ski, requested)
+		}
+	}
+}
+
+// EnableBind arms stage 2: ProbeOnce additionally requests a binding to each
+// remote Setpoint/HVAC server feature. Call alongside Setup, before the
+// service starts.
+func (p *HvacProbe) EnableBind() {
+	if p == nil {
+		return
+	}
+	p.mu.Lock()
+	p.bindEnabled = true
+	p.mu.Unlock()
 }
 
 // probeTarget is one remote Setpoint/HVAC server feature to interrogate.
@@ -190,6 +221,104 @@ func (p *HvacProbe) requestAll(ski string, local spineapi.EntityLocalInterface, 
 		}
 	}
 	return pending
+}
+
+// pendingBind tracks one bind request awaiting confirmation.
+type pendingBind struct {
+	target       probeTarget
+	localFeature spineapi.FeatureLocalInterface
+}
+
+// bindAll requests a binding from the local client feature to each remote
+// Setpoint/HVAC server feature. Acceptance is confirmed asynchronously: on an
+// accept result spine-go records the binding, which collectBindResults
+// observes via HasBindingToRemote. A result callback per local feature logs
+// the raw accept/deny replies (including the deny error number).
+func (p *HvacProbe) bindAll(ski string, local spineapi.EntityLocalInterface, targets []probeTarget) []pendingBind {
+	var requested []pendingBind
+	for _, t := range targets {
+		featureType := t.feature.Type()
+		localFeature := local.FeatureOfTypeAndRole(featureType, model.RoleTypeClient)
+		if localFeature == nil {
+			continue
+		}
+		p.hookResultLogging(ski, featureType, localFeature)
+
+		remoteAddr := t.feature.Address()
+		if localFeature.HasBindingToRemote(remoteAddr) {
+			p.logf("[HVACPROBE] ski=%s entity=%s bind %s: already bound", ski, t.entityAddr, featureType)
+			continue
+		}
+		msgCounter, err := localFeature.BindToRemote(remoteAddr)
+		if err != nil {
+			p.logf("[HVACPROBE] ski=%s entity=%s bind %s request failed: %s",
+				ski, t.entityAddr, featureType, errorTypeString(err))
+			continue
+		}
+		counter := uint64(0)
+		if msgCounter != nil {
+			counter = uint64(*msgCounter)
+		}
+		p.logf("[HVACPROBE] ski=%s entity=%s bind %s requested (msgCounter=%d)",
+			ski, t.entityAddr, featureType, counter)
+		requested = append(requested, pendingBind{target: t, localFeature: localFeature})
+	}
+	return requested
+}
+
+// hookResultLogging logs every SPINE result message arriving at a local
+// client feature once per feature type. Bind accept/deny replies surface here
+// with their error number (0 = accepted).
+func (p *HvacProbe) hookResultLogging(ski string, featureType model.FeatureTypeType, localFeature spineapi.FeatureLocalInterface) {
+	p.mu.Lock()
+	hooked := p.resultHooked[featureType]
+	if !hooked {
+		p.resultHooked[featureType] = true
+	}
+	p.mu.Unlock()
+	if hooked {
+		return
+	}
+	localFeature.AddResultCallback(func(msg spineapi.ResponseMessage) {
+		result, ok := msg.Data.(*model.ResultDataType)
+		if !ok {
+			return
+		}
+		errno := int64(-1)
+		if result.ErrorNumber != nil {
+			errno = int64(*result.ErrorNumber)
+		}
+		desc := ""
+		if result.Description != nil {
+			desc = " " + string(*result.Description)
+		}
+		p.logf("[HVACPROBE] ski=%s feature=%s result msgCounterRef=%d errorNumber=%d%s",
+			ski, featureType, uint64(msg.MsgCounterReference), errno, desc)
+	})
+}
+
+// collectBindResults polls until each requested binding is confirmed or the
+// timeout passes. A missing confirmation means the device denied or ignored
+// the bind - the result log above carries the deny error number if one came.
+func (p *HvacProbe) collectBindResults(ski string, pending []pendingBind) {
+	deadline := time.Now().Add(p.pollTimeout)
+	for len(pending) > 0 && time.Now().Before(deadline) {
+		time.Sleep(p.pollInterval)
+		remaining := pending[:0]
+		for _, b := range pending {
+			if b.localFeature.HasBindingToRemote(b.target.feature.Address()) {
+				p.logf("[HVACPROBE] ski=%s entity=%s bind %s ACCEPTED",
+					ski, b.target.entityAddr, b.target.feature.Type())
+				continue
+			}
+			remaining = append(remaining, b)
+		}
+		pending = remaining
+	}
+	for _, b := range pending {
+		p.logf("[HVACPROBE] ski=%s entity=%s bind %s NOT confirmed within %s (denied or ignored; see result log)",
+			ski, b.target.entityAddr, b.target.feature.Type(), p.pollTimeout)
+	}
 }
 
 // collectData polls the remote feature caches until every requested function

--- a/eebus-bridge/internal/eebus/hvacprobe.go
+++ b/eebus-bridge/internal/eebus/hvacprobe.go
@@ -27,7 +27,10 @@ import (
 // writes or subscribes. Stage 2 (experimental.hvac_probe_bind, EnableBind)
 // additionally requests a binding to each remote Setpoint/HVAC server feature
 // — the precondition for any SPINE write — and reports whether the device
-// accepts it. Still no writes.
+// accepts it. Stage 3 (experimental.hvac_probe_write, EnableWrite) sends one
+// echo write per accepted Setpoint binding: it writes the device's own current
+// SetpointListData back unchanged, so the write path is exercised without
+// altering any temperature, and reports the device's accept/deny result.
 type HvacProbe struct {
 	mu          sync.Mutex
 	localEntity spineapi.EntityLocalInterface
@@ -46,6 +49,15 @@ type HvacProbe struct {
 	resultHooked map[model.FeatureTypeType]bool
 	nmHooked     bool
 	bindResults  map[uint64]int64
+
+	// writeEnabled turns on the stage-3 echo write. featureResults collects,
+	// per msgCounterReference, the errorNumber of result messages arriving at
+	// the local client features: unlike binds, a write is a direct
+	// client-to-server command, so the device addresses its result to the
+	// sending client feature. bindResults is still polled as a fallback in
+	// case a device routes the write result via NodeManagement instead.
+	writeEnabled   bool
+	featureResults map[uint64]int64
 
 	// pollInterval/pollTimeout control how long collectData waits for read
 	// responses to land in the remote feature caches. Overridden in tests.
@@ -80,12 +92,13 @@ func NewHvacProbe(logf func(format string, args ...any)) *HvacProbe {
 		logf = log.Printf
 	}
 	return &HvacProbe{
-		probed:       make(map[string]bool),
-		resultHooked: make(map[model.FeatureTypeType]bool),
-		bindResults:  make(map[uint64]int64),
-		logf:         logf,
-		pollInterval: 2 * time.Second,
-		pollTimeout:  30 * time.Second,
+		probed:         make(map[string]bool),
+		resultHooked:   make(map[model.FeatureTypeType]bool),
+		bindResults:    make(map[uint64]int64),
+		featureResults: make(map[uint64]int64),
+		logf:           logf,
+		pollInterval:   2 * time.Second,
+		pollTimeout:    30 * time.Second,
 	}
 }
 
@@ -192,6 +205,18 @@ func (p *HvacProbe) EnableBind() {
 	p.mu.Unlock()
 }
 
+// EnableWrite arms stage 3: after a Setpoint binding is ACCEPTED, the probe
+// writes the device's current SetpointListData back unchanged and reports the
+// result. Requires EnableBind; without an accepted binding no write is sent.
+func (p *HvacProbe) EnableWrite() {
+	if p == nil {
+		return
+	}
+	p.mu.Lock()
+	p.writeEnabled = true
+	p.mu.Unlock()
+}
+
 // probeTarget is one remote Setpoint/HVAC server feature to interrogate.
 type probeTarget struct {
 	entityAddr string
@@ -258,10 +283,12 @@ func (p *HvacProbe) requestAll(ski string, local spineapi.EntityLocalInterface, 
 	return pending
 }
 
-// pendingBind tracks one bind request awaiting confirmation.
+// pendingBind tracks one bind request awaiting confirmation. localFeature is
+// kept so the stage-3 write can reuse the bound client feature as sender.
 type pendingBind struct {
-	target     probeTarget
-	msgCounter uint64
+	target       probeTarget
+	localFeature spineapi.FeatureLocalInterface
+	msgCounter   uint64
 }
 
 // bindAll requests a binding from the local client feature to each remote
@@ -299,7 +326,7 @@ func (p *HvacProbe) bindAll(ski string, local spineapi.EntityLocalInterface, tar
 		}
 		p.logf("[HVACPROBE] ski=%s entity=%s bind %s requested (msgCounter=%d)",
 			ski, t.entityAddr, featureType, counter)
-		requested = append(requested, pendingBind{target: t, msgCounter: counter})
+		requested = append(requested, pendingBind{target: t, localFeature: localFeature, msgCounter: counter})
 	}
 	return requested
 }
@@ -350,6 +377,9 @@ func (p *HvacProbe) hookResultLogging(ski string, featureType model.FeatureTypeT
 		if result.ErrorNumber != nil {
 			errno = int64(*result.ErrorNumber)
 		}
+		p.mu.Lock()
+		p.featureResults[uint64(msg.MsgCounterReference)] = errno
+		p.mu.Unlock()
 		desc := ""
 		if result.Description != nil {
 			desc = " " + string(*result.Description)
@@ -378,6 +408,12 @@ func (p *HvacProbe) collectBindResults(ski string, pending []pendingBind) {
 			if errno == 0 {
 				p.logf("[HVACPROBE] ski=%s entity=%s bind %s ACCEPTED (msgCounter=%d)",
 					ski, b.target.entityAddr, b.target.feature.Type(), b.msgCounter)
+				p.mu.Lock()
+				write := p.writeEnabled
+				p.mu.Unlock()
+				if write && b.target.feature.Type() == model.FeatureTypeTypeSetpoint {
+					go p.attemptSetpointEchoWrite(ski, b)
+				}
 			} else {
 				p.logf("[HVACPROBE] ski=%s entity=%s bind %s DENIED errorNumber=%d (msgCounter=%d)",
 					ski, b.target.entityAddr, b.target.feature.Type(), errno, b.msgCounter)
@@ -389,6 +425,88 @@ func (p *HvacProbe) collectBindResults(ski string, pending []pendingBind) {
 		p.logf("[HVACPROBE] ski=%s entity=%s bind %s NOT answered within %s",
 			ski, b.target.entityAddr, b.target.feature.Type(), p.pollTimeout)
 	}
+}
+
+// attemptSetpointEchoWrite is stage 3: once the device accepted the Setpoint
+// binding, wait for its SetpointListData to arrive in the remote feature
+// cache, then write that exact data back. The values are unchanged, so the
+// device's temperature configuration is untouched — the point is whether the
+// write command itself is ACCEPTED (result errorNumber 0) or denied, which is
+// the last open question before building a real configurationOf* use case.
+func (p *HvacProbe) attemptSetpointEchoWrite(ski string, b pendingBind) {
+	data := p.waitForSetpointData(b.target)
+	if data == nil {
+		p.logf("[HVACPROBE] ski=%s entity=%s write skipped: no setpointListData within %s",
+			ski, b.target.entityAddr, p.pollTimeout)
+		return
+	}
+	if len(data.SetpointData) == 0 {
+		p.logf("[HVACPROBE] ski=%s entity=%s write skipped: setpointListData has no entries", ski, b.target.entityAddr)
+		return
+	}
+
+	payload, err := json.Marshal(data)
+	if err != nil {
+		payload = []byte(fmt.Sprintf("%+v", data))
+	}
+	p.logf("[HVACPROBE] ski=%s entity=%s echo-writing current setpointListData (values unchanged): %s",
+		ski, b.target.entityAddr, payload)
+
+	cmd := model.CmdType{SetpointListData: data}
+	msgCounter, werr := b.target.feature.Device().Sender().Write(b.localFeature.Address(), b.target.feature.Address(), cmd)
+	if werr != nil {
+		p.logf("[HVACPROBE] ski=%s entity=%s write Setpoint send failed: %v", ski, b.target.entityAddr, werr)
+		return
+	}
+	counter := uint64(0)
+	if msgCounter != nil {
+		counter = uint64(*msgCounter)
+	}
+	p.logf("[HVACPROBE] ski=%s entity=%s write Setpoint sent (msgCounter=%d)", ski, b.target.entityAddr, counter)
+
+	deadline := time.Now().Add(p.pollTimeout)
+	for time.Now().Before(deadline) {
+		time.Sleep(p.pollInterval)
+		p.mu.Lock()
+		errno, ok := p.featureResults[counter]
+		if !ok {
+			// Fallback: some routing puts results on NodeManagement instead.
+			errno, ok = p.bindResults[counter]
+		}
+		p.mu.Unlock()
+		if !ok {
+			continue
+		}
+		if errno == 0 {
+			p.logf("[HVACPROBE] ski=%s entity=%s write Setpoint ACCEPTED (msgCounter=%d)",
+				ski, b.target.entityAddr, counter)
+		} else {
+			p.logf("[HVACPROBE] ski=%s entity=%s write Setpoint DENIED errorNumber=%d (msgCounter=%d)",
+				ski, b.target.entityAddr, errno, counter)
+		}
+		return
+	}
+	p.logf("[HVACPROBE] ski=%s entity=%s write Setpoint NOT answered within %s",
+		ski, b.target.entityAddr, p.pollTimeout)
+}
+
+// waitForSetpointData polls the remote feature cache until SetpointListData is
+// available or the poll timeout passes. Returns nil on timeout or type
+// mismatch.
+func (p *HvacProbe) waitForSetpointData(t probeTarget) *model.SetpointListDataType {
+	deadline := time.Now().Add(p.pollTimeout)
+	for time.Now().Before(deadline) {
+		raw := t.feature.DataCopy(model.FunctionTypeSetpointListData)
+		if raw != nil && !isNilPointer(raw) {
+			data, ok := raw.(*model.SetpointListDataType)
+			if !ok {
+				return nil
+			}
+			return data
+		}
+		time.Sleep(p.pollInterval)
+	}
+	return nil
 }
 
 // collectData polls the remote feature caches until every requested function

--- a/eebus-bridge/internal/eebus/hvacprobe.go
+++ b/eebus-bridge/internal/eebus/hvacprobe.go
@@ -31,6 +31,9 @@ import (
 // echo write per accepted Setpoint binding: it writes the device's own current
 // SetpointListData back unchanged, so the write path is exercised without
 // altering any temperature, and reports the device's accept/deny result.
+// Stage 3b (experimental.hvac_probe_write_delta_ski, EnableWriteDelta) proves
+// the device applies writes: scoped to one SKI, it changes the dhwTemperature
+// setpoint by one advertised step, confirms via re-read, and restores.
 type HvacProbe struct {
 	mu          sync.Mutex
 	localEntity spineapi.EntityLocalInterface
@@ -46,6 +49,7 @@ type HvacProbe struct {
 	// its errorNumber per msgCounterReference for collectBindResults to match
 	// against the counters returned by BindToRemote.
 	bindEnabled  bool
+	ucAdvertised bool
 	resultHooked map[model.FeatureTypeType]bool
 	nmHooked     bool
 	bindResults  map[uint64]int64
@@ -59,12 +63,12 @@ type HvacProbe struct {
 	writeEnabled   bool
 	featureResults map[uint64]int64
 
-	// writeDeltaEnabled turns on the stage-3b value-changing test: on the
-	// DHWCircuit entity the echo write is replaced by write(current±1) →
-	// re-read to confirm the device applied it → write(original) → re-read.
-	// The setpoint is off its original value only for the seconds between the
-	// two writes.
-	writeDeltaEnabled bool
+	// writeDeltaSKI arms the stage-3b value-changing test for exactly one
+	// device: on that device's DHWCircuit entity the echo write is replaced by
+	// write(current±step) → re-read to confirm the device applied it →
+	// write(original) → re-read. The setpoint is off its original value only
+	// for the seconds between the two writes. Empty means never.
+	writeDeltaSKI string
 
 	// pollInterval/pollTimeout control how long collectData waits for read
 	// responses to land in the remote feature caches. Overridden in tests.
@@ -132,21 +136,44 @@ var hvacProbeUseCases = []struct {
 }
 
 // Setup arms the probe: it registers Setpoint and HVAC client features on the
-// local entity (required as SPINE sender addresses for the read requests) and
-// advertises the matching ConfigurationAppliance client use cases. Both change
-// the announced NodeManagement data, so Setup must run before the EEBUS
+// local entity (required as SPINE sender addresses for the read requests).
+// The ConfigurationAppliance client use cases are only advertised once the
+// bind stage is armed (stage 2b) — the pure read probe must not claim use
+// cases the bridge doesn't implement. Both change the announced
+// NodeManagement data, so Setup and EnableBind must run before the EEBUS
 // service starts. Not calling Setup leaves ProbeOnce a no-op.
 func (p *HvacProbe) Setup(localEntity spineapi.EntityLocalInterface) {
 	if p == nil || localEntity == nil {
 		return
 	}
 	p.mu.Lock()
-	defer p.mu.Unlock()
 	p.localEntity = localEntity
+	bind := p.bindEnabled
+	p.mu.Unlock()
 	localEntity.GetOrAddFeature(model.FeatureTypeTypeSetpoint, model.RoleTypeClient)
 	localEntity.GetOrAddFeature(model.FeatureTypeTypeHvac, model.RoleTypeClient)
+	if bind {
+		p.advertiseClientUseCases()
+	}
+}
+
+// advertiseClientUseCases announces, once, the ConfigurationAppliance client
+// counterparts of the configurationOf* use cases in NodeManagement. Part of
+// stage 2b: claiming the client role is only justified when the probe
+// actually binds (and possibly writes), not for raw diagnostic reads.
+func (p *HvacProbe) advertiseClientUseCases() {
+	p.mu.Lock()
+	local := p.localEntity
+	done := p.ucAdvertised
+	if local != nil {
+		p.ucAdvertised = true
+	}
+	p.mu.Unlock()
+	if local == nil || done {
+		return
+	}
 	for _, uc := range hvacProbeUseCases {
-		localEntity.AddUseCaseSupport(
+		local.AddUseCaseSupport(
 			model.UseCaseActorTypeConfigurationAppliance,
 			uc.name,
 			model.SpecificationVersionType("1.0.0"),
@@ -201,8 +228,9 @@ func (p *HvacProbe) ProbeOnce(ski string, device spineapi.DeviceRemoteInterface)
 }
 
 // EnableBind arms stage 2: ProbeOnce additionally requests a binding to each
-// remote Setpoint/HVAC server feature. Call alongside Setup, before the
-// service starts.
+// remote Setpoint/HVAC server feature, and the matching ConfigurationAppliance
+// client use cases are advertised in NodeManagement. Call alongside Setup,
+// before the service starts.
 func (p *HvacProbe) EnableBind() {
 	if p == nil {
 		return
@@ -210,6 +238,7 @@ func (p *HvacProbe) EnableBind() {
 	p.mu.Lock()
 	p.bindEnabled = true
 	p.mu.Unlock()
+	p.advertiseClientUseCases()
 }
 
 // EnableWrite arms stage 3: after a Setpoint binding is ACCEPTED, the probe
@@ -224,16 +253,19 @@ func (p *HvacProbe) EnableWrite() {
 	p.mu.Unlock()
 }
 
-// EnableWriteDelta arms stage 3b: on the DHWCircuit entity, instead of the
-// echo write, change the DHW setpoint by one step (clamped to the advertised
-// constraints), re-read to confirm the device applied it, then write the
-// original value back and confirm the restore. Requires EnableWrite.
-func (p *HvacProbe) EnableWriteDelta() {
+// EnableWriteDelta arms stage 3b for exactly the device with the given SKI:
+// on its DHWCircuit entity, instead of the echo write, change the
+// dhwTemperature setpoint by one advertised step, re-read to confirm the
+// device applied it, then write the original value back and confirm the
+// restore. Fail-closed: without a SKI, a dhwTemperature-scoped setpoint
+// description, complete constraints, and a writable setpointListData
+// operation, no value-changing write is sent. Requires EnableWrite.
+func (p *HvacProbe) EnableWriteDelta(ski string) {
 	if p == nil {
 		return
 	}
 	p.mu.Lock()
-	p.writeDeltaEnabled = true
+	p.writeDeltaSKI = NormalizeSKI(ski)
 	p.mu.Unlock()
 }
 
@@ -466,9 +498,9 @@ func (p *HvacProbe) attemptSetpointEchoWrite(ski string, b pendingBind) {
 	}
 
 	p.mu.Lock()
-	delta := p.writeDeltaEnabled
+	deltaSKI := p.writeDeltaSKI
 	p.mu.Unlock()
-	if delta && b.target.entityType == model.EntityTypeTypeDHWCircuit {
+	if deltaSKI != "" && deltaSKI == NormalizeSKI(ski) && b.target.entityType == model.EntityTypeTypeDHWCircuit {
 		p.runSetpointDeltaTest(ski, b, data)
 		return
 	}
@@ -483,14 +515,15 @@ func (p *HvacProbe) attemptSetpointEchoWrite(ski string, b pendingBind) {
 }
 
 // sendSetpointWriteAndAwait sends one SetpointListData write and waits for the
-// device's result. Returns the errorNumber and whether a result arrived at
-// all; label distinguishes echo/delta/restore writes in the log.
-func (p *HvacProbe) sendSetpointWriteAndAwait(ski string, b pendingBind, data *model.SetpointListDataType, label string) (int64, bool) {
+// device's result. sent reports whether the command reached the sender at all;
+// seen whether a result arrived; errno is only meaningful when seen. label
+// distinguishes echo/delta/restore writes in the log.
+func (p *HvacProbe) sendSetpointWriteAndAwait(ski string, b pendingBind, data *model.SetpointListDataType, label string) (errno int64, seen, sent bool) {
 	cmd := model.CmdType{SetpointListData: data}
 	msgCounter, werr := b.target.feature.Device().Sender().Write(b.localFeature.Address(), b.target.feature.Address(), cmd)
 	if werr != nil {
 		p.logf("[HVACPROBE] ski=%s entity=%s %s Setpoint send failed: %v", ski, b.target.entityAddr, label, werr)
-		return -1, false
+		return -1, false, false
 	}
 	counter := uint64(0)
 	if msgCounter != nil {
@@ -502,78 +535,108 @@ func (p *HvacProbe) sendSetpointWriteAndAwait(ski string, b pendingBind, data *m
 	for time.Now().Before(deadline) {
 		time.Sleep(p.pollInterval)
 		p.mu.Lock()
-		errno, ok := p.featureResults[counter]
+		res, ok := p.featureResults[counter]
 		if !ok {
 			// Fallback: some routing puts results on NodeManagement instead.
-			errno, ok = p.bindResults[counter]
+			res, ok = p.bindResults[counter]
 		}
 		p.mu.Unlock()
 		if !ok {
 			continue
 		}
-		if errno == 0 {
+		if res == 0 {
 			p.logf("[HVACPROBE] ski=%s entity=%s %s Setpoint ACCEPTED (msgCounter=%d)",
 				ski, b.target.entityAddr, label, counter)
 		} else {
 			p.logf("[HVACPROBE] ski=%s entity=%s %s Setpoint DENIED errorNumber=%d (msgCounter=%d)",
-				ski, b.target.entityAddr, label, errno, counter)
+				ski, b.target.entityAddr, label, res, counter)
 		}
-		return errno, true
+		return res, true, true
 	}
 	p.logf("[HVACPROBE] ski=%s entity=%s %s Setpoint NOT answered within %s",
 		ski, b.target.entityAddr, label, p.pollTimeout)
-	return -1, false
+	return -1, false, true
 }
 
 // runSetpointDeltaTest is stage 3b: prove the device APPLIES writes, not just
-// ACKs them. It changes the first valued setpoint by one constraint step
-// (default +1, clamped to the advertised range), re-reads until the device
-// reports the new value, then writes the original value back and confirms the
-// restore. A failed restore is logged loudly — that is the one outcome
-// needing manual attention (device keeps the changed setpoint).
+// ACKs them. Fail-closed target selection: the setpoint must be identified as
+// dhwTemperature via its description, declare complete constraints (positive
+// step, min and max), and the remote feature must advertise setpointListData
+// as writable — otherwise no value-changing write is sent. Once the delta
+// write was handed to the sender, the original value is restored best-effort
+// regardless of whether a result was seen: a lost or late result does not
+// prove the device ignored the command. A failed restore is logged loudly —
+// that is the one outcome needing manual attention.
 func (p *HvacProbe) runSetpointDeltaTest(ski string, b pendingBind, data *model.SetpointListDataType) {
+	op := b.target.feature.Operations()[model.FunctionTypeSetpointListData]
+	if op == nil || !op.Write() {
+		p.logf("[HVACPROBE] ski=%s entity=%s delta test skipped: setpointListData not advertised writable", ski, b.target.entityAddr)
+		return
+	}
+	id, ok := p.dhwTemperatureSetpointId(b.target)
+	if !ok {
+		p.logf("[HVACPROBE] ski=%s entity=%s delta test skipped: no dhwTemperature-scoped setpoint description within %s",
+			ski, b.target.entityAddr, p.pollTimeout)
+		return
+	}
 	idx := -1
 	for i, sp := range data.SetpointData {
-		if sp.SetpointId != nil && sp.Value != nil {
+		if sp.SetpointId != nil && *sp.SetpointId == id && sp.Value != nil {
 			idx = i
 			break
 		}
 	}
 	if idx < 0 {
-		p.logf("[HVACPROBE] ski=%s entity=%s delta test skipped: no setpoint entry with a value", ski, b.target.entityAddr)
+		p.logf("[HVACPROBE] ski=%s entity=%s delta test skipped: setpointId=%d has no value", ski, b.target.entityAddr, id)
 		return
 	}
-	id := *data.SetpointData[idx].SetpointId
 	orig := data.SetpointData[idx].Value.GetValue()
 
-	step, minV, maxV := p.setpointConstraints(b.target, id)
+	step, minV, maxV, ok := p.setpointConstraints(b.target, id)
+	if !ok {
+		p.logf("[HVACPROBE] ski=%s entity=%s delta test skipped: setpointId=%d has incomplete constraints (need step+min+max)",
+			ski, b.target.entityAddr, id)
+		return
+	}
 	target := orig + step
-	if maxV != nil && target > *maxV {
+	if target > maxV {
 		target = orig - step
 	}
-	if minV != nil && target < *minV {
+	if target < minV {
 		p.logf("[HVACPROBE] ski=%s entity=%s delta test skipped: no room within constraints [%v..%v]",
-			ski, b.target.entityAddr, *minV, *maxV)
+			ski, b.target.entityAddr, minV, maxV)
 		return
 	}
 
 	p.logf("[HVACPROBE] ski=%s entity=%s DELTA TEST setpointId=%d: %v -> %v (restore follows)",
 		ski, b.target.entityAddr, id, orig, target)
-	if errno, ok := p.sendSetpointWriteAndAwait(ski, b, setpointListWithValue(data, idx, target), "delta-write"); !ok || errno != 0 {
-		p.logf("[HVACPROBE] ski=%s entity=%s DELTA TEST aborted: delta write not accepted; device should still be at %v",
+	errno, seen, sent := p.sendSetpointWriteAndAwait(ski, b, setpointListWithValue(data, idx, target), "delta-write")
+	if !sent {
+		// Nothing reached the sender; the device cannot have changed.
+		p.logf("[HVACPROBE] ski=%s entity=%s DELTA TEST aborted: delta write not sent; device unchanged at %v",
 			ski, b.target.entityAddr, orig)
 		return
 	}
-	if p.confirmSetpointValue(b, id, target) {
+	// From here on the command is out — restore no matter what the result
+	// said: even a missing or negative result does not prove the device did
+	// not apply the write.
+	if !seen {
+		p.logf("[HVACPROBE] ski=%s entity=%s delta-write result not seen; confirming and restoring anyway", ski, b.target.entityAddr)
+	}
+	switch {
+	case seen && errno != 0:
+		p.logf("[HVACPROBE] ski=%s entity=%s DELTA TEST setpointId=%d denied by device; verifying it stayed at %v",
+			ski, b.target.entityAddr, id, orig)
+	case p.confirmSetpointValue(b, id, target):
 		p.logf("[HVACPROBE] ski=%s entity=%s DELTA TEST setpointId=%d APPLIED: device now reports %v",
 			ski, b.target.entityAddr, id, target)
-	} else {
+	default:
 		p.logf("[HVACPROBE] ski=%s entity=%s DELTA TEST setpointId=%d NOT CONFIRMED: device never reported %v (ACK without apply?)",
 			ski, b.target.entityAddr, id, target)
 	}
 
-	// Restore unconditionally — even an unconfirmed delta may have been applied.
-	if errno, ok := p.sendSetpointWriteAndAwait(ski, b, setpointListWithValue(data, idx, orig), "restore"); !ok || errno != 0 {
+	_, _, sent = p.sendSetpointWriteAndAwait(ski, b, setpointListWithValue(data, idx, orig), "restore")
+	if !sent {
 		p.logf("[HVACPROBE] ski=%s entity=%s RESTORE FAILED: setpointId=%d may still be at %v instead of %v — fix manually (myVAILLANT)!",
 			ski, b.target.entityAddr, id, target, orig)
 		return
@@ -587,6 +650,27 @@ func (p *HvacProbe) runSetpointDeltaTest(ski string, b pendingBind, data *model.
 	}
 }
 
+// dhwTemperatureSetpointId polls the cached setpoint descriptions for the one
+// scoped dhwTemperature. The description read is requested during stage 1, so
+// the data normally arrives within the poll window.
+func (p *HvacProbe) dhwTemperatureSetpointId(t probeTarget) (model.SetpointIdType, bool) {
+	deadline := time.Now().Add(p.pollTimeout)
+	for {
+		raw := t.feature.DataCopy(model.FunctionTypeSetpointDescriptionListData)
+		if desc, ok := raw.(*model.SetpointDescriptionListDataType); ok && desc != nil {
+			for _, d := range desc.SetpointDescriptionData {
+				if d.SetpointId != nil && d.ScopeType != nil && *d.ScopeType == model.ScopeTypeTypeDhwTemperature {
+					return *d.SetpointId, true
+				}
+			}
+		}
+		if !time.Now().Before(deadline) {
+			return 0, false
+		}
+		time.Sleep(p.pollInterval)
+	}
+}
+
 // setpointListWithValue returns a copy of the list with entry idx's value
 // replaced — the original stays untouched for the later restore write.
 func setpointListWithValue(data *model.SetpointListDataType, idx int, value float64) *model.SetpointListDataType {
@@ -597,34 +681,29 @@ func setpointListWithValue(data *model.SetpointListDataType, idx int, value floa
 }
 
 // setpointConstraints returns the advertised step/min/max for a setpoint from
-// the cached constraints data. Step defaults to 1 when unavailable.
-func (p *HvacProbe) setpointConstraints(t probeTarget, id model.SetpointIdType) (step float64, minV, maxV *float64) {
-	step = 1
+// the cached constraints data. ok is false unless all three are present and
+// the step is positive — the delta test must not guess bounds for a write
+// that changes a real appliance.
+func (p *HvacProbe) setpointConstraints(t probeTarget, id model.SetpointIdType) (step, minV, maxV float64, ok bool) {
 	raw := t.feature.DataCopy(model.FunctionTypeSetpointConstraintsListData)
-	constraints, ok := raw.(*model.SetpointConstraintsListDataType)
-	if !ok || constraints == nil {
-		return step, nil, nil
+	constraints, isList := raw.(*model.SetpointConstraintsListDataType)
+	if !isList || constraints == nil {
+		return 0, 0, 0, false
 	}
 	for _, c := range constraints.SetpointConstraintsData {
 		if c.SetpointId == nil || *c.SetpointId != id {
 			continue
 		}
-		if c.SetpointStepSize != nil {
-			if s := c.SetpointStepSize.GetValue(); s > 0 {
-				step = s
-			}
+		if c.SetpointStepSize == nil || c.SetpointRangeMin == nil || c.SetpointRangeMax == nil {
+			return 0, 0, 0, false
 		}
-		if c.SetpointRangeMin != nil {
-			v := c.SetpointRangeMin.GetValue()
-			minV = &v
+		step = c.SetpointStepSize.GetValue()
+		if step <= 0 {
+			return 0, 0, 0, false
 		}
-		if c.SetpointRangeMax != nil {
-			v := c.SetpointRangeMax.GetValue()
-			maxV = &v
-		}
-		break
+		return step, c.SetpointRangeMin.GetValue(), c.SetpointRangeMax.GetValue(), true
 	}
-	return step, minV, maxV
+	return 0, 0, 0, false
 }
 
 // confirmSetpointValue re-reads SetpointListData until the device reports the

--- a/eebus-bridge/internal/eebus/hvacprobe.go
+++ b/eebus-bridge/internal/eebus/hvacprobe.go
@@ -1,0 +1,263 @@
+package eebus
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	spineapi "github.com/enbility/spine-go/api"
+	"github.com/enbility/spine-go/model"
+)
+
+// HvacProbe is a read-only diagnostic for the VR940's HVAC domain (stage 1 of
+// the HVAC/DHW control spike, see docs/vr940-usecase-dump.txt). The dump shows
+// the DHWCircuit and HVACRoom entities expose Setpoint and HVAC server
+// features backing the configurationOfDhw*/configurationOfRoomHeating* use
+// cases, but eebus-go ships no use case for them — so this probe talks raw
+// SPINE: it requests every Setpoint/HVAC read function from those features and
+// logs the returned data plus the advertised read/write operations. The
+// operations output is the payoff: it tells us which functions the device
+// declares writable before we attempt any write.
+//
+// Gated behind experimental.hvac_probe; sends only SPINE read commands, never
+// writes, subscribes or binds.
+type HvacProbe struct {
+	mu          sync.Mutex
+	localEntity spineapi.EntityLocalInterface
+	probed      map[string]bool
+	logf        func(format string, args ...any)
+
+	// pollInterval/pollTimeout control how long collectData waits for read
+	// responses to land in the remote feature caches. Overridden in tests.
+	pollInterval time.Duration
+	pollTimeout  time.Duration
+}
+
+// hvacProbeFunctions lists, per feature type, the SPINE read functions the
+// probe requests. Order matches the SPINE spec grouping (descriptions before
+// values) purely for log readability.
+var hvacProbeFunctions = map[model.FeatureTypeType][]model.FunctionType{
+	model.FeatureTypeTypeSetpoint: {
+		model.FunctionTypeSetpointDescriptionListData,
+		model.FunctionTypeSetpointConstraintsListData,
+		model.FunctionTypeSetpointListData,
+	},
+	model.FeatureTypeTypeHvac: {
+		model.FunctionTypeHvacSystemFunctionDescriptionListData,
+		model.FunctionTypeHvacSystemFunctionListData,
+		model.FunctionTypeHvacOperationModeDescriptionListData,
+		model.FunctionTypeHvacSystemFunctionOperationModeRelationListData,
+		model.FunctionTypeHvacSystemFunctionSetPointRelationListData,
+		model.FunctionTypeHvacOverrunDescriptionListData,
+		model.FunctionTypeHvacOverrunListData,
+	},
+}
+
+// NewHvacProbe returns a probe writing through logf (nil uses log.Printf).
+// The probe stays inert until Setup provides a local entity.
+func NewHvacProbe(logf func(format string, args ...any)) *HvacProbe {
+	if logf == nil {
+		logf = log.Printf
+	}
+	return &HvacProbe{
+		probed:       make(map[string]bool),
+		logf:         logf,
+		pollInterval: 2 * time.Second,
+		pollTimeout:  30 * time.Second,
+	}
+}
+
+var defaultHvacProbe = NewHvacProbe(nil)
+
+// DefaultHvacProbe returns the process-wide probe shared by the use-case
+// wrappers, mirroring DefaultUseCaseDiscovery.
+func DefaultHvacProbe() *HvacProbe { return defaultHvacProbe }
+
+// Setup arms the probe: it registers Setpoint and HVAC client features on the
+// local entity (required as SPINE sender addresses for the read requests) and
+// must therefore run before the EEBUS service starts announcing its feature
+// map. Not calling Setup leaves ProbeOnce a no-op.
+func (p *HvacProbe) Setup(localEntity spineapi.EntityLocalInterface) {
+	if p == nil || localEntity == nil {
+		return
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.localEntity = localEntity
+	localEntity.GetOrAddFeature(model.FeatureTypeTypeSetpoint, model.RoleTypeClient)
+	localEntity.GetOrAddFeature(model.FeatureTypeTypeHvac, model.RoleTypeClient)
+}
+
+// ProbeOnce probes a remote device the first time it appears with at least one
+// Setpoint/HVAC server feature. Devices without such features are ignored but
+// not marked probed, so a later event (once SPINE detailed discovery filled in
+// the entities) retries. Safe for nil receiver/device and when Setup never ran.
+func (p *HvacProbe) ProbeOnce(ski string, device spineapi.DeviceRemoteInterface) {
+	if p == nil || device == nil {
+		return
+	}
+
+	ski = NormalizeSKI(ski)
+	if ski == "" {
+		ski = NormalizeSKI(device.Ski())
+	}
+
+	p.mu.Lock()
+	local := p.localEntity
+	if local == nil || p.probed[ski] {
+		p.mu.Unlock()
+		return
+	}
+	targets := p.findTargets(device)
+	if len(targets) == 0 {
+		p.mu.Unlock()
+		return
+	}
+	p.probed[ski] = true
+	p.mu.Unlock()
+
+	pending := p.requestAll(ski, local, targets)
+	if len(pending) > 0 {
+		go p.collectData(ski, pending)
+	}
+}
+
+// probeTarget is one remote Setpoint/HVAC server feature to interrogate.
+type probeTarget struct {
+	entityAddr string
+	entityType model.EntityTypeType
+	feature    spineapi.FeatureRemoteInterface
+}
+
+// pendingRead tracks one requested function awaiting response data.
+type pendingRead struct {
+	target   probeTarget
+	function model.FunctionType
+}
+
+// findTargets collects every Setpoint/HVAC server feature across the device's
+// entities. Caller holds p.mu.
+func (p *HvacProbe) findTargets(device spineapi.DeviceRemoteInterface) []probeTarget {
+	var targets []probeTarget
+	for _, entity := range device.Entities() {
+		if entity == nil {
+			continue
+		}
+		for featureType := range hvacProbeFunctions {
+			feature := entity.FeatureOfTypeAndRole(featureType, model.RoleTypeServer)
+			if feature == nil {
+				continue
+			}
+			targets = append(targets, probeTarget{
+				entityAddr: formatEntityAddress(entity.Address()),
+				entityType: entity.EntityType(),
+				feature:    feature,
+			})
+		}
+	}
+	return targets
+}
+
+// requestAll logs each target's advertised operations (read/write flags per
+// function — the ground truth for what the device claims is controllable) and
+// fires a SPINE read request per candidate function. Returns the reads to
+// poll for response data.
+func (p *HvacProbe) requestAll(ski string, local spineapi.EntityLocalInterface, targets []probeTarget) []pendingRead {
+	var pending []pendingRead
+	for _, t := range targets {
+		featureType := t.feature.Type()
+		p.logf("[HVACPROBE] ski=%s entity=%s type=%s feature=%s operations=[%s]",
+			ski, t.entityAddr, t.entityType, featureType, formatOperations(t.feature.Operations()))
+
+		localFeature := local.FeatureOfTypeAndRole(featureType, model.RoleTypeClient)
+		if localFeature == nil {
+			p.logf("[HVACPROBE] ski=%s entity=%s feature=%s: no local client feature, skipping",
+				ski, t.entityAddr, featureType)
+			continue
+		}
+
+		for _, fn := range hvacProbeFunctions[featureType] {
+			if _, err := localFeature.RequestRemoteData(fn, nil, nil, t.feature); err != nil {
+				p.logf("[HVACPROBE] ski=%s entity=%s read %s failed: %s",
+					ski, t.entityAddr, fn, errorTypeString(err))
+				continue
+			}
+			pending = append(pending, pendingRead{target: t, function: fn})
+		}
+	}
+	return pending
+}
+
+// collectData polls the remote feature caches until every requested function
+// produced data or the timeout passes, logging each payload as JSON once.
+func (p *HvacProbe) collectData(ski string, pending []pendingRead) {
+	deadline := time.Now().Add(p.pollTimeout)
+	for len(pending) > 0 && time.Now().Before(deadline) {
+		time.Sleep(p.pollInterval)
+		remaining := pending[:0]
+		for _, r := range pending {
+			data := r.target.feature.DataCopy(r.function)
+			if data == nil || isNilPointer(data) {
+				remaining = append(remaining, r)
+				continue
+			}
+			payload, err := json.Marshal(data)
+			if err != nil {
+				payload = []byte(fmt.Sprintf("%+v", data))
+			}
+			p.logf("[HVACPROBE] ski=%s entity=%s type=%s data %s = %s",
+				ski, r.target.entityAddr, r.target.entityType, r.function, payload)
+		}
+		pending = remaining
+	}
+	for _, r := range pending {
+		p.logf("[HVACPROBE] ski=%s entity=%s data %s = <no response within %s>",
+			ski, r.target.entityAddr, r.function, p.pollTimeout)
+	}
+}
+
+// isNilPointer reports whether DataCopy returned a typed nil pointer wrapped
+// in a non-nil interface (spine-go returns e.g. (*SetpointListDataType)(nil)
+// for functions that never received data).
+func isNilPointer(v any) bool {
+	return v == nil || fmt.Sprintf("%v", v) == "<nil>"
+}
+
+// formatOperations renders a sorted "function:r/w" summary of a feature's
+// advertised operations. Empty when the device announced none (yet).
+func formatOperations(ops map[model.FunctionType]spineapi.OperationsInterface) string {
+	out := make([]string, 0, len(ops))
+	for fn, op := range ops {
+		if op == nil {
+			continue
+		}
+		flags := ""
+		if op.Read() {
+			flags += "r"
+		}
+		if op.Write() {
+			flags += "w"
+		}
+		if flags == "" {
+			flags = "-"
+		}
+		out = append(out, fmt.Sprintf("%s:%s", fn, flags))
+	}
+	sort.Strings(out)
+	return strings.Join(out, ", ")
+}
+
+// errorTypeString renders a spine ErrorType for logging.
+func errorTypeString(err *model.ErrorType) string {
+	if err == nil {
+		return "unknown error"
+	}
+	if err.Description != nil && *err.Description != "" {
+		return fmt.Sprintf("%d (%s)", err.ErrorNumber, string(*err.Description))
+	}
+	return fmt.Sprintf("error number %d", err.ErrorNumber)
+}

--- a/eebus-bridge/internal/eebus/hvacprobe.go
+++ b/eebus-bridge/internal/eebus/hvacprobe.go
@@ -36,9 +36,16 @@ type HvacProbe struct {
 
 	// bindEnabled turns on the stage-2 binding attempt. resultHooked tracks
 	// which local client features already log incoming SPINE result messages
-	// (accept/deny replies to the bind requests).
+	// (errors replying to the read requests). Bind accept/deny results do NOT
+	// arrive there: binding management runs NodeManagement-to-NodeManagement,
+	// so the device addresses its result to the local NodeManagement feature.
+	// nmHooked guards the one callback registered there; bindResults collects
+	// its errorNumber per msgCounterReference for collectBindResults to match
+	// against the counters returned by BindToRemote.
 	bindEnabled  bool
 	resultHooked map[model.FeatureTypeType]bool
+	nmHooked     bool
+	bindResults  map[uint64]int64
 
 	// pollInterval/pollTimeout control how long collectData waits for read
 	// responses to land in the remote feature caches. Overridden in tests.
@@ -75,6 +82,7 @@ func NewHvacProbe(logf func(format string, args ...any)) *HvacProbe {
 	return &HvacProbe{
 		probed:       make(map[string]bool),
 		resultHooked: make(map[model.FeatureTypeType]bool),
+		bindResults:  make(map[uint64]int64),
 		logf:         logf,
 		pollInterval: 2 * time.Second,
 		pollTimeout:  30 * time.Second,
@@ -252,16 +260,19 @@ func (p *HvacProbe) requestAll(ski string, local spineapi.EntityLocalInterface, 
 
 // pendingBind tracks one bind request awaiting confirmation.
 type pendingBind struct {
-	target       probeTarget
-	localFeature spineapi.FeatureLocalInterface
+	target     probeTarget
+	msgCounter uint64
 }
 
 // bindAll requests a binding from the local client feature to each remote
-// Setpoint/HVAC server feature. Acceptance is confirmed asynchronously: on an
-// accept result spine-go records the binding, which collectBindResults
-// observes via HasBindingToRemote. A result callback per local feature logs
-// the raw accept/deny replies (including the deny error number).
+// Setpoint/HVAC server feature. Acceptance is confirmed asynchronously via
+// the result callback on the local NodeManagement feature (binding management
+// is a NodeManagement-to-NodeManagement exchange, so the accept/deny result
+// is addressed there — NOT to the client feature; spine-go's own
+// bindResponseCallback and HasBindingToRemote miss it for the same reason).
+// collectBindResults matches the results against the request msgCounters.
 func (p *HvacProbe) bindAll(ski string, local spineapi.EntityLocalInterface, targets []probeTarget) []pendingBind {
+	p.hookNodeManagementResults(local)
 	var requested []pendingBind
 	for _, t := range targets {
 		featureType := t.feature.Type()
@@ -288,9 +299,33 @@ func (p *HvacProbe) bindAll(ski string, local spineapi.EntityLocalInterface, tar
 		}
 		p.logf("[HVACPROBE] ski=%s entity=%s bind %s requested (msgCounter=%d)",
 			ski, t.entityAddr, featureType, counter)
-		requested = append(requested, pendingBind{target: t, localFeature: localFeature})
+		requested = append(requested, pendingBind{target: t, msgCounter: counter})
 	}
 	return requested
+}
+
+// hookNodeManagementResults registers, once, a result callback on the local
+// NodeManagement feature that records every result's errorNumber by
+// msgCounterReference — the only place bind accept/deny replies surface.
+func (p *HvacProbe) hookNodeManagementResults(local spineapi.EntityLocalInterface) {
+	p.mu.Lock()
+	hooked := p.nmHooked
+	if !hooked {
+		p.nmHooked = true
+	}
+	p.mu.Unlock()
+	if hooked {
+		return
+	}
+	local.Device().NodeManagement().AddResultCallback(func(msg spineapi.ResponseMessage) {
+		result, ok := msg.Data.(*model.ResultDataType)
+		if !ok || result.ErrorNumber == nil {
+			return
+		}
+		p.mu.Lock()
+		p.bindResults[uint64(msg.MsgCounterReference)] = int64(*result.ErrorNumber)
+		p.mu.Unlock()
+	})
 }
 
 // hookResultLogging logs every SPINE result message arriving at a local
@@ -324,26 +359,34 @@ func (p *HvacProbe) hookResultLogging(ski string, featureType model.FeatureTypeT
 	})
 }
 
-// collectBindResults polls until each requested binding is confirmed or the
-// timeout passes. A missing confirmation means the device denied or ignored
-// the bind - the result log above carries the deny error number if one came.
+// collectBindResults polls the NodeManagement result log until each requested
+// bind's msgCounter got an accept (errorNumber 0) or deny result, or the
+// timeout passes.
 func (p *HvacProbe) collectBindResults(ski string, pending []pendingBind) {
 	deadline := time.Now().Add(p.pollTimeout)
 	for len(pending) > 0 && time.Now().Before(deadline) {
 		time.Sleep(p.pollInterval)
 		remaining := pending[:0]
 		for _, b := range pending {
-			if b.localFeature.HasBindingToRemote(b.target.feature.Address()) {
-				p.logf("[HVACPROBE] ski=%s entity=%s bind %s ACCEPTED",
-					ski, b.target.entityAddr, b.target.feature.Type())
+			p.mu.Lock()
+			errno, ok := p.bindResults[b.msgCounter]
+			p.mu.Unlock()
+			if !ok {
+				remaining = append(remaining, b)
 				continue
 			}
-			remaining = append(remaining, b)
+			if errno == 0 {
+				p.logf("[HVACPROBE] ski=%s entity=%s bind %s ACCEPTED (msgCounter=%d)",
+					ski, b.target.entityAddr, b.target.feature.Type(), b.msgCounter)
+			} else {
+				p.logf("[HVACPROBE] ski=%s entity=%s bind %s DENIED errorNumber=%d (msgCounter=%d)",
+					ski, b.target.entityAddr, b.target.feature.Type(), errno, b.msgCounter)
+			}
 		}
 		pending = remaining
 	}
 	for _, b := range pending {
-		p.logf("[HVACPROBE] ski=%s entity=%s bind %s NOT confirmed within %s (denied or ignored; see result log)",
+		p.logf("[HVACPROBE] ski=%s entity=%s bind %s NOT answered within %s",
 			ski, b.target.entityAddr, b.target.feature.Type(), p.pollTimeout)
 	}
 }

--- a/eebus-bridge/internal/eebus/hvacprobe_test.go
+++ b/eebus-bridge/internal/eebus/hvacprobe_test.go
@@ -72,6 +72,7 @@ func TestHvacProbeSkipsDeviceWithoutHvacFeatures(t *testing.T) {
 
 	local := mocks.NewEntityLocalInterface(t)
 	local.On("GetOrAddFeature", mock.Anything, mock.Anything).Return(nil).Maybe()
+	local.On("AddUseCaseSupport", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return().Maybe()
 	p.Setup(local)
 
 	entity := mocks.NewEntityRemoteInterface(t)
@@ -116,6 +117,7 @@ func TestHvacProbeRequestsAndDedups(t *testing.T) {
 
 	local := mocks.NewEntityLocalInterface(t)
 	local.On("GetOrAddFeature", mock.Anything, mock.Anything).Return(localFeature).Maybe()
+	local.On("AddUseCaseSupport", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return().Maybe()
 	local.On("FeatureOfTypeAndRole", model.FeatureTypeTypeSetpoint, model.RoleTypeClient).Return(localFeature).Maybe()
 	p.Setup(local)
 
@@ -186,6 +188,7 @@ func TestHvacProbeBindRequestsAndConfirms(t *testing.T) {
 
 	local := mocks.NewEntityLocalInterface(t)
 	local.On("GetOrAddFeature", mock.Anything, mock.Anything).Return(localFeature).Maybe()
+	local.On("AddUseCaseSupport", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return().Maybe()
 	local.On("FeatureOfTypeAndRole", model.FeatureTypeTypeSetpoint, model.RoleTypeClient).Return(localFeature).Maybe()
 	p.Setup(local)
 	p.EnableBind()
@@ -203,6 +206,44 @@ func TestHvacProbeBindRequestsAndConfirms(t *testing.T) {
 			t.Fatalf("probe never confirmed binding:\n%s", out)
 		}
 		time.Sleep(5 * time.Millisecond)
+	}
+}
+
+func TestHvacProbeSetupAdvertisesClientUseCases(t *testing.T) {
+	p := NewHvacProbe(func(string, ...any) {})
+
+	var (
+		mu         sync.Mutex
+		advertised []model.UseCaseNameType
+	)
+	local := mocks.NewEntityLocalInterface(t)
+	local.On("GetOrAddFeature", mock.Anything, mock.Anything).Return(nil).Maybe()
+	local.On("AddUseCaseSupport",
+		model.UseCaseActorTypeConfigurationAppliance,
+		mock.Anything, mock.Anything, mock.Anything, true, mock.Anything,
+	).Run(func(args mock.Arguments) {
+		mu.Lock()
+		advertised = append(advertised, args.Get(1).(model.UseCaseNameType))
+		mu.Unlock()
+	}).Return()
+
+	p.Setup(local)
+
+	want := []model.UseCaseNameType{
+		model.UseCaseNameTypeConfigurationOfDhwSystemFunction,
+		model.UseCaseNameTypeConfigurationOfDhwTemperature,
+		model.UseCaseNameTypeConfigurationOfRoomHeatingSystemFunction,
+		model.UseCaseNameTypeConfigurationOfRoomHeatingTemperature,
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if len(advertised) != len(want) {
+		t.Fatalf("advertised %d use cases %v, want %d", len(advertised), advertised, len(want))
+	}
+	for i, name := range want {
+		if advertised[i] != name {
+			t.Errorf("use case %d = %s, want %s", i, advertised[i], name)
+		}
 	}
 }
 

--- a/eebus-bridge/internal/eebus/hvacprobe_test.go
+++ b/eebus-bridge/internal/eebus/hvacprobe_test.go
@@ -371,6 +371,162 @@ func TestHvacProbeEchoWriteAfterBindAccept(t *testing.T) {
 	}
 }
 
+func TestHvacProbeDeltaWriteAppliesAndRestores(t *testing.T) {
+	logf, lines := collectLogf()
+	p := NewHvacProbe(logf)
+	p.pollInterval = 5 * time.Millisecond
+	p.pollTimeout = 500 * time.Millisecond
+	p.EnableBind()
+	p.EnableWrite()
+	p.EnableWriteDelta()
+
+	remoteAddr := &model.FeatureAddressType{
+		Device:  ptr(model.AddressDeviceType("d0")),
+		Entity:  []model.AddressEntityType{4},
+		Feature: ptr(model.AddressFeatureType(1)),
+	}
+	localAddr := &model.FeatureAddressType{
+		Device:  ptr(model.AddressDeviceType("bridge")),
+		Entity:  []model.AddressEntityType{1},
+		Feature: ptr(model.AddressFeatureType(2)),
+	}
+
+	// deviceValue simulates the device's live DHW setpoint: writes update it,
+	// reads return it.
+	var (
+		valueMu     sync.Mutex
+		deviceValue = float64(46)
+	)
+	constraints := &model.SetpointConstraintsListDataType{
+		SetpointConstraintsData: []model.SetpointConstraintsDataType{{
+			SetpointId:       ptr(model.SetpointIdType(1)),
+			SetpointRangeMin: model.NewScaledNumberType(35),
+			SetpointRangeMax: model.NewScaledNumberType(70),
+			SetpointStepSize: model.NewScaledNumberType(1),
+		}},
+	}
+
+	writeCounter := model.MsgCounterType(9)
+	var (
+		cbMu           sync.Mutex
+		nmCallback     func(spineapi.ResponseMessage)
+		clientCallback func(spineapi.ResponseMessage)
+	)
+	sender := mocks.NewSenderInterface(t)
+	sender.On("Write", localAddr, remoteAddr, mock.Anything).Run(func(args mock.Arguments) {
+		cmd := args.Get(2).(model.CmdType)
+		for _, sp := range cmd.SetpointListData.SetpointData {
+			if sp.SetpointId != nil && *sp.SetpointId == 1 && sp.Value != nil {
+				valueMu.Lock()
+				deviceValue = sp.Value.GetValue()
+				valueMu.Unlock()
+			}
+		}
+		// Device ACKs the write on the sending client feature.
+		cbMu.Lock()
+		ccb := clientCallback
+		cbMu.Unlock()
+		if ccb != nil {
+			go ccb(spineapi.ResponseMessage{
+				MsgCounterReference: writeCounter,
+				Data:                &model.ResultDataType{ErrorNumber: ptr(model.ErrorNumberType(0))},
+			})
+		}
+	}).Return(&writeCounter, nil)
+	deviceRemote := mocks.NewDeviceRemoteInterface(t)
+	deviceRemote.On("Sender").Return(sender).Maybe()
+
+	remoteFeature := mocks.NewFeatureRemoteInterface(t)
+	remoteFeature.On("String").Return("setpoint-server-feature").Maybe()
+	remoteFeature.On("Type").Return(model.FeatureTypeTypeSetpoint).Maybe()
+	remoteFeature.On("Address").Return(remoteAddr).Maybe()
+	remoteFeature.On("Operations").Return(map[model.FunctionType]spineapi.OperationsInterface{}).Maybe()
+	remoteFeature.On("DataCopy", model.FunctionTypeSetpointListData).Return(func(model.FunctionType) any {
+		valueMu.Lock()
+		defer valueMu.Unlock()
+		return &model.SetpointListDataType{
+			SetpointData: []model.SetpointDataType{
+				{SetpointId: ptr(model.SetpointIdType(1)), Value: model.NewScaledNumberType(deviceValue)},
+			},
+		}
+	}).Maybe()
+	remoteFeature.On("DataCopy", model.FunctionTypeSetpointConstraintsListData).Return(constraints).Maybe()
+	remoteFeature.On("DataCopy", mock.Anything).Return(nil).Maybe()
+	remoteFeature.On("Device").Return(deviceRemote).Maybe()
+
+	bindCounter := model.MsgCounterType(7)
+	localFeature := mocks.NewFeatureLocalInterface(t)
+	localFeature.On("RequestRemoteData", mock.Anything, nil, nil, remoteFeature).Return(&bindCounter, nil)
+	localFeature.On("AddResultCallback", mock.Anything).Run(func(args mock.Arguments) {
+		cbMu.Lock()
+		clientCallback = args.Get(0).(func(spineapi.ResponseMessage))
+		cbMu.Unlock()
+	}).Return()
+	localFeature.On("HasBindingToRemote", remoteAddr).Return(false).Maybe()
+	localFeature.On("BindToRemote", remoteAddr).Return(&bindCounter, nil)
+	localFeature.On("Address").Return(localAddr).Maybe()
+
+	nm := mocks.NewNodeManagementInterface(t)
+	nm.On("AddResultCallback", mock.Anything).Run(func(args mock.Arguments) {
+		cbMu.Lock()
+		nmCallback = args.Get(0).(func(spineapi.ResponseMessage))
+		cbMu.Unlock()
+	}).Return()
+	deviceLocal := mocks.NewDeviceLocalInterface(t)
+	deviceLocal.On("NodeManagement").Return(nm).Maybe()
+
+	local := mocks.NewEntityLocalInterface(t)
+	local.On("GetOrAddFeature", mock.Anything, mock.Anything).Return(localFeature).Maybe()
+	local.On("AddUseCaseSupport", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return().Maybe()
+	local.On("FeatureOfTypeAndRole", model.FeatureTypeTypeSetpoint, model.RoleTypeClient).Return(localFeature).Maybe()
+	local.On("Device").Return(deviceLocal).Maybe()
+	p.Setup(local)
+
+	device := buildProbeDeviceMock(t, "ABCD1234", remoteFeature)
+	p.ProbeOnce("ABCD1234", device)
+
+	cbMu.Lock()
+	cb := nmCallback
+	cbMu.Unlock()
+	if cb == nil {
+		t.Fatal("probe never registered a NodeManagement result callback")
+	}
+	cb(spineapi.ResponseMessage{
+		MsgCounterReference: bindCounter,
+		Data:                &model.ResultDataType{ErrorNumber: ptr(model.ErrorNumberType(0))},
+	})
+
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		out := strings.Join(lines(), "\n")
+		if strings.Contains(out, "RESTORED to 46") {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("delta test never completed:\n%s", out)
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	out := strings.Join(lines(), "\n")
+	for _, want := range []string{
+		"DELTA TEST setpointId=1: 46 -> 47",
+		"delta-write Setpoint ACCEPTED",
+		"APPLIED: device now reports 47",
+		"restore Setpoint ACCEPTED",
+		"DELTA TEST complete: setpointId=1 RESTORED to 46",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing log %q in:\n%s", want, out)
+		}
+	}
+	valueMu.Lock()
+	defer valueMu.Unlock()
+	if deviceValue != 46 {
+		t.Errorf("device value after test = %v, want restored 46", deviceValue)
+	}
+}
+
 func TestHvacProbeSetupAdvertisesClientUseCases(t *testing.T) {
 	p := NewHvacProbe(func(string, ...any) {})
 

--- a/eebus-bridge/internal/eebus/hvacprobe_test.go
+++ b/eebus-bridge/internal/eebus/hvacprobe_test.go
@@ -147,4 +147,63 @@ func TestHvacProbeRequestsAndDedups(t *testing.T) {
 	}
 }
 
+func TestHvacProbeBindRequestsAndConfirms(t *testing.T) {
+	logf, lines := collectLogf()
+	p := NewHvacProbe(logf)
+	p.pollInterval = 5 * time.Millisecond
+	p.pollTimeout = 200 * time.Millisecond
+
+	remoteAddr := &model.FeatureAddressType{
+		Device:  ptr(model.AddressDeviceType("d0")),
+		Entity:  []model.AddressEntityType{4},
+		Feature: ptr(model.AddressFeatureType(1)),
+	}
+	remoteFeature := mocks.NewFeatureRemoteInterface(t)
+	remoteFeature.On("String").Return("setpoint-server-feature").Maybe()
+	remoteFeature.On("Type").Return(model.FeatureTypeTypeSetpoint).Maybe()
+	remoteFeature.On("Address").Return(remoteAddr).Maybe()
+	remoteFeature.On("Operations").Return(map[model.FunctionType]spineapi.OperationsInterface{}).Maybe()
+	remoteFeature.On("DataCopy", mock.Anything).Return(nil).Maybe()
+
+	counter := model.MsgCounterType(7)
+	var (
+		boundMu sync.Mutex
+		bound   bool
+	)
+	localFeature := mocks.NewFeatureLocalInterface(t)
+	localFeature.On("RequestRemoteData", mock.Anything, nil, nil, remoteFeature).Return(&counter, nil)
+	localFeature.On("AddResultCallback", mock.Anything).Return()
+	localFeature.On("HasBindingToRemote", remoteAddr).Return(func(*model.FeatureAddressType) bool {
+		boundMu.Lock()
+		defer boundMu.Unlock()
+		return bound
+	}).Maybe()
+	localFeature.On("BindToRemote", remoteAddr).Run(func(mock.Arguments) {
+		boundMu.Lock()
+		bound = true // simulate the device accepting the binding
+		boundMu.Unlock()
+	}).Return(&counter, nil)
+
+	local := mocks.NewEntityLocalInterface(t)
+	local.On("GetOrAddFeature", mock.Anything, mock.Anything).Return(localFeature).Maybe()
+	local.On("FeatureOfTypeAndRole", model.FeatureTypeTypeSetpoint, model.RoleTypeClient).Return(localFeature).Maybe()
+	p.Setup(local)
+	p.EnableBind()
+
+	device := buildProbeDeviceMock(t, "ABCD1234", remoteFeature)
+	p.ProbeOnce("ABCD1234", device)
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		out := strings.Join(lines(), "\n")
+		if strings.Contains(out, "bind Setpoint requested") && strings.Contains(out, "bind Setpoint ACCEPTED") {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("probe never confirmed binding:\n%s", out)
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
 func ptr[T any](v T) *T { return &v }

--- a/eebus-bridge/internal/eebus/hvacprobe_test.go
+++ b/eebus-bridge/internal/eebus/hvacprobe_test.go
@@ -226,6 +226,151 @@ func TestHvacProbeBindRequestsAndConfirms(t *testing.T) {
 	}
 }
 
+func TestHvacProbeEchoWriteAfterBindAccept(t *testing.T) {
+	logf, lines := collectLogf()
+	p := NewHvacProbe(logf)
+	p.pollInterval = 5 * time.Millisecond
+	p.pollTimeout = 500 * time.Millisecond
+	p.EnableBind()
+	p.EnableWrite()
+
+	remoteAddr := &model.FeatureAddressType{
+		Device:  ptr(model.AddressDeviceType("d0")),
+		Entity:  []model.AddressEntityType{4},
+		Feature: ptr(model.AddressFeatureType(1)),
+	}
+	localAddr := &model.FeatureAddressType{
+		Device:  ptr(model.AddressDeviceType("bridge")),
+		Entity:  []model.AddressEntityType{1},
+		Feature: ptr(model.AddressFeatureType(2)),
+	}
+	setpointData := &model.SetpointListDataType{
+		SetpointData: []model.SetpointDataType{
+			{SetpointId: ptr(model.SetpointIdType(1)), Value: model.NewScaledNumberType(50)},
+		},
+	}
+
+	writeCounter := model.MsgCounterType(9)
+	var (
+		writeMu  sync.Mutex
+		writeCmd *model.CmdType
+	)
+	sender := mocks.NewSenderInterface(t)
+	sender.On("Write", localAddr, remoteAddr, mock.Anything).Run(func(args mock.Arguments) {
+		cmd := args.Get(2).(model.CmdType)
+		writeMu.Lock()
+		writeCmd = &cmd
+		writeMu.Unlock()
+	}).Return(&writeCounter, nil)
+	deviceRemote := mocks.NewDeviceRemoteInterface(t)
+	deviceRemote.On("Sender").Return(sender).Maybe()
+
+	remoteFeature := mocks.NewFeatureRemoteInterface(t)
+	remoteFeature.On("String").Return("setpoint-server-feature").Maybe()
+	remoteFeature.On("Type").Return(model.FeatureTypeTypeSetpoint).Maybe()
+	remoteFeature.On("Address").Return(remoteAddr).Maybe()
+	remoteFeature.On("Operations").Return(map[model.FunctionType]spineapi.OperationsInterface{}).Maybe()
+	remoteFeature.On("DataCopy", model.FunctionTypeSetpointListData).Return(setpointData).Maybe()
+	remoteFeature.On("DataCopy", mock.Anything).Return(nil).Maybe()
+	remoteFeature.On("Device").Return(deviceRemote).Maybe()
+
+	bindCounter := model.MsgCounterType(7)
+	var (
+		cbMu           sync.Mutex
+		nmCallback     func(spineapi.ResponseMessage)
+		clientCallback func(spineapi.ResponseMessage)
+	)
+	localFeature := mocks.NewFeatureLocalInterface(t)
+	localFeature.On("RequestRemoteData", mock.Anything, nil, nil, remoteFeature).Return(&bindCounter, nil)
+	localFeature.On("AddResultCallback", mock.Anything).Run(func(args mock.Arguments) {
+		cbMu.Lock()
+		clientCallback = args.Get(0).(func(spineapi.ResponseMessage))
+		cbMu.Unlock()
+	}).Return()
+	localFeature.On("HasBindingToRemote", remoteAddr).Return(false).Maybe()
+	localFeature.On("BindToRemote", remoteAddr).Return(&bindCounter, nil)
+	localFeature.On("Address").Return(localAddr).Maybe()
+
+	nm := mocks.NewNodeManagementInterface(t)
+	nm.On("AddResultCallback", mock.Anything).Run(func(args mock.Arguments) {
+		cbMu.Lock()
+		nmCallback = args.Get(0).(func(spineapi.ResponseMessage))
+		cbMu.Unlock()
+	}).Return()
+	deviceLocal := mocks.NewDeviceLocalInterface(t)
+	deviceLocal.On("NodeManagement").Return(nm).Maybe()
+
+	local := mocks.NewEntityLocalInterface(t)
+	local.On("GetOrAddFeature", mock.Anything, mock.Anything).Return(localFeature).Maybe()
+	local.On("AddUseCaseSupport", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return().Maybe()
+	local.On("FeatureOfTypeAndRole", model.FeatureTypeTypeSetpoint, model.RoleTypeClient).Return(localFeature).Maybe()
+	local.On("Device").Return(deviceLocal).Maybe()
+	p.Setup(local)
+
+	device := buildProbeDeviceMock(t, "ABCD1234", remoteFeature)
+	p.ProbeOnce("ABCD1234", device)
+
+	// Device accepts the binding via a NodeManagement result.
+	cbMu.Lock()
+	cb := nmCallback
+	cbMu.Unlock()
+	if cb == nil {
+		t.Fatal("probe never registered a NodeManagement result callback")
+	}
+	cb(spineapi.ResponseMessage{
+		MsgCounterReference: bindCounter,
+		Data:                &model.ResultDataType{ErrorNumber: ptr(model.ErrorNumberType(0))},
+	})
+
+	// Wait for the echo write to be sent, then answer it on the client feature.
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		out := strings.Join(lines(), "\n")
+		if strings.Contains(out, "write Setpoint sent") {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("probe never sent the echo write:\n%s", out)
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	cbMu.Lock()
+	ccb := clientCallback
+	cbMu.Unlock()
+	if ccb == nil {
+		t.Fatal("probe never registered a client feature result callback")
+	}
+	ccb(spineapi.ResponseMessage{
+		MsgCounterReference: writeCounter,
+		Data:                &model.ResultDataType{ErrorNumber: ptr(model.ErrorNumberType(0))},
+	})
+
+	for {
+		out := strings.Join(lines(), "\n")
+		if strings.Contains(out, "write Setpoint ACCEPTED") {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("probe never confirmed the write:\n%s", out)
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	// The write must echo the device's own data unchanged.
+	writeMu.Lock()
+	defer writeMu.Unlock()
+	if writeCmd == nil || writeCmd.SetpointListData == nil {
+		t.Fatal("write command carried no setpointListData")
+	}
+	got := writeCmd.SetpointListData.SetpointData
+	if len(got) != 1 || got[0].SetpointId == nil || *got[0].SetpointId != 1 {
+		t.Errorf("echo write data = %+v, want the device's setpointId 1 unchanged", got)
+	}
+	if got[0].Value == nil || got[0].Value.GetValue() != 50 {
+		t.Errorf("echo write value = %+v, want unchanged 50", got[0].Value)
+	}
+}
+
 func TestHvacProbeSetupAdvertisesClientUseCases(t *testing.T) {
 	p := NewHvacProbe(func(string, ...any) {})
 

--- a/eebus-bridge/internal/eebus/hvacprobe_test.go
+++ b/eebus-bridge/internal/eebus/hvacprobe_test.go
@@ -169,32 +169,49 @@ func TestHvacProbeBindRequestsAndConfirms(t *testing.T) {
 
 	counter := model.MsgCounterType(7)
 	var (
-		boundMu sync.Mutex
-		bound   bool
+		nmCallbackMu sync.Mutex
+		nmCallback   func(spineapi.ResponseMessage)
 	)
 	localFeature := mocks.NewFeatureLocalInterface(t)
 	localFeature.On("RequestRemoteData", mock.Anything, nil, nil, remoteFeature).Return(&counter, nil)
 	localFeature.On("AddResultCallback", mock.Anything).Return()
-	localFeature.On("HasBindingToRemote", remoteAddr).Return(func(*model.FeatureAddressType) bool {
-		boundMu.Lock()
-		defer boundMu.Unlock()
-		return bound
-	}).Maybe()
-	localFeature.On("BindToRemote", remoteAddr).Run(func(mock.Arguments) {
-		boundMu.Lock()
-		bound = true // simulate the device accepting the binding
-		boundMu.Unlock()
-	}).Return(&counter, nil)
+	localFeature.On("HasBindingToRemote", remoteAddr).Return(false).Maybe()
+	localFeature.On("BindToRemote", remoteAddr).Return(&counter, nil)
+
+	// Bind accept/deny results arrive at the local NodeManagement feature, not
+	// the client feature — capture its callback to inject the device's accept.
+	nm := mocks.NewNodeManagementInterface(t)
+	nm.On("AddResultCallback", mock.Anything).Run(func(args mock.Arguments) {
+		nmCallbackMu.Lock()
+		nmCallback = args.Get(0).(func(spineapi.ResponseMessage))
+		nmCallbackMu.Unlock()
+	}).Return()
+	deviceLocal := mocks.NewDeviceLocalInterface(t)
+	deviceLocal.On("NodeManagement").Return(nm).Maybe()
 
 	local := mocks.NewEntityLocalInterface(t)
 	local.On("GetOrAddFeature", mock.Anything, mock.Anything).Return(localFeature).Maybe()
 	local.On("AddUseCaseSupport", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return().Maybe()
 	local.On("FeatureOfTypeAndRole", model.FeatureTypeTypeSetpoint, model.RoleTypeClient).Return(localFeature).Maybe()
+	local.On("Device").Return(deviceLocal).Maybe()
 	p.Setup(local)
 	p.EnableBind()
 
 	device := buildProbeDeviceMock(t, "ABCD1234", remoteFeature)
 	p.ProbeOnce("ABCD1234", device)
+
+	// Simulate the VR940 accepting the binding: result errorNumber=0
+	// referencing the bind request's msgCounter.
+	nmCallbackMu.Lock()
+	cb := nmCallback
+	nmCallbackMu.Unlock()
+	if cb == nil {
+		t.Fatal("probe never registered a NodeManagement result callback")
+	}
+	cb(spineapi.ResponseMessage{
+		MsgCounterReference: counter,
+		Data:                &model.ResultDataType{ErrorNumber: ptr(model.ErrorNumberType(0))},
+	})
 
 	deadline := time.Now().Add(2 * time.Second)
 	for {

--- a/eebus-bridge/internal/eebus/hvacprobe_test.go
+++ b/eebus-bridge/internal/eebus/hvacprobe_test.go
@@ -1,0 +1,150 @@
+package eebus
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	spineapi "github.com/enbility/spine-go/api"
+	"github.com/enbility/spine-go/mocks"
+	"github.com/enbility/spine-go/model"
+	"github.com/stretchr/testify/mock"
+)
+
+// collectLogf returns a threadsafe log collector for probe output.
+func collectLogf() (func(format string, args ...any), func() []string) {
+	var (
+		mu    sync.Mutex
+		lines []string
+	)
+	logf := func(format string, args ...any) {
+		mu.Lock()
+		defer mu.Unlock()
+		lines = append(lines, fmt.Sprintf(format, args...))
+	}
+	get := func() []string {
+		mu.Lock()
+		defer mu.Unlock()
+		out := make([]string, len(lines))
+		copy(out, lines)
+		return out
+	}
+	return logf, get
+}
+
+// buildProbeDeviceMock returns a remote-device mock with one DHWCircuit entity
+// exposing a Setpoint server feature, mirroring the VR940 dump (entity 4).
+func buildProbeDeviceMock(t *testing.T, ski string, setpoint spineapi.FeatureRemoteInterface) *mocks.DeviceRemoteInterface {
+	t.Helper()
+
+	entityAddr := &model.EntityAddressType{Entity: []model.AddressEntityType{4}}
+	entity := mocks.NewEntityRemoteInterface(t)
+	entity.On("Address").Return(entityAddr).Maybe()
+	entity.On("EntityType").Return(model.EntityTypeTypeDHWCircuit).Maybe()
+	entity.On("FeatureOfTypeAndRole", model.FeatureTypeTypeSetpoint, model.RoleTypeServer).Return(setpoint).Maybe()
+	entity.On("FeatureOfTypeAndRole", model.FeatureTypeTypeHvac, model.RoleTypeServer).Return(nil).Maybe()
+
+	device := mocks.NewDeviceRemoteInterface(t)
+	device.On("Ski").Return(ski).Maybe()
+	device.On("Entities").Return([]spineapi.EntityRemoteInterface{entity}).Maybe()
+	return device
+}
+
+func TestHvacProbeInertWithoutSetup(t *testing.T) {
+	logf, lines := collectLogf()
+	p := NewHvacProbe(logf)
+
+	device := mocks.NewDeviceRemoteInterface(t)
+	device.On("Ski").Return("ABCD1234").Maybe()
+
+	p.ProbeOnce("ABCD1234", device)
+
+	if got := lines(); len(got) != 0 {
+		t.Errorf("probe without Setup logged %v, want nothing", got)
+	}
+}
+
+func TestHvacProbeSkipsDeviceWithoutHvacFeatures(t *testing.T) {
+	logf, lines := collectLogf()
+	p := NewHvacProbe(logf)
+
+	local := mocks.NewEntityLocalInterface(t)
+	local.On("GetOrAddFeature", mock.Anything, mock.Anything).Return(nil).Maybe()
+	p.Setup(local)
+
+	entity := mocks.NewEntityRemoteInterface(t)
+	entity.On("FeatureOfTypeAndRole", mock.Anything, model.RoleTypeServer).Return(nil).Maybe()
+	device := mocks.NewDeviceRemoteInterface(t)
+	device.On("Ski").Return("ABCD1234").Maybe()
+	device.On("Entities").Return([]spineapi.EntityRemoteInterface{entity}).Maybe()
+
+	p.ProbeOnce("ABCD1234", device)
+
+	if got := lines(); len(got) != 0 {
+		t.Errorf("probe on device without Setpoint/HVAC features logged %v, want nothing", got)
+	}
+	if p.probed["ABCD1234"] {
+		t.Error("device without HVAC features must not be marked probed (entities may still be loading)")
+	}
+}
+
+func TestHvacProbeRequestsAndDedups(t *testing.T) {
+	logf, lines := collectLogf()
+	p := NewHvacProbe(logf)
+	p.pollInterval = 5 * time.Millisecond
+	p.pollTimeout = 100 * time.Millisecond
+
+	setpointData := &model.SetpointListDataType{
+		SetpointData: []model.SetpointDataType{
+			{SetpointId: ptr(model.SetpointIdType(1))},
+		},
+	}
+
+	remoteFeature := mocks.NewFeatureRemoteInterface(t)
+	// testify renders %v on argument mismatch checks, which calls String().
+	remoteFeature.On("String").Return("setpoint-server-feature").Maybe()
+	remoteFeature.On("Type").Return(model.FeatureTypeTypeSetpoint).Maybe()
+	remoteFeature.On("Operations").Return(map[model.FunctionType]spineapi.OperationsInterface{}).Maybe()
+	remoteFeature.On("DataCopy", model.FunctionTypeSetpointListData).Return(setpointData).Maybe()
+	remoteFeature.On("DataCopy", mock.Anything).Return(nil).Maybe()
+
+	counter := model.MsgCounterType(1)
+	localFeature := mocks.NewFeatureLocalInterface(t)
+	localFeature.On("RequestRemoteData", mock.Anything, nil, nil, remoteFeature).Return(&counter, nil)
+
+	local := mocks.NewEntityLocalInterface(t)
+	local.On("GetOrAddFeature", mock.Anything, mock.Anything).Return(localFeature).Maybe()
+	local.On("FeatureOfTypeAndRole", model.FeatureTypeTypeSetpoint, model.RoleTypeClient).Return(localFeature).Maybe()
+	p.Setup(local)
+
+	device := buildProbeDeviceMock(t, "ABCD1234", remoteFeature)
+	p.ProbeOnce("ABCD1234", device)
+	p.ProbeOnce("abcd1234", device) // same SKI, different case -> deduped
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		out := strings.Join(lines(), "\n")
+		if strings.Contains(out, "setpointListData") && strings.Contains(out, `"setpointId":1`) {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("probe never logged setpoint data:\n%s", out)
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	// Exactly one operations header despite two ProbeOnce calls -> deduped.
+	headers := 0
+	for _, l := range lines() {
+		if strings.Contains(l, "operations=[") {
+			headers++
+		}
+	}
+	if headers != 1 {
+		t.Errorf("got %d operations headers, want 1 (dedup by normalized SKI)", headers)
+	}
+}
+
+func ptr[T any](v T) *T { return &v }

--- a/eebus-bridge/internal/eebus/hvacprobe_test.go
+++ b/eebus-bridge/internal/eebus/hvacprobe_test.go
@@ -371,14 +371,29 @@ func TestHvacProbeEchoWriteAfterBindAccept(t *testing.T) {
 	}
 }
 
-func TestHvacProbeDeltaWriteAppliesAndRestores(t *testing.T) {
+// deltaHarness wires the full stage-3b mock scenario: a DHWCircuit whose
+// "live" DHW setpoint (id 1, plus a decoy valued setpoint id 0 that is NOT
+// dhwTemperature-scoped) is updated by writes and returned by reads.
+type deltaHarness struct {
+	p          *HvacProbe
+	lines      func() []string
+	value      func() float64
+	senderUsed func() bool
+	acceptBind func()
+}
+
+// newDeltaHarness builds the scenario. constraints is the DataCopy return for
+// SetpointConstraintsListData (nil = device advertises none); ackWrites
+// controls whether the device answers writes with a result errorNumber=0.
+func newDeltaHarness(t *testing.T, constraints any, ackWrites bool) *deltaHarness {
+	t.Helper()
 	logf, lines := collectLogf()
 	p := NewHvacProbe(logf)
 	p.pollInterval = 5 * time.Millisecond
-	p.pollTimeout = 500 * time.Millisecond
+	p.pollTimeout = 300 * time.Millisecond
 	p.EnableBind()
 	p.EnableWrite()
-	p.EnableWriteDelta()
+	p.EnableWriteDelta("ABCD1234")
 
 	remoteAddr := &model.FeatureAddressType{
 		Device:  ptr(model.AddressDeviceType("d0")),
@@ -390,22 +405,18 @@ func TestHvacProbeDeltaWriteAppliesAndRestores(t *testing.T) {
 		Entity:  []model.AddressEntityType{1},
 		Feature: ptr(model.AddressFeatureType(2)),
 	}
+	descriptions := &model.SetpointDescriptionListDataType{
+		SetpointDescriptionData: []model.SetpointDescriptionDataType{
+			{SetpointId: ptr(model.SetpointIdType(0)), ScopeType: ptr(model.ScopeTypeTypeRoomAirTemperature)},
+			{SetpointId: ptr(model.SetpointIdType(1)), ScopeType: ptr(model.ScopeTypeTypeDhwTemperature)},
+		},
+	}
 
-	// deviceValue simulates the device's live DHW setpoint: writes update it,
-	// reads return it.
 	var (
 		valueMu     sync.Mutex
 		deviceValue = float64(46)
+		senderCalls int
 	)
-	constraints := &model.SetpointConstraintsListDataType{
-		SetpointConstraintsData: []model.SetpointConstraintsDataType{{
-			SetpointId:       ptr(model.SetpointIdType(1)),
-			SetpointRangeMin: model.NewScaledNumberType(35),
-			SetpointRangeMax: model.NewScaledNumberType(70),
-			SetpointStepSize: model.NewScaledNumberType(1),
-		}},
-	}
-
 	writeCounter := model.MsgCounterType(9)
 	var (
 		cbMu           sync.Mutex
@@ -415,14 +426,17 @@ func TestHvacProbeDeltaWriteAppliesAndRestores(t *testing.T) {
 	sender := mocks.NewSenderInterface(t)
 	sender.On("Write", localAddr, remoteAddr, mock.Anything).Run(func(args mock.Arguments) {
 		cmd := args.Get(2).(model.CmdType)
+		valueMu.Lock()
+		senderCalls++
 		for _, sp := range cmd.SetpointListData.SetpointData {
 			if sp.SetpointId != nil && *sp.SetpointId == 1 && sp.Value != nil {
-				valueMu.Lock()
 				deviceValue = sp.Value.GetValue()
-				valueMu.Unlock()
 			}
 		}
-		// Device ACKs the write on the sending client feature.
+		valueMu.Unlock()
+		if !ackWrites {
+			return
+		}
 		cbMu.Lock()
 		ccb := clientCallback
 		cbMu.Unlock()
@@ -432,24 +446,34 @@ func TestHvacProbeDeltaWriteAppliesAndRestores(t *testing.T) {
 				Data:                &model.ResultDataType{ErrorNumber: ptr(model.ErrorNumberType(0))},
 			})
 		}
-	}).Return(&writeCounter, nil)
+	}).Return(&writeCounter, nil).Maybe()
 	deviceRemote := mocks.NewDeviceRemoteInterface(t)
 	deviceRemote.On("Sender").Return(sender).Maybe()
+
+	writableOp := mocks.NewOperationsInterface(t)
+	writableOp.On("Read").Return(true).Maybe()
+	writableOp.On("Write").Return(true).Maybe()
+	writableOp.On("String").Return("rw").Maybe()
 
 	remoteFeature := mocks.NewFeatureRemoteInterface(t)
 	remoteFeature.On("String").Return("setpoint-server-feature").Maybe()
 	remoteFeature.On("Type").Return(model.FeatureTypeTypeSetpoint).Maybe()
 	remoteFeature.On("Address").Return(remoteAddr).Maybe()
-	remoteFeature.On("Operations").Return(map[model.FunctionType]spineapi.OperationsInterface{}).Maybe()
+	remoteFeature.On("Operations").Return(map[model.FunctionType]spineapi.OperationsInterface{
+		model.FunctionTypeSetpointListData: writableOp,
+	}).Maybe()
 	remoteFeature.On("DataCopy", model.FunctionTypeSetpointListData).Return(func(model.FunctionType) any {
 		valueMu.Lock()
 		defer valueMu.Unlock()
 		return &model.SetpointListDataType{
 			SetpointData: []model.SetpointDataType{
+				// Decoy: valued, but its description is not dhwTemperature.
+				{SetpointId: ptr(model.SetpointIdType(0)), Value: model.NewScaledNumberType(99)},
 				{SetpointId: ptr(model.SetpointIdType(1)), Value: model.NewScaledNumberType(deviceValue)},
 			},
 		}
 	}).Maybe()
+	remoteFeature.On("DataCopy", model.FunctionTypeSetpointDescriptionListData).Return(descriptions).Maybe()
 	remoteFeature.On("DataCopy", model.FunctionTypeSetpointConstraintsListData).Return(constraints).Maybe()
 	remoteFeature.On("DataCopy", mock.Anything).Return(nil).Maybe()
 	remoteFeature.On("Device").Return(deviceRemote).Maybe()
@@ -485,30 +509,65 @@ func TestHvacProbeDeltaWriteAppliesAndRestores(t *testing.T) {
 	device := buildProbeDeviceMock(t, "ABCD1234", remoteFeature)
 	p.ProbeOnce("ABCD1234", device)
 
-	cbMu.Lock()
-	cb := nmCallback
-	cbMu.Unlock()
-	if cb == nil {
-		t.Fatal("probe never registered a NodeManagement result callback")
+	return &deltaHarness{
+		p:     p,
+		lines: lines,
+		value: func() float64 {
+			valueMu.Lock()
+			defer valueMu.Unlock()
+			return deviceValue
+		},
+		senderUsed: func() bool {
+			valueMu.Lock()
+			defer valueMu.Unlock()
+			return senderCalls > 0
+		},
+		acceptBind: func() {
+			cbMu.Lock()
+			cb := nmCallback
+			cbMu.Unlock()
+			if cb == nil {
+				t.Fatal("probe never registered a NodeManagement result callback")
+			}
+			cb(spineapi.ResponseMessage{
+				MsgCounterReference: bindCounter,
+				Data:                &model.ResultDataType{ErrorNumber: ptr(model.ErrorNumberType(0))},
+			})
+		},
 	}
-	cb(spineapi.ResponseMessage{
-		MsgCounterReference: bindCounter,
-		Data:                &model.ResultDataType{ErrorNumber: ptr(model.ErrorNumberType(0))},
-	})
+}
 
-	deadline := time.Now().Add(3 * time.Second)
+func waitForLog(t *testing.T, lines func() []string, want string, timeout time.Duration) string {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
 	for {
 		out := strings.Join(lines(), "\n")
-		if strings.Contains(out, "RESTORED to 46") {
-			break
+		if strings.Contains(out, want) {
+			return out
 		}
 		if time.Now().After(deadline) {
-			t.Fatalf("delta test never completed:\n%s", out)
+			t.Fatalf("log never contained %q:\n%s", want, out)
 		}
 		time.Sleep(5 * time.Millisecond)
 	}
+}
 
-	out := strings.Join(lines(), "\n")
+func fullConstraints() *model.SetpointConstraintsListDataType {
+	return &model.SetpointConstraintsListDataType{
+		SetpointConstraintsData: []model.SetpointConstraintsDataType{{
+			SetpointId:       ptr(model.SetpointIdType(1)),
+			SetpointRangeMin: model.NewScaledNumberType(35),
+			SetpointRangeMax: model.NewScaledNumberType(70),
+			SetpointStepSize: model.NewScaledNumberType(1),
+		}},
+	}
+}
+
+func TestHvacProbeDeltaWriteAppliesAndRestores(t *testing.T) {
+	h := newDeltaHarness(t, fullConstraints(), true)
+	h.acceptBind()
+
+	out := waitForLog(t, h.lines, "RESTORED to 46", 3*time.Second)
 	for _, want := range []string{
 		"DELTA TEST setpointId=1: 46 -> 47",
 		"delta-write Setpoint ACCEPTED",
@@ -520,32 +579,77 @@ func TestHvacProbeDeltaWriteAppliesAndRestores(t *testing.T) {
 			t.Errorf("missing log %q in:\n%s", want, out)
 		}
 	}
-	valueMu.Lock()
-	defer valueMu.Unlock()
-	if deviceValue != 46 {
-		t.Errorf("device value after test = %v, want restored 46", deviceValue)
+	if got := h.value(); got != 46 {
+		t.Errorf("device value after test = %v, want restored 46", got)
 	}
 }
 
-func TestHvacProbeSetupAdvertisesClientUseCases(t *testing.T) {
-	p := NewHvacProbe(func(string, ...any) {})
+func TestHvacProbeDeltaRestoresWhenResultLost(t *testing.T) {
+	// Device applies writes but its results never arrive: the probe must
+	// still confirm via re-read and restore the original value.
+	h := newDeltaHarness(t, fullConstraints(), false)
+	h.acceptBind()
 
+	out := waitForLog(t, h.lines, "RESTORED to 46", 5*time.Second)
+	for _, want := range []string{
+		"delta-write Setpoint NOT answered",
+		"delta-write result not seen; confirming and restoring anyway",
+		"APPLIED: device now reports 47",
+		"DELTA TEST complete: setpointId=1 RESTORED to 46",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing log %q in:\n%s", want, out)
+		}
+	}
+	if got := h.value(); got != 46 {
+		t.Errorf("device value after test = %v, want restored 46", got)
+	}
+}
+
+func TestHvacProbeDeltaFailsClosedWithoutConstraints(t *testing.T) {
+	h := newDeltaHarness(t, nil, true)
+	h.acceptBind()
+
+	waitForLog(t, h.lines, "delta test skipped: setpointId=1 has incomplete constraints", 3*time.Second)
+	if h.senderUsed() {
+		t.Error("probe sent a write despite missing constraints — must fail closed")
+	}
+	if got := h.value(); got != 46 {
+		t.Errorf("device value = %v, want untouched 46", got)
+	}
+}
+
+func TestHvacProbeAdvertisesClientUseCasesOnlyWithBind(t *testing.T) {
 	var (
 		mu         sync.Mutex
 		advertised []model.UseCaseNameType
 	)
-	local := mocks.NewEntityLocalInterface(t)
-	local.On("GetOrAddFeature", mock.Anything, mock.Anything).Return(nil).Maybe()
-	local.On("AddUseCaseSupport",
-		model.UseCaseActorTypeConfigurationAppliance,
-		mock.Anything, mock.Anything, mock.Anything, true, mock.Anything,
-	).Run(func(args mock.Arguments) {
-		mu.Lock()
-		advertised = append(advertised, args.Get(1).(model.UseCaseNameType))
-		mu.Unlock()
-	}).Return()
+	newLocal := func() *mocks.EntityLocalInterface {
+		local := mocks.NewEntityLocalInterface(t)
+		local.On("GetOrAddFeature", mock.Anything, mock.Anything).Return(nil).Maybe()
+		local.On("AddUseCaseSupport",
+			model.UseCaseActorTypeConfigurationAppliance,
+			mock.Anything, mock.Anything, mock.Anything, true, mock.Anything,
+		).Run(func(args mock.Arguments) {
+			mu.Lock()
+			advertised = append(advertised, args.Get(1).(model.UseCaseNameType))
+			mu.Unlock()
+		}).Return().Maybe()
+		return local
+	}
 
-	p.Setup(local)
+	// Read-only stage 1: Setup without EnableBind must not claim any use case.
+	p := NewHvacProbe(func(string, ...any) {})
+	p.Setup(newLocal())
+	mu.Lock()
+	if len(advertised) != 0 {
+		t.Fatalf("read-only probe advertised %v, want none", advertised)
+	}
+	mu.Unlock()
+
+	// Stage 2: EnableBind after Setup advertises all four, exactly once.
+	p.EnableBind()
+	p.EnableBind() // idempotent
 
 	want := []model.UseCaseNameType{
 		model.UseCaseNameTypeConfigurationOfDhwSystemFunction,
@@ -554,7 +658,6 @@ func TestHvacProbeSetupAdvertisesClientUseCases(t *testing.T) {
 		model.UseCaseNameTypeConfigurationOfRoomHeatingTemperature,
 	}
 	mu.Lock()
-	defer mu.Unlock()
 	if len(advertised) != len(want) {
 		t.Fatalf("advertised %d use cases %v, want %d", len(advertised), advertised, len(want))
 	}
@@ -562,6 +665,18 @@ func TestHvacProbeSetupAdvertisesClientUseCases(t *testing.T) {
 		if advertised[i] != name {
 			t.Errorf("use case %d = %s, want %s", i, advertised[i], name)
 		}
+	}
+	advertised = nil
+	mu.Unlock()
+
+	// Reverse order (EnableBind before Setup) also advertises exactly once.
+	p2 := NewHvacProbe(func(string, ...any) {})
+	p2.EnableBind()
+	p2.Setup(newLocal())
+	mu.Lock()
+	defer mu.Unlock()
+	if len(advertised) != len(want) {
+		t.Errorf("bind-before-Setup advertised %d use cases %v, want %d", len(advertised), advertised, len(want))
 	}
 }
 

--- a/eebus-bridge/internal/usecases/lpc.go
+++ b/eebus-bridge/internal/usecases/lpc.go
@@ -59,6 +59,8 @@ func (w *LPCWrapper) HandleEvent(ski string, device spineapi.DeviceRemoteInterfa
 	if w.debug {
 		eebus.DefaultUseCaseDiscovery().LogOnce(ski, device)
 	}
+	// No-op unless the experimental HVAC probe was armed in main.
+	eebus.DefaultHvacProbe().ProbeOnce(ski, device)
 
 	if w.registry != nil {
 		w.registry.UpsertObservation(ski, device, entity, "lpc")

--- a/eebus-bridge/internal/usecases/monitoring.go
+++ b/eebus-bridge/internal/usecases/monitoring.go
@@ -71,6 +71,8 @@ func (w *MonitoringWrapper) HandleEvent(ski string, device spineapi.DeviceRemote
 	if w.debug {
 		eebus.DefaultUseCaseDiscovery().LogOnce(ski, device)
 	}
+	// No-op unless the experimental HVAC probe was armed in main.
+	eebus.DefaultHvacProbe().ProbeOnce(ski, device)
 
 	if w.registry != nil {
 		w.registry.UpsertObservation(ski, device, entity, "monitoring")


### PR DESCRIPTION
Experimental, off-by-default spike that answered whether the Vaillant VR940 exposes usable HVAC/DHW control over EEBUS. It grew beyond the original read-only stage 1 — the current head can bind, echo-write, and (behind a SKI-scoped gate) deliberately change a live setpoint once for validation.

## Stages and gates

| Stage | Gate (env) | What it does | VR940 result |
|---|---|---|---|
| 1 read probe | `EEBUS_EXP_HVAC_PROBE` | raw SPINE reads of all Setpoint/HVAC functions + advertised operations | DHW setpoint 35–70/1 and room setpoint 5–30/0.5 declared `rw` |
| 2 bind | `EEBUS_EXP_HVAC_PROBE_BIND` | requests bindings to each Setpoint/HVAC server feature; advertises the ConfigurationAppliance client use cases | all 4 binds ACCEPTED (results route via NodeManagement, not the client feature) |
| 3 echo write | `EEBUS_EXP_HVAC_PROBE_WRITE` | writes the device's own setpointListData back unchanged | ACCEPTED (errorNumber 0) on DHWCircuit + HVACRoom |
| 3b delta test | `EEBUS_EXP_HVAC_PROBE_WRITE_DELTA_SKI=<ski>` | one-shot: dhwTemperature setpoint ±1 step, re-read to confirm the device applied it, restore, confirm | APPLIED and RESTORED (46→47→46, ~4 s deviation) |

Each stage requires the previous one. Stage 3b is additionally fail-closed: it needs an explicitly configured target SKI, a dhwTemperature-scoped setpoint description, complete advertised constraints (step/min/max) and writable operations, and it best-effort restores the original value after every sent write even when the device's result is lost. It must not be left enabled — it re-runs on every reconnect.

## Safety / scope

- Everything is off by default; without the env knobs the probe is inert.
- Stages 1–3 never change device state (stage 3 writes existing values back unchanged).
- Stage 3b changes one setpoint by one step for a few seconds, on one explicitly named device, and restores it; a failed restore is logged loudly for manual follow-up.
- Spike code stays bridge-internal and will be removed when the real `configurationOf*` use cases are built as eebus-go contributions (see `docs/superpowers/specs/2026-07-13-eebus-go-upstream-strategy-design.md`).

## Outcome

Full control chain proven on the VR940: discover → bind → write → **apply**. Detailed hardware logs in the PR comments. Also documented: spine-go routes bind/subscribe results to the local NodeManagement feature (per-feature result callbacks and `HasBindingToRemote` never see them) — relevant for a future upstream fix.
