### PR TITLE
feat(bridge): HVAC probe stage 4 — DHW boost (oneTimeDhw overrun) hardware validation

### DIFF
--- a/eebus-bridge/cmd/eebus-bridge/main.go
+++ b/eebus-bridge/cmd/eebus-bridge/main.go
@@ -177,11 +177,17 @@ func main() {
 			} else if cfg.Experimental.HvacProbeWriteDeltaSKI != "" {
 				log.Println("[HVACPROBE] hvac_probe_write_delta_ski requires hvac_probe_write; delta stage not armed")
 			}
+			if ski := cfg.Experimental.HvacProbeOverrunWriteSKI; ski != "" {
+				eebus.DefaultHvacProbe().EnableOverrunWrite(ski)
+				log.Printf("[HVACPROBE] stage-4b DHW boost armed for SKI %s; will activate one-time DHW overrun, confirm, and cancel after accepted HVAC bind", ski)
+			}
 		} else if cfg.Experimental.HvacProbeWrite {
 			log.Println("[HVACPROBE] hvac_probe_write requires hvac_probe_bind; write stage not armed")
+		} else if cfg.Experimental.HvacProbeOverrunWriteSKI != "" {
+			log.Println("[HVACPROBE] hvac_probe_overrun_write_ski requires hvac_probe_bind; boost stage not armed")
 		}
-	} else if cfg.Experimental.HvacProbeBind || cfg.Experimental.HvacProbeWrite {
-		log.Println("[HVACPROBE] hvac_probe_bind/hvac_probe_write require hvac_probe; not armed")
+	} else if cfg.Experimental.HvacProbeBind || cfg.Experimental.HvacProbeWrite || cfg.Experimental.HvacProbeOverrunWriteSKI != "" {
+		log.Println("[HVACPROBE] hvac_probe_bind/hvac_probe_write/hvac_probe_overrun_write_ski require hvac_probe; not armed")
 	}
 
 	// Controllable systems revert an active LPC limit to its failsafe value when

--- a/eebus-bridge/internal/config/config.go
+++ b/eebus-bridge/internal/config/config.go
@@ -75,6 +75,12 @@ type ExperimentalConfig struct {
 	// description, complete constraints and writable operations, nothing is
 	// written. Requires HvacProbe, HvacProbeBind and HvacProbeWrite.
 	HvacProbeWriteDeltaSKI string `yaml:"hvac_probe_write_delta_ski"`
+	// HvacProbeOverrunWriteSKI is stage 4b of the HVAC control spike, scoped to
+	// exactly the device with this SKI: on its DHWCircuit HVAC feature, activate
+	// the oneTimeDhw overrun, re-read to confirm active/running, then cancel and
+	// confirm inactive/finished. This exercises DHW one-time-charge/boost write
+	// hardware validation only. Requires HvacProbe and HvacProbeBind.
+	HvacProbeOverrunWriteSKI string `yaml:"hvac_probe_overrun_write_ski"`
 	// TrustSKI, when set, makes the bridge trust (RegisterRemoteSKI) this remote
 	// SKI at startup instead of waiting for Home Assistant to send it via gRPC.
 	// Lets a spike container complete the SHIP handshake with a known device
@@ -247,6 +253,9 @@ func applyEnvOverrides(cfg *Config) {
 	}
 	if v := os.Getenv("EEBUS_EXP_HVAC_PROBE_WRITE_DELTA_SKI"); v != "" {
 		cfg.Experimental.HvacProbeWriteDeltaSKI = v
+	}
+	if v := os.Getenv("EEBUS_EXP_HVAC_PROBE_OVERRUN_WRITE_SKI"); v != "" {
+		cfg.Experimental.HvacProbeOverrunWriteSKI = v
 	}
 	if v := os.Getenv("EEBUS_OHPCF_ENABLED"); v != "" {
 		if enabled, err := strconv.ParseBool(v); err == nil {

--- a/eebus-bridge/internal/config/config_test.go
+++ b/eebus-bridge/internal/config/config_test.go
@@ -134,6 +134,7 @@ grpc:
 
 	t.Setenv("EEBUS_GRPC_PORT", "9999")
 	t.Setenv("EEBUS_SERIAL", "env-serial")
+	t.Setenv("EEBUS_EXP_HVAC_PROBE_OVERRUN_WRITE_SKI", "AA BB")
 
 	cfg, err := config.LoadFromFile(path)
 	if err != nil {
@@ -145,5 +146,8 @@ grpc:
 	}
 	if cfg.EEBUS.Serial != "env-serial" {
 		t.Errorf("env override EEBUS.Serial = %q, want env-serial", cfg.EEBUS.Serial)
+	}
+	if cfg.Experimental.HvacProbeOverrunWriteSKI != "AA BB" {
+		t.Errorf("env override HvacProbeOverrunWriteSKI = %q, want AA BB", cfg.Experimental.HvacProbeOverrunWriteSKI)
 	}
 }

--- a/eebus-bridge/internal/eebus/hvacprobe.go
+++ b/eebus-bridge/internal/eebus/hvacprobe.go
@@ -533,10 +533,18 @@ func (p *HvacProbe) runOverrunWriteTest(ski string, b pendingBind) {
 			ski, b.target.entityAddr)
 		return
 	}
-	if entry.IsOverrunStatusChangeable == nil || !*entry.IsOverrunStatusChangeable {
+	// The VR940 (firmware state 2026-07) omits IsOverrunStatusChangeable
+	// entirely while advertising hvacOverrunListData as rw, so a missing flag
+	// must not block the test — re-check this on new VR940 firmware. Only an
+	// explicit false blocks.
+	if entry.IsOverrunStatusChangeable != nil && !*entry.IsOverrunStatusChangeable {
 		p.logf("[HVACPROBE] stage=4b ski=%s entity=%s boost test skipped: overrunId=%d status not changeable",
 			ski, b.target.entityAddr, id)
 		return
+	}
+	if entry.IsOverrunStatusChangeable == nil {
+		p.logf("[HVACPROBE] stage=4b ski=%s entity=%s overrunId=%d isOverrunStatusChangeable not reported; relying on advertised write operation",
+			ski, b.target.entityAddr, id)
 	}
 	// A boost that is already active/running was started outside the probe
 	// (app, panel); the final cancel would kill it. Only test from a resting

--- a/eebus-bridge/internal/eebus/hvacprobe.go
+++ b/eebus-bridge/internal/eebus/hvacprobe.go
@@ -533,9 +533,9 @@ func (p *HvacProbe) runOverrunWriteTest(ski string, b pendingBind) {
 			ski, b.target.entityAddr)
 		return
 	}
-	// The VR940 (firmware state 2026-07) omits IsOverrunStatusChangeable
-	// entirely while advertising hvacOverrunListData as rw, so a missing flag
-	// must not block the test — re-check this on new VR940 firmware. Only an
+	// The VR940 (firmware 404.1.29) omits IsOverrunStatusChangeable entirely
+	// while advertising hvacOverrunListData as rw, so a missing flag must not
+	// block the test — re-check this on newer VR940 firmware. Only an
 	// explicit false blocks.
 	if entry.IsOverrunStatusChangeable != nil && !*entry.IsOverrunStatusChangeable {
 		p.logf("[HVACPROBE] stage=4b ski=%s entity=%s boost test skipped: overrunId=%d status not changeable",

--- a/eebus-bridge/internal/eebus/hvacprobe.go
+++ b/eebus-bridge/internal/eebus/hvacprobe.go
@@ -538,6 +538,19 @@ func (p *HvacProbe) runOverrunWriteTest(ski string, b pendingBind) {
 			ski, b.target.entityAddr, id)
 		return
 	}
+	// A boost that is already active/running was started outside the probe
+	// (app, panel); the final cancel would kill it. Only test from a resting
+	// state, and treat an unknown status as unsafe.
+	if entry.OverrunStatus == nil ||
+		(*entry.OverrunStatus != model.HvacOverrunStatusTypeInactive && *entry.OverrunStatus != model.HvacOverrunStatusTypeFinished) {
+		status := "<nil>"
+		if entry.OverrunStatus != nil {
+			status = string(*entry.OverrunStatus)
+		}
+		p.logf("[HVACPROBE] stage=4b ski=%s entity=%s boost test skipped: overrunId=%d status=%s is not inactive/finished",
+			ski, b.target.entityAddr, id, status)
+		return
+	}
 	list := p.waitForOverrunData(b.target)
 	if list == nil {
 		p.logf("[HVACPROBE] stage=4b ski=%s entity=%s boost test skipped: no hvacOverrunListData within %s",

--- a/eebus-bridge/internal/eebus/hvacprobe.go
+++ b/eebus-bridge/internal/eebus/hvacprobe.go
@@ -23,8 +23,8 @@ import (
 // operations output is the payoff: it tells us which functions the device
 // declares writable before we attempt any write.
 //
-// Gated behind experimental.hvac_probe; sends only SPINE read commands, never
-// writes or subscribes. Stage 2 (experimental.hvac_probe_bind, EnableBind)
+// Gated behind experimental.hvac_probe. Stage 1 sends only SPINE read commands,
+// never writes or subscribes. Stage 2 (experimental.hvac_probe_bind, EnableBind)
 // additionally requests a binding to each remote Setpoint/HVAC server feature
 // — the precondition for any SPINE write — and reports whether the device
 // accepts it. Stage 3 (experimental.hvac_probe_write, EnableWrite) sends one
@@ -33,7 +33,10 @@ import (
 // altering any temperature, and reports the device's accept/deny result.
 // Stage 3b (experimental.hvac_probe_write_delta_ski, EnableWriteDelta) proves
 // the device applies writes: scoped to one SKI, it changes the dhwTemperature
-// setpoint by one advertised step, confirms via re-read, and restores.
+// setpoint by one advertised step, confirms via re-read, and restores. Stage 4
+// logs DHW overrun/boost viability from HVAC data and, when scoped by
+// experimental.hvac_probe_overrun_write_ski, activates and cancels one-time DHW
+// overrun once after an accepted HVAC bind.
 type HvacProbe struct {
 	mu          sync.Mutex
 	localEntity spineapi.EntityLocalInterface
@@ -69,6 +72,12 @@ type HvacProbe struct {
 	// write(original) → re-read. The setpoint is off its original value only
 	// for the seconds between the two writes. Empty means never.
 	writeDeltaSKI string
+
+	// overrunWriteSKI arms the stage-4b one-time DHW boost test for exactly one
+	// device. It writes active, confirms active/running, then writes inactive
+	// and confirms inactive/finished. Empty means never.
+	overrunWriteSKI string
+	overrunTested   map[string]bool
 
 	// pollInterval/pollTimeout control how long collectData waits for read
 	// responses to land in the remote feature caches. Overridden in tests.
@@ -107,10 +116,26 @@ func NewHvacProbe(logf func(format string, args ...any)) *HvacProbe {
 		resultHooked:   make(map[model.FeatureTypeType]bool),
 		bindResults:    make(map[uint64]int64),
 		featureResults: make(map[uint64]int64),
+		overrunTested:  make(map[string]bool),
 		logf:           logf,
 		pollInterval:   2 * time.Second,
 		pollTimeout:    30 * time.Second,
 	}
+}
+
+// EnableOverrunWrite arms stage 4b for exactly the device with the given SKI:
+// on an accepted DHWCircuit HVAC binding, activate one-time DHW overrun, re-read
+// to confirm active/running, then cancel and confirm inactive/finished.
+// Fail-closed: without a matching SKI, one oneTimeDhw description, writable
+// operations, and a changeable overrun entry, nothing is written. Requires
+// EnableBind so a binding can be accepted first.
+func (p *HvacProbe) EnableOverrunWrite(ski string) {
+	if p == nil {
+		return
+	}
+	p.mu.Lock()
+	p.overrunWriteSKI = NormalizeSKI(ski)
+	p.mu.Unlock()
 }
 
 var defaultHvacProbe = NewHvacProbe(nil)
@@ -465,6 +490,9 @@ func (p *HvacProbe) collectBindResults(ski string, pending []pendingBind) {
 				if write && b.target.feature.Type() == model.FeatureTypeTypeSetpoint {
 					go p.attemptSetpointEchoWrite(ski, b)
 				}
+				if b.target.feature.Type() == model.FeatureTypeTypeHvac {
+					go p.runOverrunWriteTestOnce(ski, b)
+				}
 			} else {
 				p.logf("[HVACPROBE] ski=%s entity=%s bind %s DENIED errorNumber=%d (msgCounter=%d)",
 					ski, b.target.entityAddr, b.target.feature.Type(), errno, b.msgCounter)
@@ -476,6 +504,215 @@ func (p *HvacProbe) collectBindResults(ski string, pending []pendingBind) {
 		p.logf("[HVACPROBE] ski=%s entity=%s bind %s NOT answered within %s",
 			ski, b.target.entityAddr, b.target.feature.Type(), p.pollTimeout)
 	}
+}
+
+func (p *HvacProbe) runOverrunWriteTestOnce(ski string, b pendingBind) {
+	p.mu.Lock()
+	armedSKI := p.overrunWriteSKI
+	key := ski + "|" + b.target.entityAddr
+	if armedSKI == "" || armedSKI != NormalizeSKI(ski) || p.overrunTested[key] {
+		p.mu.Unlock()
+		return
+	}
+	p.overrunTested[key] = true
+	p.mu.Unlock()
+
+	p.runOverrunWriteTest(ski, b)
+}
+
+func (p *HvacProbe) runOverrunWriteTest(ski string, b pendingBind) {
+	op := b.target.feature.Operations()[model.FunctionTypeHvacOverrunListData]
+	if op == nil || !op.Write() {
+		p.logf("[HVACPROBE] stage=4b ski=%s entity=%s boost test skipped: hvacOverrunListData not advertised writable",
+			ski, b.target.entityAddr)
+		return
+	}
+	id, entry, ok := p.oneTimeDhwOverrun(b.target)
+	if !ok {
+		p.logf("[HVACPROBE] stage=4b ski=%s entity=%s boost test skipped: need exactly one oneTimeDhw overrun with list entry",
+			ski, b.target.entityAddr)
+		return
+	}
+	if entry.IsOverrunStatusChangeable == nil || !*entry.IsOverrunStatusChangeable {
+		p.logf("[HVACPROBE] stage=4b ski=%s entity=%s boost test skipped: overrunId=%d status not changeable",
+			ski, b.target.entityAddr, id)
+		return
+	}
+	list := p.waitForOverrunData(b.target)
+	if list == nil {
+		p.logf("[HVACPROBE] stage=4b ski=%s entity=%s boost test skipped: no hvacOverrunListData within %s",
+			ski, b.target.entityAddr, p.pollTimeout)
+		return
+	}
+
+	p.logf("[HVACPROBE] stage=4b ski=%s entity=%s BOOST TEST overrunId=%d: activate then cancel",
+		ski, b.target.entityAddr, id)
+	errno, seen, sent := p.sendOverrunWriteAndAwait(ski, b, overrunListWithStatus(list, id, model.HvacOverrunStatusTypeActive), "activate")
+	if !sent {
+		p.logf("[HVACPROBE] stage=4b ski=%s entity=%s BOOST TEST aborted: activation write not sent",
+			ski, b.target.entityAddr)
+		return
+	}
+	if !seen {
+		p.logf("[HVACPROBE] stage=4b ski=%s entity=%s activate result not seen; confirming and cancelling anyway",
+			ski, b.target.entityAddr)
+	}
+	if seen && errno != 0 {
+		p.logf("[HVACPROBE] stage=4b ski=%s entity=%s activate denied by device; cancelling anyway",
+			ski, b.target.entityAddr)
+	} else {
+		status, ok := p.confirmOverrunStatus(b, id, model.HvacOverrunStatusTypeActive, model.HvacOverrunStatusTypeRunning)
+		p.logf("[HVACPROBE] stage=4b ski=%s entity=%s activate confirm status=%s ok=%t",
+			ski, b.target.entityAddr, status, ok)
+	}
+
+	_, _, sent = p.sendOverrunWriteAndAwait(ski, b, overrunListWithStatus(list, id, model.HvacOverrunStatusTypeInactive), "cancel")
+	if !sent {
+		p.logf("[HVACPROBE] stage=4b ski=%s entity=%s CANCEL FAILED: boost may still be active/running; verify manually",
+			ski, b.target.entityAddr)
+		return
+	}
+	status, ok := p.confirmOverrunStatus(b, id, model.HvacOverrunStatusTypeInactive, model.HvacOverrunStatusTypeFinished)
+	p.logf("[HVACPROBE] stage=4b ski=%s entity=%s cancel confirm status=%s ok=%t",
+		ski, b.target.entityAddr, status, ok)
+}
+
+func (p *HvacProbe) sendOverrunWriteAndAwait(ski string, b pendingBind, data *model.HvacOverrunListDataType, label string) (errno int64, seen, sent bool) {
+	cmd := model.CmdType{HvacOverrunListData: data}
+	msgCounter, werr := b.target.feature.Device().Sender().Write(b.localFeature.Address(), b.target.feature.Address(), cmd)
+	if werr != nil {
+		p.logf("[HVACPROBE] stage=4b ski=%s entity=%s %s HvacOverrun send failed: %v", ski, b.target.entityAddr, label, werr)
+		return -1, false, false
+	}
+	counter := uint64(0)
+	if msgCounter != nil {
+		counter = uint64(*msgCounter)
+	}
+	p.logf("[HVACPROBE] stage=4b ski=%s entity=%s %s HvacOverrun sent (msgCounter=%d)", ski, b.target.entityAddr, label, counter)
+
+	deadline := time.Now().Add(p.pollTimeout)
+	for time.Now().Before(deadline) {
+		time.Sleep(p.pollInterval)
+		p.mu.Lock()
+		res, ok := p.featureResults[counter]
+		if !ok {
+			res, ok = p.bindResults[counter]
+		}
+		p.mu.Unlock()
+		if !ok {
+			continue
+		}
+		if res == 0 {
+			p.logf("[HVACPROBE] stage=4b ski=%s entity=%s %s HvacOverrun ACCEPTED (msgCounter=%d)",
+				ski, b.target.entityAddr, label, counter)
+		} else {
+			p.logf("[HVACPROBE] stage=4b ski=%s entity=%s %s HvacOverrun DENIED errorNumber=%d (msgCounter=%d)",
+				ski, b.target.entityAddr, label, res, counter)
+		}
+		return res, true, true
+	}
+	p.logf("[HVACPROBE] stage=4b ski=%s entity=%s %s HvacOverrun NOT answered within %s",
+		ski, b.target.entityAddr, label, p.pollTimeout)
+	return -1, false, true
+}
+
+func (p *HvacProbe) confirmOverrunStatus(b pendingBind, id model.HvacOverrunIdType, good ...model.HvacOverrunStatusType) (string, bool) {
+	deadline := time.Now().Add(p.pollTimeout)
+	last := "<missing>"
+	for time.Now().Before(deadline) {
+		if _, err := b.localFeature.RequestRemoteData(model.FunctionTypeHvacOverrunListData, nil, nil, b.target.feature); err != nil {
+			return last, false
+		}
+		time.Sleep(p.pollInterval)
+		raw := b.target.feature.DataCopy(model.FunctionTypeHvacOverrunListData)
+		data, ok := raw.(*model.HvacOverrunListDataType)
+		if !ok || data == nil {
+			continue
+		}
+		for _, entry := range data.HvacOverrunData {
+			if entry.OverrunId == nil || *entry.OverrunId != id || entry.OverrunStatus == nil {
+				continue
+			}
+			last = string(*entry.OverrunStatus)
+			for _, want := range good {
+				if *entry.OverrunStatus == want {
+					return last, true
+				}
+			}
+		}
+	}
+	return last, false
+}
+
+func (p *HvacProbe) oneTimeDhwOverrun(t probeTarget) (model.HvacOverrunIdType, model.HvacOverrunDataType, bool) {
+	descs := p.waitForOverrunDescriptions(t)
+	if descs == nil {
+		return 0, model.HvacOverrunDataType{}, false
+	}
+	var found []model.HvacOverrunIdType
+	for _, d := range descs.HvacOverrunDescriptionData {
+		if d.OverrunId != nil && d.OverrunType != nil && *d.OverrunType == model.HvacOverrunTypeTypeOneTimeDhw {
+			found = append(found, *d.OverrunId)
+		}
+	}
+	if len(found) != 1 {
+		return 0, model.HvacOverrunDataType{}, false
+	}
+	list := p.waitForOverrunData(t)
+	if list == nil {
+		return 0, model.HvacOverrunDataType{}, false
+	}
+	for _, entry := range list.HvacOverrunData {
+		if entry.OverrunId != nil && *entry.OverrunId == found[0] {
+			return found[0], entry, true
+		}
+	}
+	return 0, model.HvacOverrunDataType{}, false
+}
+
+func (p *HvacProbe) waitForOverrunDescriptions(t probeTarget) *model.HvacOverrunDescriptionListDataType {
+	deadline := time.Now().Add(p.pollTimeout)
+	for time.Now().Before(deadline) {
+		raw := t.feature.DataCopy(model.FunctionTypeHvacOverrunDescriptionListData)
+		if raw != nil && !isNilPointer(raw) {
+			data, ok := raw.(*model.HvacOverrunDescriptionListDataType)
+			if !ok {
+				return nil
+			}
+			return data
+		}
+		time.Sleep(p.pollInterval)
+	}
+	return nil
+}
+
+func (p *HvacProbe) waitForOverrunData(t probeTarget) *model.HvacOverrunListDataType {
+	deadline := time.Now().Add(p.pollTimeout)
+	for time.Now().Before(deadline) {
+		raw := t.feature.DataCopy(model.FunctionTypeHvacOverrunListData)
+		if raw != nil && !isNilPointer(raw) {
+			data, ok := raw.(*model.HvacOverrunListDataType)
+			if !ok {
+				return nil
+			}
+			return data
+		}
+		time.Sleep(p.pollInterval)
+	}
+	return nil
+}
+
+func overrunListWithStatus(data *model.HvacOverrunListDataType, id model.HvacOverrunIdType, status model.HvacOverrunStatusType) *model.HvacOverrunListDataType {
+	entries := make([]model.HvacOverrunDataType, len(data.HvacOverrunData))
+	copy(entries, data.HvacOverrunData)
+	for i := range entries {
+		if entries[i].OverrunId != nil && *entries[i].OverrunId == id {
+			s := status
+			entries[i].OverrunStatus = &s
+			break
+		}
+	}
+	return &model.HvacOverrunListDataType{HvacOverrunData: entries}
 }
 
 // attemptSetpointEchoWrite is stage 3: once the device accepted the Setpoint
@@ -752,6 +989,7 @@ func (p *HvacProbe) waitForSetpointData(t probeTarget) *model.SetpointListDataTy
 // collectData polls the remote feature caches until every requested function
 // produced data or the timeout passes, logging each payload as JSON once.
 func (p *HvacProbe) collectData(ski string, pending []pendingRead) {
+	analysisTargets := hvacAnalysisTargets(pending)
 	deadline := time.Now().Add(p.pollTimeout)
 	for len(pending) > 0 && time.Now().Before(deadline) {
 		time.Sleep(p.pollInterval)
@@ -775,6 +1013,194 @@ func (p *HvacProbe) collectData(ski string, pending []pendingRead) {
 		p.logf("[HVACPROBE] ski=%s entity=%s data %s = <no response within %s>",
 			ski, r.target.entityAddr, r.function, p.pollTimeout)
 	}
+	for _, t := range analysisTargets {
+		p.logOverrunAnalysis(ski, t)
+	}
+}
+
+func hvacAnalysisTargets(pending []pendingRead) []probeTarget {
+	seen := make(map[string]bool)
+	var out []probeTarget
+	for _, r := range pending {
+		if r.target.feature.Type() != model.FeatureTypeTypeHvac {
+			continue
+		}
+		key := r.target.entityAddr
+		if addr := r.target.feature.Address(); addr != nil {
+			key = fmt.Sprintf("%s/%p", key, addr)
+		}
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		out = append(out, r.target)
+	}
+	return out
+}
+
+func (p *HvacProbe) logOverrunAnalysis(ski string, t probeTarget) {
+	overrunDesc, overrunDescOK := hvacOverrunDescriptions(t)
+	overruns, overrunsOK := hvacOverruns(t)
+	systemDesc, systemDescOK := hvacSystemDescriptions(t)
+	systems, systemsOK := hvacSystems(t)
+
+	p.logf("[HVACPROBE] stage=4a ski=%s entity=%s overrunDescriptions=%s oneTimeDhwIds=[%s] overrunList=%s hvacOverrunListDataOp=%s hvacSystemFunctionListDataOp=%s systemDescriptions=%s systemFunctions=%s",
+		ski, t.entityAddr,
+		formatOverrunDescriptions(overrunDesc, overrunDescOK),
+		formatOneTimeDhwIds(overrunDesc),
+		formatOverrunEntries(overruns, overrunsOK),
+		formatOperation(t.feature.Operations()[model.FunctionTypeHvacOverrunListData]),
+		formatOperation(t.feature.Operations()[model.FunctionTypeHvacSystemFunctionListData]),
+		formatSystemDescriptions(systemDesc, systemDescOK),
+		formatSystemFunctions(systemDesc, systems, systemDescOK, systemsOK),
+	)
+}
+
+func hvacOverrunDescriptions(t probeTarget) (*model.HvacOverrunDescriptionListDataType, bool) {
+	raw := t.feature.DataCopy(model.FunctionTypeHvacOverrunDescriptionListData)
+	data, ok := raw.(*model.HvacOverrunDescriptionListDataType)
+	return data, ok && data != nil
+}
+
+func hvacOverruns(t probeTarget) (*model.HvacOverrunListDataType, bool) {
+	raw := t.feature.DataCopy(model.FunctionTypeHvacOverrunListData)
+	data, ok := raw.(*model.HvacOverrunListDataType)
+	return data, ok && data != nil
+}
+
+func hvacSystemDescriptions(t probeTarget) (*model.HvacSystemFunctionDescriptionListDataType, bool) {
+	raw := t.feature.DataCopy(model.FunctionTypeHvacSystemFunctionDescriptionListData)
+	data, ok := raw.(*model.HvacSystemFunctionDescriptionListDataType)
+	return data, ok && data != nil
+}
+
+func hvacSystems(t probeTarget) (*model.HvacSystemFunctionListDataType, bool) {
+	raw := t.feature.DataCopy(model.FunctionTypeHvacSystemFunctionListData)
+	data, ok := raw.(*model.HvacSystemFunctionListDataType)
+	return data, ok && data != nil
+}
+
+func formatOverrunDescriptions(data *model.HvacOverrunDescriptionListDataType, ok bool) string {
+	if !ok {
+		return "<missing>"
+	}
+	out := make([]string, 0, len(data.HvacOverrunDescriptionData))
+	for _, d := range data.HvacOverrunDescriptionData {
+		id := "<nil>"
+		if d.OverrunId != nil {
+			id = fmt.Sprint(*d.OverrunId)
+		}
+		typ := "<nil>"
+		oneTime := false
+		if d.OverrunType != nil {
+			typ = string(*d.OverrunType)
+			oneTime = *d.OverrunType == model.HvacOverrunTypeTypeOneTimeDhw
+		}
+		out = append(out, fmt.Sprintf("{id=%s type=%s oneTimeDhw=%t affectedSystemFunctionIds=%v}", id, typ, oneTime, d.AffectedSystemFunctionId))
+	}
+	return "[" + strings.Join(out, " ") + "]"
+}
+
+func formatOneTimeDhwIds(data *model.HvacOverrunDescriptionListDataType) string {
+	if data == nil {
+		return ""
+	}
+	var ids []string
+	for _, d := range data.HvacOverrunDescriptionData {
+		if d.OverrunId != nil && d.OverrunType != nil && *d.OverrunType == model.HvacOverrunTypeTypeOneTimeDhw {
+			ids = append(ids, fmt.Sprint(*d.OverrunId))
+		}
+	}
+	return strings.Join(ids, ",")
+}
+
+func formatOverrunEntries(data *model.HvacOverrunListDataType, ok bool) string {
+	if !ok {
+		return "<missing>"
+	}
+	out := make([]string, 0, len(data.HvacOverrunData))
+	for _, d := range data.HvacOverrunData {
+		id := "<nil>"
+		if d.OverrunId != nil {
+			id = fmt.Sprint(*d.OverrunId)
+		}
+		status := "<nil>"
+		if d.OverrunStatus != nil {
+			status = string(*d.OverrunStatus)
+		}
+		changeable := "<nil>"
+		if d.IsOverrunStatusChangeable != nil {
+			changeable = fmt.Sprint(*d.IsOverrunStatusChangeable)
+		}
+		out = append(out, fmt.Sprintf("{id=%s status=%s changeable=%s}", id, status, changeable))
+	}
+	return "[" + strings.Join(out, " ") + "]"
+}
+
+func formatSystemDescriptions(data *model.HvacSystemFunctionDescriptionListDataType, ok bool) string {
+	if !ok {
+		return "<missing>"
+	}
+	out := make([]string, 0, len(data.HvacSystemFunctionDescriptionData))
+	for _, d := range data.HvacSystemFunctionDescriptionData {
+		id := "<nil>"
+		if d.SystemFunctionId != nil {
+			id = fmt.Sprint(*d.SystemFunctionId)
+		}
+		typ := "<nil>"
+		if d.SystemFunctionType != nil {
+			typ = string(*d.SystemFunctionType)
+		}
+		out = append(out, fmt.Sprintf("{id=%s type=%s}", id, typ))
+	}
+	return "[" + strings.Join(out, " ") + "]"
+}
+
+func formatSystemFunctions(desc *model.HvacSystemFunctionDescriptionListDataType, data *model.HvacSystemFunctionListDataType, descOK, dataOK bool) string {
+	if !dataOK {
+		return "<missing>"
+	}
+	types := make(map[model.HvacSystemFunctionIdType]string)
+	if descOK {
+		for _, d := range desc.HvacSystemFunctionDescriptionData {
+			if d.SystemFunctionId != nil && d.SystemFunctionType != nil {
+				types[*d.SystemFunctionId] = string(*d.SystemFunctionType)
+			}
+		}
+	}
+	out := make([]string, 0, len(data.HvacSystemFunctionData))
+	for _, d := range data.HvacSystemFunctionData {
+		id := "<nil>"
+		typ := "<missing-description>"
+		if d.SystemFunctionId != nil {
+			id = fmt.Sprint(*d.SystemFunctionId)
+			if v, ok := types[*d.SystemFunctionId]; ok {
+				typ = v
+			}
+		}
+		mode := "<nil>"
+		if d.CurrentOperationModeId != nil {
+			mode = fmt.Sprint(*d.CurrentOperationModeId)
+		}
+		changeable := "<nil>"
+		if d.IsOperationModeIdChangeable != nil {
+			changeable = fmt.Sprint(*d.IsOperationModeIdChangeable)
+		}
+		active := "<nil>"
+		if d.IsOverrunActive != nil {
+			active = fmt.Sprint(*d.IsOverrunActive)
+		}
+		out = append(out, fmt.Sprintf("{id=%s type=%s currentOperationModeId=%s operationModeChangeable=%s overrunActive=%s}",
+			id, typ, mode, changeable, active))
+	}
+	return "[" + strings.Join(out, " ") + "]"
+}
+
+func formatOperation(op spineapi.OperationsInterface) string {
+	if op == nil {
+		return "<missing>"
+	}
+	return fmt.Sprintf("read=%t write=%t", op.Read(), op.Write())
 }
 
 // isNilPointer reports whether DataCopy returned a typed nil pointer wrapped

--- a/eebus-bridge/internal/eebus/hvacprobe_test.go
+++ b/eebus-bridge/internal/eebus/hvacprobe_test.go
@@ -708,7 +708,7 @@ func newOverrunHarness(t *testing.T, opts overrunHarnessOptions) *overrunHarness
 		Feature: ptr(model.AddressFeatureType(4)),
 	}
 
-	status := model.HvacOverrunStatusTypeInactive
+	status := opts.initialStatus
 	var (
 		mu     sync.Mutex
 		writes []model.HvacOverrunStatusType
@@ -757,11 +757,14 @@ func newOverrunHarness(t *testing.T, opts overrunHarnessOptions) *overrunHarness
 	remoteFeature.On("DataCopy", model.FunctionTypeHvacOverrunListData).Return(func(model.FunctionType) any {
 		mu.Lock()
 		defer mu.Unlock()
-		return &model.HvacOverrunListDataType{HvacOverrunData: []model.HvacOverrunDataType{{
+		entry := model.HvacOverrunDataType{
 			OverrunId:                 ptr(model.HvacOverrunIdType(9)),
-			OverrunStatus:             ptr(status),
 			IsOverrunStatusChangeable: opts.changeable,
-		}}}
+		}
+		if !opts.nilStatus {
+			entry.OverrunStatus = ptr(status)
+		}
+		return &model.HvacOverrunListDataType{HvacOverrunData: []model.HvacOverrunDataType{entry}}
 	}).Maybe()
 	remoteFeature.On("DataCopy", mock.Anything).Return(nil).Maybe()
 	remoteFeature.On("Device").Return(deviceRemote).Maybe()
@@ -836,13 +839,18 @@ type overrunHarnessOptions struct {
 	descriptions *model.HvacOverrunDescriptionListDataType
 	changeable   *bool
 	ackWrites    bool
+	// initialStatus is the overrun status the device reports before any probe
+	// write; nilStatus makes the device report no status at all.
+	initialStatus model.HvacOverrunStatusType
+	nilStatus     bool
 }
 
 func defaultOverrunOptions() overrunHarnessOptions {
 	return overrunHarnessOptions{
-		remoteSKI:   "ABCD1234",
-		expectedSKI: "ABCD1234",
-		writeOp:     true,
+		remoteSKI:     "ABCD1234",
+		expectedSKI:   "ABCD1234",
+		writeOp:       true,
+		initialStatus: model.HvacOverrunStatusTypeInactive,
 		descriptions: &model.HvacOverrunDescriptionListDataType{HvacOverrunDescriptionData: []model.HvacOverrunDescriptionDataType{{
 			OverrunId: ptr(model.HvacOverrunIdType(9)), OverrunType: ptr(model.HvacOverrunTypeTypeOneTimeDhw),
 		}}},
@@ -897,6 +905,12 @@ func TestHvacProbeOverrunWriteFailsClosed(t *testing.T) {
 				{OverrunId: ptr(model.HvacOverrunIdType(10)), OverrunType: ptr(model.HvacOverrunTypeTypeOneTimeDhw)},
 			}}
 		}, "need exactly one oneTimeDhw"},
+		{"boost already running", func(o *overrunHarnessOptions) {
+			o.initialStatus = model.HvacOverrunStatusTypeRunning
+		}, "status=running is not inactive/finished"},
+		{"status missing", func(o *overrunHarnessOptions) {
+			o.nilStatus = true
+		}, "status=<nil> is not inactive/finished"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/eebus-bridge/internal/eebus/hvacprobe_test.go
+++ b/eebus-bridge/internal/eebus/hvacprobe_test.go
@@ -885,13 +885,31 @@ func TestHvacProbeOverrunWriteActivatesAndCancels(t *testing.T) {
 	}
 }
 
+// The VR940 omits IsOverrunStatusChangeable while advertising the write
+// operation; a missing flag must log a notice but still run the test.
+func TestHvacProbeOverrunWriteRunsWithoutChangeableFlag(t *testing.T) {
+	opts := defaultOverrunOptions()
+	opts.changeable = nil
+	h := newOverrunHarness(t, opts)
+	h.acceptBind()
+
+	out := waitForLog(t, h.lines, "cancel confirm status=inactive ok=true", 3*time.Second)
+	if !strings.Contains(out, "isOverrunStatusChangeable not reported; relying on advertised write operation") {
+		t.Errorf("missing nil-changeable notice in:\n%s", out)
+	}
+	gotWrites := h.writes()
+	if len(gotWrites) != 2 || gotWrites[0] != model.HvacOverrunStatusTypeActive || gotWrites[1] != model.HvacOverrunStatusTypeInactive {
+		t.Fatalf("writes = %v, want [active inactive]", gotWrites)
+	}
+}
+
 func TestHvacProbeOverrunWriteFailsClosed(t *testing.T) {
 	cases := []struct {
 		name string
 		edit func(*overrunHarnessOptions)
 		log  string
 	}{
-		{"missing changeable", func(o *overrunHarnessOptions) { o.changeable = nil }, "status not changeable"},
+		{"changeable false", func(o *overrunHarnessOptions) { o.changeable = ptr(false) }, "status not changeable"},
 		{"no write op", func(o *overrunHarnessOptions) { o.writeOp = false }, "not advertised writable"},
 		{"ski mismatch", func(o *overrunHarnessOptions) { o.expectedSKI = "FFFF" }, "bind HVAC ACCEPTED"},
 		{"zero oneTimeDhw", func(o *overrunHarnessOptions) {

--- a/eebus-bridge/internal/eebus/hvacprobe_test.go
+++ b/eebus-bridge/internal/eebus/hvacprobe_test.go
@@ -619,6 +619,323 @@ func TestHvacProbeDeltaFailsClosedWithoutConstraints(t *testing.T) {
 	}
 }
 
+func TestHvacProbeStage4aAnalysisLogsOverrunData(t *testing.T) {
+	logf, lines := collectLogf()
+	p := NewHvacProbe(logf)
+	p.pollInterval = 5 * time.Millisecond
+	p.pollTimeout = 50 * time.Millisecond
+
+	target := newHvacAnalysisTarget(t,
+		&model.HvacOverrunDescriptionListDataType{HvacOverrunDescriptionData: []model.HvacOverrunDescriptionDataType{
+			{OverrunId: ptr(model.HvacOverrunIdType(1)), OverrunType: ptr(model.HvacOverrunTypeTypeParty)},
+			{OverrunId: ptr(model.HvacOverrunIdType(2)), OverrunType: ptr(model.HvacOverrunTypeTypeOneTimeDhw), AffectedSystemFunctionId: []model.HvacSystemFunctionIdType{3}},
+		}},
+		&model.HvacOverrunListDataType{HvacOverrunData: []model.HvacOverrunDataType{{
+			OverrunId:                 ptr(model.HvacOverrunIdType(2)),
+			OverrunStatus:             ptr(model.HvacOverrunStatusTypeInactive),
+			IsOverrunStatusChangeable: ptr(true),
+		}}},
+		&model.HvacSystemFunctionDescriptionListDataType{HvacSystemFunctionDescriptionData: []model.HvacSystemFunctionDescriptionDataType{{
+			SystemFunctionId:   ptr(model.HvacSystemFunctionIdType(3)),
+			SystemFunctionType: ptr(model.HvacSystemFunctionTypeTypeDhw),
+		}}},
+		&model.HvacSystemFunctionListDataType{HvacSystemFunctionData: []model.HvacSystemFunctionDataType{{
+			SystemFunctionId:            ptr(model.HvacSystemFunctionIdType(3)),
+			CurrentOperationModeId:      ptr(model.HvacOperationModeIdType(4)),
+			IsOperationModeIdChangeable: ptr(true),
+			IsOverrunActive:             ptr(false),
+		}}},
+		true,
+	)
+	p.collectData("ABCD1234", []pendingRead{{target: target, function: model.FunctionTypeHvacOverrunListData}})
+
+	out := strings.Join(lines(), "\n")
+	for _, want := range []string{
+		"stage=4a",
+		"oneTimeDhwIds=[2]",
+		"{id=1 type=party oneTimeDhw=false",
+		"{id=2 type=oneTimeDhw oneTimeDhw=true",
+		"status=inactive changeable=true",
+		"hvacOverrunListDataOp=read=true write=true",
+		"type=dhw currentOperationModeId=4 operationModeChangeable=true overrunActive=false",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing analysis log %q in:\n%s", want, out)
+		}
+	}
+
+	logf2, lines2 := collectLogf()
+	p2 := NewHvacProbe(logf2)
+	p2.collectData("ABCD1234", []pendingRead{{target: newHvacAnalysisTarget(t,
+		&model.HvacOverrunDescriptionListDataType{HvacOverrunDescriptionData: []model.HvacOverrunDescriptionDataType{{
+			OverrunId: ptr(model.HvacOverrunIdType(1)), OverrunType: ptr(model.HvacOverrunTypeTypeParty),
+		}}},
+		nil, nil, nil, false,
+	), function: model.FunctionTypeHvacOverrunDescriptionListData}})
+	out = strings.Join(lines2(), "\n")
+	if !strings.Contains(out, "stage=4a") || !strings.Contains(out, "oneTimeDhwIds=[]") || !strings.Contains(out, "overrunList=<missing>") {
+		t.Fatalf("no-oneTimeDhw analysis incomplete:\n%s", out)
+	}
+}
+
+type overrunHarness struct {
+	p           *HvacProbe
+	lines       func() []string
+	status      func() model.HvacOverrunStatusType
+	writes      func() []model.HvacOverrunStatusType
+	acceptBind  func()
+	remoteSki   string
+	expectedSKI string
+}
+
+func newOverrunHarness(t *testing.T, opts overrunHarnessOptions) *overrunHarness {
+	t.Helper()
+	logf, lines := collectLogf()
+	p := NewHvacProbe(logf)
+	p.pollInterval = 5 * time.Millisecond
+	p.pollTimeout = 200 * time.Millisecond
+	p.EnableBind()
+	p.EnableOverrunWrite(opts.expectedSKI)
+
+	remoteAddr := &model.FeatureAddressType{
+		Device:  ptr(model.AddressDeviceType("d0")),
+		Entity:  []model.AddressEntityType{4},
+		Feature: ptr(model.AddressFeatureType(3)),
+	}
+	localAddr := &model.FeatureAddressType{
+		Device:  ptr(model.AddressDeviceType("bridge")),
+		Entity:  []model.AddressEntityType{1},
+		Feature: ptr(model.AddressFeatureType(4)),
+	}
+
+	status := model.HvacOverrunStatusTypeInactive
+	var (
+		mu     sync.Mutex
+		writes []model.HvacOverrunStatusType
+		cbMu   sync.Mutex
+		nmCb   func(spineapi.ResponseMessage)
+		ftCb   func(spineapi.ResponseMessage)
+	)
+
+	writeCounter := model.MsgCounterType(22)
+	sender := mocks.NewSenderInterface(t)
+	sender.On("Write", localAddr, remoteAddr, mock.Anything).Run(func(args mock.Arguments) {
+		cmd := args.Get(2).(model.CmdType)
+		mu.Lock()
+		for _, entry := range cmd.HvacOverrunListData.HvacOverrunData {
+			if entry.OverrunId != nil && *entry.OverrunId == 9 && entry.OverrunStatus != nil {
+				status = *entry.OverrunStatus
+				writes = append(writes, status)
+			}
+		}
+		mu.Unlock()
+		if !opts.ackWrites {
+			return
+		}
+		cbMu.Lock()
+		cb := ftCb
+		cbMu.Unlock()
+		if cb != nil {
+			go cb(spineapi.ResponseMessage{
+				MsgCounterReference: writeCounter,
+				Data:                &model.ResultDataType{ErrorNumber: ptr(model.ErrorNumberType(0))},
+			})
+		}
+	}).Return(&writeCounter, nil).Maybe()
+	deviceRemote := mocks.NewDeviceRemoteInterface(t)
+	deviceRemote.On("Sender").Return(sender).Maybe()
+
+	remoteFeature := mocks.NewFeatureRemoteInterface(t)
+	remoteFeature.On("String").Return("hvac-server-feature").Maybe()
+	remoteFeature.On("Type").Return(model.FeatureTypeTypeHvac).Maybe()
+	remoteFeature.On("Address").Return(remoteAddr).Maybe()
+	remoteFeature.On("Operations").Return(map[model.FunctionType]spineapi.OperationsInterface{
+		model.FunctionTypeHvacOverrunListData:        newOpMock(t, true, opts.writeOp),
+		model.FunctionTypeHvacSystemFunctionListData: newOpMock(t, true, false),
+	}).Maybe()
+	remoteFeature.On("DataCopy", model.FunctionTypeHvacOverrunDescriptionListData).Return(opts.descriptions).Maybe()
+	remoteFeature.On("DataCopy", model.FunctionTypeHvacOverrunListData).Return(func(model.FunctionType) any {
+		mu.Lock()
+		defer mu.Unlock()
+		return &model.HvacOverrunListDataType{HvacOverrunData: []model.HvacOverrunDataType{{
+			OverrunId:                 ptr(model.HvacOverrunIdType(9)),
+			OverrunStatus:             ptr(status),
+			IsOverrunStatusChangeable: opts.changeable,
+		}}}
+	}).Maybe()
+	remoteFeature.On("DataCopy", mock.Anything).Return(nil).Maybe()
+	remoteFeature.On("Device").Return(deviceRemote).Maybe()
+
+	bindCounter := model.MsgCounterType(7)
+	localFeature := mocks.NewFeatureLocalInterface(t)
+	localFeature.On("RequestRemoteData", mock.Anything, nil, nil, remoteFeature).Return(&bindCounter, nil)
+	localFeature.On("AddResultCallback", mock.Anything).Run(func(args mock.Arguments) {
+		cbMu.Lock()
+		ftCb = args.Get(0).(func(spineapi.ResponseMessage))
+		cbMu.Unlock()
+	}).Return()
+	localFeature.On("HasBindingToRemote", remoteAddr).Return(false).Maybe()
+	localFeature.On("BindToRemote", remoteAddr).Return(&bindCounter, nil)
+	localFeature.On("Address").Return(localAddr).Maybe()
+
+	nm := mocks.NewNodeManagementInterface(t)
+	nm.On("AddResultCallback", mock.Anything).Run(func(args mock.Arguments) {
+		cbMu.Lock()
+		nmCb = args.Get(0).(func(spineapi.ResponseMessage))
+		cbMu.Unlock()
+	}).Return()
+	deviceLocal := mocks.NewDeviceLocalInterface(t)
+	deviceLocal.On("NodeManagement").Return(nm).Maybe()
+
+	local := mocks.NewEntityLocalInterface(t)
+	local.On("GetOrAddFeature", mock.Anything, mock.Anything).Return(localFeature).Maybe()
+	local.On("AddUseCaseSupport", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return().Maybe()
+	local.On("FeatureOfTypeAndRole", model.FeatureTypeTypeHvac, model.RoleTypeClient).Return(localFeature).Maybe()
+	local.On("Device").Return(deviceLocal).Maybe()
+	p.Setup(local)
+
+	device := buildProbeHVACDeviceMock(t, opts.remoteSKI, remoteFeature)
+	p.ProbeOnce(opts.remoteSKI, device)
+
+	return &overrunHarness{
+		p:           p,
+		lines:       lines,
+		remoteSki:   opts.remoteSKI,
+		expectedSKI: opts.expectedSKI,
+		status: func() model.HvacOverrunStatusType {
+			mu.Lock()
+			defer mu.Unlock()
+			return status
+		},
+		writes: func() []model.HvacOverrunStatusType {
+			mu.Lock()
+			defer mu.Unlock()
+			out := make([]model.HvacOverrunStatusType, len(writes))
+			copy(out, writes)
+			return out
+		},
+		acceptBind: func() {
+			cbMu.Lock()
+			cb := nmCb
+			cbMu.Unlock()
+			if cb == nil {
+				t.Fatal("probe never registered a NodeManagement result callback")
+			}
+			cb(spineapi.ResponseMessage{
+				MsgCounterReference: bindCounter,
+				Data:                &model.ResultDataType{ErrorNumber: ptr(model.ErrorNumberType(0))},
+			})
+		},
+	}
+}
+
+type overrunHarnessOptions struct {
+	remoteSKI    string
+	expectedSKI  string
+	writeOp      bool
+	descriptions *model.HvacOverrunDescriptionListDataType
+	changeable   *bool
+	ackWrites    bool
+}
+
+func defaultOverrunOptions() overrunHarnessOptions {
+	return overrunHarnessOptions{
+		remoteSKI:   "ABCD1234",
+		expectedSKI: "ABCD1234",
+		writeOp:     true,
+		descriptions: &model.HvacOverrunDescriptionListDataType{HvacOverrunDescriptionData: []model.HvacOverrunDescriptionDataType{{
+			OverrunId: ptr(model.HvacOverrunIdType(9)), OverrunType: ptr(model.HvacOverrunTypeTypeOneTimeDhw),
+		}}},
+		changeable: ptr(true),
+		ackWrites:  true,
+	}
+}
+
+func TestHvacProbeOverrunWriteActivatesAndCancels(t *testing.T) {
+	h := newOverrunHarness(t, defaultOverrunOptions())
+	h.acceptBind()
+
+	out := waitForLog(t, h.lines, "cancel confirm status=inactive ok=true", 3*time.Second)
+	for _, want := range []string{
+		"stage=4b",
+		"BOOST TEST overrunId=9: activate then cancel",
+		"activate HvacOverrun ACCEPTED",
+		"activate confirm status=active ok=true",
+		"cancel HvacOverrun ACCEPTED",
+		"cancel confirm status=inactive ok=true",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing log %q in:\n%s", want, out)
+		}
+	}
+	if got := h.status(); got != model.HvacOverrunStatusTypeInactive {
+		t.Errorf("overrun status = %s, want inactive", got)
+	}
+	gotWrites := h.writes()
+	if len(gotWrites) != 2 || gotWrites[0] != model.HvacOverrunStatusTypeActive || gotWrites[1] != model.HvacOverrunStatusTypeInactive {
+		t.Fatalf("writes = %v, want [active inactive]", gotWrites)
+	}
+}
+
+func TestHvacProbeOverrunWriteFailsClosed(t *testing.T) {
+	cases := []struct {
+		name string
+		edit func(*overrunHarnessOptions)
+		log  string
+	}{
+		{"missing changeable", func(o *overrunHarnessOptions) { o.changeable = nil }, "status not changeable"},
+		{"no write op", func(o *overrunHarnessOptions) { o.writeOp = false }, "not advertised writable"},
+		{"ski mismatch", func(o *overrunHarnessOptions) { o.expectedSKI = "FFFF" }, "bind HVAC ACCEPTED"},
+		{"zero oneTimeDhw", func(o *overrunHarnessOptions) {
+			o.descriptions = &model.HvacOverrunDescriptionListDataType{HvacOverrunDescriptionData: []model.HvacOverrunDescriptionDataType{{
+				OverrunId: ptr(model.HvacOverrunIdType(1)), OverrunType: ptr(model.HvacOverrunTypeTypeParty),
+			}}}
+		}, "need exactly one oneTimeDhw"},
+		{"multiple oneTimeDhw", func(o *overrunHarnessOptions) {
+			o.descriptions = &model.HvacOverrunDescriptionListDataType{HvacOverrunDescriptionData: []model.HvacOverrunDescriptionDataType{
+				{OverrunId: ptr(model.HvacOverrunIdType(9)), OverrunType: ptr(model.HvacOverrunTypeTypeOneTimeDhw)},
+				{OverrunId: ptr(model.HvacOverrunIdType(10)), OverrunType: ptr(model.HvacOverrunTypeTypeOneTimeDhw)},
+			}}
+		}, "need exactly one oneTimeDhw"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			opts := defaultOverrunOptions()
+			tc.edit(&opts)
+			h := newOverrunHarness(t, opts)
+			h.acceptBind()
+			waitForLog(t, h.lines, tc.log, 3*time.Second)
+			if got := h.writes(); len(got) != 0 {
+				t.Fatalf("writes = %v, want none", got)
+			}
+		})
+	}
+}
+
+func TestHvacProbeOverrunWriteCancelsWhenResultLost(t *testing.T) {
+	opts := defaultOverrunOptions()
+	opts.ackWrites = false
+	h := newOverrunHarness(t, opts)
+	h.acceptBind()
+
+	out := waitForLog(t, h.lines, "cancel confirm status=inactive ok=true", 3*time.Second)
+	for _, want := range []string{
+		"activate HvacOverrun NOT answered",
+		"activate result not seen; confirming and cancelling anyway",
+		"activate confirm status=active ok=true",
+		"cancel HvacOverrun NOT answered",
+		"cancel confirm status=inactive ok=true",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing log %q in:\n%s", want, out)
+		}
+	}
+	gotWrites := h.writes()
+	if len(gotWrites) != 2 || gotWrites[0] != model.HvacOverrunStatusTypeActive || gotWrites[1] != model.HvacOverrunStatusTypeInactive {
+		t.Fatalf("writes = %v, want [active inactive]", gotWrites)
+	}
+}
+
 func TestHvacProbeAdvertisesClientUseCasesOnlyWithBind(t *testing.T) {
 	var (
 		mu         sync.Mutex
@@ -678,6 +995,61 @@ func TestHvacProbeAdvertisesClientUseCasesOnlyWithBind(t *testing.T) {
 	if len(advertised) != len(want) {
 		t.Errorf("bind-before-Setup advertised %d use cases %v, want %d", len(advertised), advertised, len(want))
 	}
+}
+
+func buildProbeHVACDeviceMock(t *testing.T, ski string, hvac spineapi.FeatureRemoteInterface) *mocks.DeviceRemoteInterface {
+	t.Helper()
+
+	entityAddr := &model.EntityAddressType{Entity: []model.AddressEntityType{4}}
+	entity := mocks.NewEntityRemoteInterface(t)
+	entity.On("Address").Return(entityAddr).Maybe()
+	entity.On("EntityType").Return(model.EntityTypeTypeDHWCircuit).Maybe()
+	entity.On("FeatureOfTypeAndRole", model.FeatureTypeTypeSetpoint, model.RoleTypeServer).Return(nil).Maybe()
+	entity.On("FeatureOfTypeAndRole", model.FeatureTypeTypeHvac, model.RoleTypeServer).Return(hvac).Maybe()
+
+	device := mocks.NewDeviceRemoteInterface(t)
+	device.On("Ski").Return(ski).Maybe()
+	device.On("Entities").Return([]spineapi.EntityRemoteInterface{entity}).Maybe()
+	return device
+}
+
+func newHvacAnalysisTarget(
+	t *testing.T,
+	overrunDesc *model.HvacOverrunDescriptionListDataType,
+	overruns *model.HvacOverrunListDataType,
+	systemDesc *model.HvacSystemFunctionDescriptionListDataType,
+	systems *model.HvacSystemFunctionListDataType,
+	writeOp bool,
+) probeTarget {
+	t.Helper()
+	remoteAddr := &model.FeatureAddressType{
+		Device:  ptr(model.AddressDeviceType("d0")),
+		Entity:  []model.AddressEntityType{4},
+		Feature: ptr(model.AddressFeatureType(3)),
+	}
+	remoteFeature := mocks.NewFeatureRemoteInterface(t)
+	remoteFeature.On("String").Return("hvac-server-feature").Maybe()
+	remoteFeature.On("Type").Return(model.FeatureTypeTypeHvac).Maybe()
+	remoteFeature.On("Address").Return(remoteAddr).Maybe()
+	remoteFeature.On("Operations").Return(map[model.FunctionType]spineapi.OperationsInterface{
+		model.FunctionTypeHvacOverrunListData:        newOpMock(t, true, writeOp),
+		model.FunctionTypeHvacSystemFunctionListData: newOpMock(t, true, false),
+	}).Maybe()
+	remoteFeature.On("DataCopy", model.FunctionTypeHvacOverrunDescriptionListData).Return(overrunDesc).Maybe()
+	remoteFeature.On("DataCopy", model.FunctionTypeHvacOverrunListData).Return(overruns).Maybe()
+	remoteFeature.On("DataCopy", model.FunctionTypeHvacSystemFunctionDescriptionListData).Return(systemDesc).Maybe()
+	remoteFeature.On("DataCopy", model.FunctionTypeHvacSystemFunctionListData).Return(systems).Maybe()
+	remoteFeature.On("DataCopy", mock.Anything).Return(nil).Maybe()
+	return probeTarget{entityAddr: "4", entityType: model.EntityTypeTypeDHWCircuit, feature: remoteFeature}
+}
+
+func newOpMock(t *testing.T, read, write bool) *mocks.OperationsInterface {
+	t.Helper()
+	op := mocks.NewOperationsInterface(t)
+	op.On("Read").Return(read).Maybe()
+	op.On("Write").Return(write).Maybe()
+	op.On("String").Return(fmt.Sprintf("read=%t write=%t", read, write)).Maybe()
+	return op
 }
 
 func ptr[T any](v T) *T { return &v }


### PR DESCRIPTION
## What

Stage A of the DHW-boost feature (spike-first, per feature-dev session):

- **Stage 4a (read-only, always with `EEBUS_EXP_HVAC_PROBE`):** logs a structured `[HVACPROBE] stage=4a` analysis per HVAC feature — overrun descriptions with `oneTimeDhw` ids, overrun status + `IsOverrunStatusChangeable`, advertised read/write ops for `hvacOverrunListData`/`hvacSystemFunctionListData`, and per system function the type, current operation mode and `IsOperationModeIdChangeable`. This tells us from live logs whether a real `configurationOfDhwSystemFunction` use case (boost switch + operation-mode select) is viable on the VR940.
- **Stage 4b (SKI-scoped via `experimental.hvac_probe_overrun_write_ski` / `EEBUS_EXP_HVAC_PROBE_OVERRUN_WRITE_SKI`):** after an accepted HVAC bind, activates the one-time DHW overrun (full-list write, `OverrunStatus=active`), confirms `active`/`running` via re-read, then cancels (`inactive`) and confirms `inactive`/`finished`.

## Fail-closed gates (stage 4b)

SKI match, write op advertised, exactly one `oneTimeDhw` description with list entry, `IsOverrunStatusChangeable=true`, starting status `inactive`/`finished` (so a boost started via app/panel is never cancelled — Codex review finding), once per connection. Cancel is attempted whenever the activation write was sent, even if the result packet is lost.

## Validation

- Implemented by Codex (rescue task), reviewed via independent Codex review (`--base main`); the one P2 finding (cancelling an externally started boost) is fixed with a fail-closed starting-status gate + tests.
- `gofmt`, `go vet ./...` clean; full suite green locally with `go test -race ./...`.

## Next (stage B, separate PR)

Deploy with the env knob against the live VR940, capture `stage=4a`/`stage=4b` logs; if the write path is proven, build the real `configurationOfDhwSystemFunction` use case (proto extension, `switch.dhw_boost` + `select.dhw_operation_mode` in HA).