### PR TITLE
feat: DHW boost switch + operation-mode select (configurationOfDhwSystemFunction)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Lokale Integration von EEBUS-faehigen Waermepumpen in Home Assistant ueber das *
 - **Heartbeat-Ueberwachung** -- Sicherheitsrelevanter EEBUS-Heartbeat mit Failsafe-Fallback
 - **Warmwasser-Solltemperatur** -- Lokales Lesen und Setzen des vom Geraet
   angebotenen DHW-Sollwerts mit dynamischen Min/Max/Schritt-Grenzen
+- **Warmwasser-Boost und Betriebsart** -- Lokales Aktivieren der Einmalladung
+  und Auswahl der vom Geraet angebotenen DHW-Betriebsarten
 - **Energy Dashboard** -- Volle Integration mit dem HA Energy Dashboard
 - **Erweiterbar** -- Architektur vorbereitet fuer zukuenftige EEBUS-HVAC-Use-Cases
 
@@ -99,6 +101,7 @@ Die Integration nutzt **gRPC Streaming** (Server-Sent Events) fuer Echtzeit-Upda
 - **Leistungsmessung:** Event-basiert (ca. alle 60s vom Inverter)
 - **LPC-Limits:** Event-basiert (bei Aenderung)
 - **Warmwasser-Solltemperatur:** Event-basiert (bei Aenderung)
+- **Warmwasser-Boost/Betriebsart:** Event-basiert (bei Aenderung)
 - **Heartbeat:** Alle 4 Sekunden (im Bridge, nicht in HA)
 
 ## Verfuegbare Entities
@@ -119,6 +122,8 @@ Die Integration nutzt **gRPC Streaming** (Server-Sent Events) fuer Echtzeit-Upda
 | `number.eebus_dhw_setpoint` | number | Warmwasser-Solltemperatur; Bereich und Schrittweite kommen vom Geraet |
 | `switch.eebus_lpc_active` | switch | Limit aktivieren/deaktivieren |
 | `switch.eebus_heartbeat` | switch | Heartbeat an/aus, standardmaessig deaktiviert |
+| `switch.eebus_dhw_boost` | switch | Warmwasser-Einmalladung aktivieren/deaktivieren |
+| `select.eebus_dhw_operation_mode` | select | Warmwasser-Betriebsart; Optionen kommen vom Geraet |
 | `select.eebus_compressor_flexibility` | select | OHPCF-Verdichter-Flexibilitaet: `on`/`paused`/`off`, nur vorhanden wenn WP ein Angebot meldet |
 
 ### Diagnose
@@ -147,7 +152,7 @@ Die Integration nutzt **gRPC Streaming** (Server-Sent Events) fuer Echtzeit-Upda
 
 ### Nicht unterstuetzt
 
-- Raumheizungs-Sollwerte, Betriebsmodi und DHW-Boost -- noch nicht produktiv verdrahtet
+- Raumheizungs-Sollwerte und Raumheizungs-Betriebsmodi -- noch nicht produktiv verdrahtet
 - Geraete ohne EEBUS-Schnittstelle
 
 ## Energiemanagement mit EEBUS verstehen

--- a/custom_components/eebus/coordinator.py
+++ b/custom_components/eebus/coordinator.py
@@ -97,6 +97,23 @@ def _rpc_error_text(err: grpc.aio.AioRpcError) -> str:
     return f"code={err.code().name} details={err.details()}"
 
 
+def _dhw_system_function_to_dict(state: Any) -> dict[str, Any]:
+    """Convert a DHW system-function protobuf state into coordinator data."""
+    from . import proto_stubs
+
+    status = proto_stubs.DHWBoostStatus.Name(state.boost_status)
+    prefix = "DHW_BOOST_STATUS_"
+    if status.startswith(prefix):
+        status = status[len(prefix) :]
+    return {
+        "boost_status": status.lower(),
+        "boost_writable": state.boost_writable,
+        "operation_mode": state.operation_mode,
+        "available_modes": list(state.available_modes),
+        "mode_writable": state.mode_writable,
+    }
+
+
 class EebusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     """Coordinator that manages gRPC connection and data updates."""
 
@@ -151,6 +168,7 @@ class EebusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self._failsafe_supported: bool | None = None
         self._ohpcf_supported: bool | None = None
         self._dhw_supported: bool | None = None
+        self._dhw_sysfn_supported: bool | None = None
         self._ski_registered: bool = False
         self._not_found_streak: int = 0
 
@@ -533,6 +551,10 @@ class EebusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 channel, proto_stubs, request
             )
             data["dhw_supported"] = self._dhw_supported
+            data["dhw_system_function"] = await self._async_read_dhw_system_function(
+                channel, proto_stubs, request
+            )
+            data["dhw_sysfn_supported"] = self._dhw_sysfn_supported
 
             if saw_not_found:
                 self._not_found_streak += 1
@@ -894,6 +916,84 @@ class EebusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 ) from err
             raise
 
+    async def _async_read_dhw_system_function(
+        self, channel: grpc.aio.Channel, proto_stubs: Any, request: Any
+    ) -> dict[str, Any] | None:
+        """Read DHW boost and operation mode state."""
+        try:
+            stub = proto_stubs.dhw_service_stub(channel)
+            state = await stub.GetDHWSystemFunction(request, timeout=RPC_TIMEOUT)
+        except grpc.aio.AioRpcError as err:
+            if _is_unimplemented(err) or err.code() in (
+                grpc.StatusCode.NOT_FOUND,
+                grpc.StatusCode.UNAVAILABLE,
+            ):
+                self._dhw_sysfn_supported = False
+            else:
+                _LOGGER.debug(
+                    "EEBUS DHW system function read failed for SKI %s: %s",
+                    self.ski,
+                    _rpc_error_text(err),
+                )
+            return None
+
+        self._dhw_sysfn_supported = True
+        return _dhw_system_function_to_dict(state)
+
+    async def async_set_dhw_boost(self, active: bool) -> None:
+        """Activate or cancel DHW one-time boost."""
+        channel = await self._ensure_channel()
+        from . import proto_stubs
+
+        stub = proto_stubs.dhw_service_stub(channel)
+        try:
+            await stub.SetDHWBoost(
+                proto_stubs.SetDHWBoostRequest(ski=self.ski, active=active),
+                timeout=RPC_TIMEOUT,
+            )
+            self._dhw_sysfn_supported = True
+        except grpc.aio.AioRpcError as err:
+            if _is_unimplemented(err):
+                self._dhw_sysfn_supported = False
+                _LOGGER.info("DHW boost unsupported for SKI %s: %s", self.ski, err.details())
+                return
+            if err.code() in (
+                grpc.StatusCode.INVALID_ARGUMENT,
+                grpc.StatusCode.FAILED_PRECONDITION,
+                grpc.StatusCode.NOT_FOUND,
+            ):
+                raise ServiceValidationError(f"Domestic hot water boost failed: {err.details()}") from err
+            raise
+
+    async def async_set_dhw_operation_mode(self, mode: str) -> None:
+        """Set the DHW operation mode by advertised mode type."""
+        channel = await self._ensure_channel()
+        from . import proto_stubs
+
+        stub = proto_stubs.dhw_service_stub(channel)
+        try:
+            await stub.SetDHWOperationMode(
+                proto_stubs.SetDHWOperationModeRequest(ski=self.ski, mode=mode),
+                timeout=RPC_TIMEOUT,
+            )
+            self._dhw_sysfn_supported = True
+        except grpc.aio.AioRpcError as err:
+            if _is_unimplemented(err):
+                self._dhw_sysfn_supported = False
+                _LOGGER.info(
+                    "DHW operation mode unsupported for SKI %s: %s",
+                    self.ski,
+                    err.details(),
+                )
+                return
+            if err.code() in (
+                grpc.StatusCode.INVALID_ARGUMENT,
+                grpc.StatusCode.FAILED_PRECONDITION,
+                grpc.StatusCode.NOT_FOUND,
+            ):
+                raise ServiceValidationError(f"Domestic hot water operation mode failed: {err.details()}") from err
+            raise
+
     async def async_start_heartbeat(self) -> None:
         """Start EEBUS heartbeat via gRPC."""
         channel = await self._ensure_channel()
@@ -1224,6 +1324,7 @@ class EebusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             ("lpc_events", self._run_lpc_event_stream),
             ("measurements", self._run_measurement_stream),
             ("dhw_events", self._run_dhw_event_stream),
+            ("dhw_sysfn_events", self._run_dhw_sysfn_event_stream),
         ):
             self._stream_tasks.append(
                 self.hass.async_create_background_task(
@@ -1301,6 +1402,18 @@ class EebusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 self._handle_dhw_event(event)
 
         await self._run_stream("DHW", consume)
+
+    async def _run_dhw_sysfn_event_stream(self) -> None:
+        from . import proto_stubs
+
+        async def consume(channel: grpc.aio.Channel) -> None:
+            stub = proto_stubs.dhw_service_stub(channel)
+            async for event in stub.SubscribeDHWSystemFunctionEvents(
+                proto_stubs.DeviceRequest(ski=self.ski)
+            ):
+                self._handle_dhw_sysfn_event(event)
+
+        await self._run_stream("DHW system function", consume)
 
     def _event_matches(self, event_ski: str) -> bool:
         """Return True when an event applies to the configured device."""
@@ -1410,6 +1523,29 @@ class EebusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 }
             )
         elif event.event_type == proto_stubs.DHWEventType.DHW_EVENT_SUPPORT_UPDATED:
+            self.hass.async_create_task(self.async_request_refresh())
+
+    def _handle_dhw_sysfn_event(self, event: Any) -> None:
+        from . import proto_stubs
+
+        if not self._event_matches(event.ski):
+            return
+        if (
+            event.event_type
+            == proto_stubs.DHWSystemFunctionEventType.DHW_SYSTEM_FUNCTION_EVENT_STATE_UPDATED
+            and event.HasField("state")
+        ):
+            self._dhw_sysfn_supported = True
+            self._push_data(
+                {
+                    "dhw_system_function": _dhw_system_function_to_dict(event.state),
+                    "dhw_sysfn_supported": True,
+                }
+            )
+        elif (
+            event.event_type
+            == proto_stubs.DHWSystemFunctionEventType.DHW_SYSTEM_FUNCTION_EVENT_SUPPORT_UPDATED
+        ):
             self.hass.async_create_task(self.async_request_refresh())
 
     async def async_shutdown(self) -> None:

--- a/custom_components/eebus/generated/eebus/v1/dhw_service_pb2.py
+++ b/custom_components/eebus/generated/eebus/v1/dhw_service_pb2.py
@@ -25,7 +25,7 @@ _sym_db = _symbol_database.Default()
 from . import common_pb2 as eebus_dot_v1_dot_common__pb2
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x1a\x65\x65\x62us/v1/dhw_service.proto\x12\x08\x65\x65\x62us.v1\x1a\x15\x65\x65\x62us/v1/common.proto\"v\n\x0b\x44HWSetpoint\x12\x15\n\rvalue_celsius\x18\x01 \x01(\x01\x12\x13\n\x0bmin_celsius\x18\x02 \x01(\x01\x12\x13\n\x0bmax_celsius\x18\x03 \x01(\x01\x12\x14\n\x0cstep_celsius\x18\x04 \x01(\x01\x12\x10\n\x08writable\x18\x05 \x01(\x08\";\n\x15SetDHWSetpointRequest\x12\x0b\n\x03ski\x18\x01 \x01(\t\x12\x15\n\rvalue_celsius\x18\x02 \x01(\x01\"l\n\x08\x44HWEvent\x12\x0b\n\x03ski\x18\x01 \x01(\t\x12*\n\nevent_type\x18\x02 \x01(\x0e\x32\x16.eebus.v1.DHWEventType\x12\'\n\x08setpoint\x18\x03 \x01(\x0b\x32\x15.eebus.v1.DHWSetpoint*h\n\x0c\x44HWEventType\x12\x19\n\x15\x44HW_EVENT_UNSPECIFIED\x10\x00\x12\x1d\n\x19\x44HW_EVENT_SUPPORT_UPDATED\x10\x01\x12\x1e\n\x1a\x44HW_EVENT_SETPOINT_UPDATED\x10\x02\x32\xd7\x01\n\nDHWService\x12@\n\x0eGetDHWSetpoint\x12\x17.eebus.v1.DeviceRequest\x1a\x15.eebus.v1.DHWSetpoint\x12\x42\n\x0eSetDHWSetpoint\x12\x1f.eebus.v1.SetDHWSetpointRequest\x1a\x0f.eebus.v1.Empty\x12\x43\n\x12SubscribeDHWEvents\x12\x17.eebus.v1.DeviceRequest\x1a\x12.eebus.v1.DHWEvent0\x01\x42=Z;github.com/volschin/eebus-bridge/gen/proto/eebus/v1;eebusv1b\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x1a\x65\x65\x62us/v1/dhw_service.proto\x12\x08\x65\x65\x62us.v1\x1a\x15\x65\x65\x62us/v1/common.proto\"v\n\x0b\x44HWSetpoint\x12\x15\n\rvalue_celsius\x18\x01 \x01(\x01\x12\x13\n\x0bmin_celsius\x18\x02 \x01(\x01\x12\x13\n\x0bmax_celsius\x18\x03 \x01(\x01\x12\x14\n\x0cstep_celsius\x18\x04 \x01(\x01\x12\x10\n\x08writable\x18\x05 \x01(\x08\";\n\x15SetDHWSetpointRequest\x12\x0b\n\x03ski\x18\x01 \x01(\t\x12\x15\n\rvalue_celsius\x18\x02 \x01(\x01\"l\n\x08\x44HWEvent\x12\x0b\n\x03ski\x18\x01 \x01(\t\x12*\n\nevent_type\x18\x02 \x01(\x0e\x32\x16.eebus.v1.DHWEventType\x12\'\n\x08setpoint\x18\x03 \x01(\x0b\x32\x15.eebus.v1.DHWSetpoint\"\xa8\x01\n\x16\x44HWSystemFunctionState\x12.\n\x0c\x62oost_status\x18\x01 \x01(\x0e\x32\x18.eebus.v1.DHWBoostStatus\x12\x16\n\x0e\x62oost_writable\x18\x02 \x01(\x08\x12\x16\n\x0eoperation_mode\x18\x03 \x01(\t\x12\x17\n\x0f\x61vailable_modes\x18\x04 \x03(\t\x12\x15\n\rmode_writable\x18\x05 \x01(\x08\"1\n\x12SetDHWBoostRequest\x12\x0b\n\x03ski\x18\x01 \x01(\t\x12\x0e\n\x06\x61\x63tive\x18\x02 \x01(\x08\"7\n\x1aSetDHWOperationModeRequest\x12\x0b\n\x03ski\x18\x01 \x01(\t\x12\x0c\n\x04mode\x18\x02 \x01(\t\"\x90\x01\n\x16\x44HWSystemFunctionEvent\x12\x0b\n\x03ski\x18\x01 \x01(\t\x12\x38\n\nevent_type\x18\x02 \x01(\x0e\x32$.eebus.v1.DHWSystemFunctionEventType\x12/\n\x05state\x18\x03 \x01(\x0b\x32 .eebus.v1.DHWSystemFunctionState*h\n\x0c\x44HWEventType\x12\x19\n\x15\x44HW_EVENT_UNSPECIFIED\x10\x00\x12\x1d\n\x19\x44HW_EVENT_SUPPORT_UPDATED\x10\x01\x12\x1e\n\x1a\x44HW_EVENT_SETPOINT_UPDATED\x10\x02*\xab\x01\n\x0e\x44HWBoostStatus\x12 \n\x1c\x44HW_BOOST_STATUS_UNSPECIFIED\x10\x00\x12\x1d\n\x19\x44HW_BOOST_STATUS_INACTIVE\x10\x01\x12\x1b\n\x17\x44HW_BOOST_STATUS_ACTIVE\x10\x02\x12\x1c\n\x18\x44HW_BOOST_STATUS_RUNNING\x10\x03\x12\x1d\n\x19\x44HW_BOOST_STATUS_FINISHED\x10\x04*\xa3\x01\n\x1a\x44HWSystemFunctionEventType\x12)\n%DHW_SYSTEM_FUNCTION_EVENT_UNSPECIFIED\x10\x00\x12-\n)DHW_SYSTEM_FUNCTION_EVENT_SUPPORT_UPDATED\x10\x01\x12+\n\'DHW_SYSTEM_FUNCTION_EVENT_STATE_UPDATED\x10\x02\x32\x97\x04\n\nDHWService\x12@\n\x0eGetDHWSetpoint\x12\x17.eebus.v1.DeviceRequest\x1a\x15.eebus.v1.DHWSetpoint\x12\x42\n\x0eSetDHWSetpoint\x12\x1f.eebus.v1.SetDHWSetpointRequest\x1a\x0f.eebus.v1.Empty\x12\x43\n\x12SubscribeDHWEvents\x12\x17.eebus.v1.DeviceRequest\x1a\x12.eebus.v1.DHWEvent0\x01\x12Q\n\x14GetDHWSystemFunction\x12\x17.eebus.v1.DeviceRequest\x1a .eebus.v1.DHWSystemFunctionState\x12<\n\x0bSetDHWBoost\x12\x1c.eebus.v1.SetDHWBoostRequest\x1a\x0f.eebus.v1.Empty\x12L\n\x13SetDHWOperationMode\x12$.eebus.v1.SetDHWOperationModeRequest\x1a\x0f.eebus.v1.Empty\x12_\n SubscribeDHWSystemFunctionEvents\x12\x17.eebus.v1.DeviceRequest\x1a .eebus.v1.DHWSystemFunctionEvent0\x01\x42=Z;github.com/volschin/eebus-bridge/gen/proto/eebus/v1;eebusv1b\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -33,14 +33,26 @@ _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'eebus.v1.dhw_service_pb2', 
 if not _descriptor._USE_C_DESCRIPTORS:
   _globals['DESCRIPTOR']._loaded_options = None
   _globals['DESCRIPTOR']._serialized_options = b'Z;github.com/volschin/eebus-bridge/gen/proto/eebus/v1;eebusv1'
-  _globals['_DHWEVENTTYPE']._serialized_start=354
-  _globals['_DHWEVENTTYPE']._serialized_end=458
+  _globals['_DHWEVENTTYPE']._serialized_start=780
+  _globals['_DHWEVENTTYPE']._serialized_end=884
+  _globals['_DHWBOOSTSTATUS']._serialized_start=887
+  _globals['_DHWBOOSTSTATUS']._serialized_end=1058
+  _globals['_DHWSYSTEMFUNCTIONEVENTTYPE']._serialized_start=1061
+  _globals['_DHWSYSTEMFUNCTIONEVENTTYPE']._serialized_end=1224
   _globals['_DHWSETPOINT']._serialized_start=63
   _globals['_DHWSETPOINT']._serialized_end=181
   _globals['_SETDHWSETPOINTREQUEST']._serialized_start=183
   _globals['_SETDHWSETPOINTREQUEST']._serialized_end=242
   _globals['_DHWEVENT']._serialized_start=244
   _globals['_DHWEVENT']._serialized_end=352
-  _globals['_DHWSERVICE']._serialized_start=461
-  _globals['_DHWSERVICE']._serialized_end=676
+  _globals['_DHWSYSTEMFUNCTIONSTATE']._serialized_start=355
+  _globals['_DHWSYSTEMFUNCTIONSTATE']._serialized_end=523
+  _globals['_SETDHWBOOSTREQUEST']._serialized_start=525
+  _globals['_SETDHWBOOSTREQUEST']._serialized_end=574
+  _globals['_SETDHWOPERATIONMODEREQUEST']._serialized_start=576
+  _globals['_SETDHWOPERATIONMODEREQUEST']._serialized_end=631
+  _globals['_DHWSYSTEMFUNCTIONEVENT']._serialized_start=634
+  _globals['_DHWSYSTEMFUNCTIONEVENT']._serialized_end=778
+  _globals['_DHWSERVICE']._serialized_start=1227
+  _globals['_DHWSERVICE']._serialized_end=1762
 # @@protoc_insertion_point(module_scope)

--- a/custom_components/eebus/generated/eebus/v1/dhw_service_pb2.pyi
+++ b/custom_components/eebus/generated/eebus/v1/dhw_service_pb2.pyi
@@ -1,8 +1,9 @@
 from . import common_pb2 as _common_pb2
+from google.protobuf.internal import containers as _containers
 from google.protobuf.internal import enum_type_wrapper as _enum_type_wrapper
 from google.protobuf import descriptor as _descriptor
 from google.protobuf import message as _message
-from collections.abc import Mapping as _Mapping
+from collections.abc import Iterable as _Iterable, Mapping as _Mapping
 from typing import ClassVar as _ClassVar, Optional as _Optional, Union as _Union
 
 DESCRIPTOR: _descriptor.FileDescriptor
@@ -12,9 +13,31 @@ class DHWEventType(int, metaclass=_enum_type_wrapper.EnumTypeWrapper):
     DHW_EVENT_UNSPECIFIED: _ClassVar[DHWEventType]
     DHW_EVENT_SUPPORT_UPDATED: _ClassVar[DHWEventType]
     DHW_EVENT_SETPOINT_UPDATED: _ClassVar[DHWEventType]
+
+class DHWBoostStatus(int, metaclass=_enum_type_wrapper.EnumTypeWrapper):
+    __slots__ = ()
+    DHW_BOOST_STATUS_UNSPECIFIED: _ClassVar[DHWBoostStatus]
+    DHW_BOOST_STATUS_INACTIVE: _ClassVar[DHWBoostStatus]
+    DHW_BOOST_STATUS_ACTIVE: _ClassVar[DHWBoostStatus]
+    DHW_BOOST_STATUS_RUNNING: _ClassVar[DHWBoostStatus]
+    DHW_BOOST_STATUS_FINISHED: _ClassVar[DHWBoostStatus]
+
+class DHWSystemFunctionEventType(int, metaclass=_enum_type_wrapper.EnumTypeWrapper):
+    __slots__ = ()
+    DHW_SYSTEM_FUNCTION_EVENT_UNSPECIFIED: _ClassVar[DHWSystemFunctionEventType]
+    DHW_SYSTEM_FUNCTION_EVENT_SUPPORT_UPDATED: _ClassVar[DHWSystemFunctionEventType]
+    DHW_SYSTEM_FUNCTION_EVENT_STATE_UPDATED: _ClassVar[DHWSystemFunctionEventType]
 DHW_EVENT_UNSPECIFIED: DHWEventType
 DHW_EVENT_SUPPORT_UPDATED: DHWEventType
 DHW_EVENT_SETPOINT_UPDATED: DHWEventType
+DHW_BOOST_STATUS_UNSPECIFIED: DHWBoostStatus
+DHW_BOOST_STATUS_INACTIVE: DHWBoostStatus
+DHW_BOOST_STATUS_ACTIVE: DHWBoostStatus
+DHW_BOOST_STATUS_RUNNING: DHWBoostStatus
+DHW_BOOST_STATUS_FINISHED: DHWBoostStatus
+DHW_SYSTEM_FUNCTION_EVENT_UNSPECIFIED: DHWSystemFunctionEventType
+DHW_SYSTEM_FUNCTION_EVENT_SUPPORT_UPDATED: DHWSystemFunctionEventType
+DHW_SYSTEM_FUNCTION_EVENT_STATE_UPDATED: DHWSystemFunctionEventType
 
 class DHWSetpoint(_message.Message):
     __slots__ = ("value_celsius", "min_celsius", "max_celsius", "step_celsius", "writable")
@@ -47,3 +70,43 @@ class DHWEvent(_message.Message):
     event_type: DHWEventType
     setpoint: DHWSetpoint
     def __init__(self, ski: _Optional[str] = ..., event_type: _Optional[_Union[DHWEventType, str]] = ..., setpoint: _Optional[_Union[DHWSetpoint, _Mapping]] = ...) -> None: ...
+
+class DHWSystemFunctionState(_message.Message):
+    __slots__ = ("boost_status", "boost_writable", "operation_mode", "available_modes", "mode_writable")
+    BOOST_STATUS_FIELD_NUMBER: _ClassVar[int]
+    BOOST_WRITABLE_FIELD_NUMBER: _ClassVar[int]
+    OPERATION_MODE_FIELD_NUMBER: _ClassVar[int]
+    AVAILABLE_MODES_FIELD_NUMBER: _ClassVar[int]
+    MODE_WRITABLE_FIELD_NUMBER: _ClassVar[int]
+    boost_status: DHWBoostStatus
+    boost_writable: bool
+    operation_mode: str
+    available_modes: _containers.RepeatedScalarFieldContainer[str]
+    mode_writable: bool
+    def __init__(self, boost_status: _Optional[_Union[DHWBoostStatus, str]] = ..., boost_writable: bool = ..., operation_mode: _Optional[str] = ..., available_modes: _Optional[_Iterable[str]] = ..., mode_writable: bool = ...) -> None: ...
+
+class SetDHWBoostRequest(_message.Message):
+    __slots__ = ("ski", "active")
+    SKI_FIELD_NUMBER: _ClassVar[int]
+    ACTIVE_FIELD_NUMBER: _ClassVar[int]
+    ski: str
+    active: bool
+    def __init__(self, ski: _Optional[str] = ..., active: bool = ...) -> None: ...
+
+class SetDHWOperationModeRequest(_message.Message):
+    __slots__ = ("ski", "mode")
+    SKI_FIELD_NUMBER: _ClassVar[int]
+    MODE_FIELD_NUMBER: _ClassVar[int]
+    ski: str
+    mode: str
+    def __init__(self, ski: _Optional[str] = ..., mode: _Optional[str] = ...) -> None: ...
+
+class DHWSystemFunctionEvent(_message.Message):
+    __slots__ = ("ski", "event_type", "state")
+    SKI_FIELD_NUMBER: _ClassVar[int]
+    EVENT_TYPE_FIELD_NUMBER: _ClassVar[int]
+    STATE_FIELD_NUMBER: _ClassVar[int]
+    ski: str
+    event_type: DHWSystemFunctionEventType
+    state: DHWSystemFunctionState
+    def __init__(self, ski: _Optional[str] = ..., event_type: _Optional[_Union[DHWSystemFunctionEventType, str]] = ..., state: _Optional[_Union[DHWSystemFunctionState, _Mapping]] = ...) -> None: ...

--- a/custom_components/eebus/generated/eebus/v1/dhw_service_pb2_grpc.py
+++ b/custom_components/eebus/generated/eebus/v1/dhw_service_pb2_grpc.py
@@ -53,6 +53,26 @@ class DHWServiceStub(object):
                 request_serializer=eebus_dot_v1_dot_common__pb2.DeviceRequest.SerializeToString,
                 response_deserializer=eebus_dot_v1_dot_dhw__service__pb2.DHWEvent.FromString,
                 _registered_method=True)
+        self.GetDHWSystemFunction = channel.unary_unary(
+                '/eebus.v1.DHWService/GetDHWSystemFunction',
+                request_serializer=eebus_dot_v1_dot_common__pb2.DeviceRequest.SerializeToString,
+                response_deserializer=eebus_dot_v1_dot_dhw__service__pb2.DHWSystemFunctionState.FromString,
+                _registered_method=True)
+        self.SetDHWBoost = channel.unary_unary(
+                '/eebus.v1.DHWService/SetDHWBoost',
+                request_serializer=eebus_dot_v1_dot_dhw__service__pb2.SetDHWBoostRequest.SerializeToString,
+                response_deserializer=eebus_dot_v1_dot_common__pb2.Empty.FromString,
+                _registered_method=True)
+        self.SetDHWOperationMode = channel.unary_unary(
+                '/eebus.v1.DHWService/SetDHWOperationMode',
+                request_serializer=eebus_dot_v1_dot_dhw__service__pb2.SetDHWOperationModeRequest.SerializeToString,
+                response_deserializer=eebus_dot_v1_dot_common__pb2.Empty.FromString,
+                _registered_method=True)
+        self.SubscribeDHWSystemFunctionEvents = channel.unary_stream(
+                '/eebus.v1.DHWService/SubscribeDHWSystemFunctionEvents',
+                request_serializer=eebus_dot_v1_dot_common__pb2.DeviceRequest.SerializeToString,
+                response_deserializer=eebus_dot_v1_dot_dhw__service__pb2.DHWSystemFunctionEvent.FromString,
+                _registered_method=True)
 
 
 class DHWServiceServicer(object):
@@ -79,6 +99,30 @@ class DHWServiceServicer(object):
         context.set_details('Method not implemented!')
         raise NotImplementedError('Method not implemented!')
 
+    def GetDHWSystemFunction(self, request, context):
+        """Missing associated documentation comment in .proto file."""
+        context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+        context.set_details('Method not implemented!')
+        raise NotImplementedError('Method not implemented!')
+
+    def SetDHWBoost(self, request, context):
+        """Missing associated documentation comment in .proto file."""
+        context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+        context.set_details('Method not implemented!')
+        raise NotImplementedError('Method not implemented!')
+
+    def SetDHWOperationMode(self, request, context):
+        """Missing associated documentation comment in .proto file."""
+        context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+        context.set_details('Method not implemented!')
+        raise NotImplementedError('Method not implemented!')
+
+    def SubscribeDHWSystemFunctionEvents(self, request, context):
+        """Missing associated documentation comment in .proto file."""
+        context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+        context.set_details('Method not implemented!')
+        raise NotImplementedError('Method not implemented!')
+
 
 def add_DHWServiceServicer_to_server(servicer, server):
     rpc_method_handlers = {
@@ -96,6 +140,26 @@ def add_DHWServiceServicer_to_server(servicer, server):
                     servicer.SubscribeDHWEvents,
                     request_deserializer=eebus_dot_v1_dot_common__pb2.DeviceRequest.FromString,
                     response_serializer=eebus_dot_v1_dot_dhw__service__pb2.DHWEvent.SerializeToString,
+            ),
+            'GetDHWSystemFunction': grpc.unary_unary_rpc_method_handler(
+                    servicer.GetDHWSystemFunction,
+                    request_deserializer=eebus_dot_v1_dot_common__pb2.DeviceRequest.FromString,
+                    response_serializer=eebus_dot_v1_dot_dhw__service__pb2.DHWSystemFunctionState.SerializeToString,
+            ),
+            'SetDHWBoost': grpc.unary_unary_rpc_method_handler(
+                    servicer.SetDHWBoost,
+                    request_deserializer=eebus_dot_v1_dot_dhw__service__pb2.SetDHWBoostRequest.FromString,
+                    response_serializer=eebus_dot_v1_dot_common__pb2.Empty.SerializeToString,
+            ),
+            'SetDHWOperationMode': grpc.unary_unary_rpc_method_handler(
+                    servicer.SetDHWOperationMode,
+                    request_deserializer=eebus_dot_v1_dot_dhw__service__pb2.SetDHWOperationModeRequest.FromString,
+                    response_serializer=eebus_dot_v1_dot_common__pb2.Empty.SerializeToString,
+            ),
+            'SubscribeDHWSystemFunctionEvents': grpc.unary_stream_rpc_method_handler(
+                    servicer.SubscribeDHWSystemFunctionEvents,
+                    request_deserializer=eebus_dot_v1_dot_common__pb2.DeviceRequest.FromString,
+                    response_serializer=eebus_dot_v1_dot_dhw__service__pb2.DHWSystemFunctionEvent.SerializeToString,
             ),
     }
     generic_handler = grpc.method_handlers_generic_handler(
@@ -182,6 +246,114 @@ class DHWService(object):
             '/eebus.v1.DHWService/SubscribeDHWEvents',
             eebus_dot_v1_dot_common__pb2.DeviceRequest.SerializeToString,
             eebus_dot_v1_dot_dhw__service__pb2.DHWEvent.FromString,
+            options,
+            channel_credentials,
+            insecure,
+            call_credentials,
+            compression,
+            wait_for_ready,
+            timeout,
+            metadata,
+            _registered_method=True)
+
+    @staticmethod
+    def GetDHWSystemFunction(request,
+            target,
+            options=(),
+            channel_credentials=None,
+            call_credentials=None,
+            insecure=False,
+            compression=None,
+            wait_for_ready=None,
+            timeout=None,
+            metadata=None):
+        return grpc.experimental.unary_unary(
+            request,
+            target,
+            '/eebus.v1.DHWService/GetDHWSystemFunction',
+            eebus_dot_v1_dot_common__pb2.DeviceRequest.SerializeToString,
+            eebus_dot_v1_dot_dhw__service__pb2.DHWSystemFunctionState.FromString,
+            options,
+            channel_credentials,
+            insecure,
+            call_credentials,
+            compression,
+            wait_for_ready,
+            timeout,
+            metadata,
+            _registered_method=True)
+
+    @staticmethod
+    def SetDHWBoost(request,
+            target,
+            options=(),
+            channel_credentials=None,
+            call_credentials=None,
+            insecure=False,
+            compression=None,
+            wait_for_ready=None,
+            timeout=None,
+            metadata=None):
+        return grpc.experimental.unary_unary(
+            request,
+            target,
+            '/eebus.v1.DHWService/SetDHWBoost',
+            eebus_dot_v1_dot_dhw__service__pb2.SetDHWBoostRequest.SerializeToString,
+            eebus_dot_v1_dot_common__pb2.Empty.FromString,
+            options,
+            channel_credentials,
+            insecure,
+            call_credentials,
+            compression,
+            wait_for_ready,
+            timeout,
+            metadata,
+            _registered_method=True)
+
+    @staticmethod
+    def SetDHWOperationMode(request,
+            target,
+            options=(),
+            channel_credentials=None,
+            call_credentials=None,
+            insecure=False,
+            compression=None,
+            wait_for_ready=None,
+            timeout=None,
+            metadata=None):
+        return grpc.experimental.unary_unary(
+            request,
+            target,
+            '/eebus.v1.DHWService/SetDHWOperationMode',
+            eebus_dot_v1_dot_dhw__service__pb2.SetDHWOperationModeRequest.SerializeToString,
+            eebus_dot_v1_dot_common__pb2.Empty.FromString,
+            options,
+            channel_credentials,
+            insecure,
+            call_credentials,
+            compression,
+            wait_for_ready,
+            timeout,
+            metadata,
+            _registered_method=True)
+
+    @staticmethod
+    def SubscribeDHWSystemFunctionEvents(request,
+            target,
+            options=(),
+            channel_credentials=None,
+            call_credentials=None,
+            insecure=False,
+            compression=None,
+            wait_for_ready=None,
+            timeout=None,
+            metadata=None):
+        return grpc.experimental.unary_stream(
+            request,
+            target,
+            '/eebus.v1.DHWService/SubscribeDHWSystemFunctionEvents',
+            eebus_dot_v1_dot_common__pb2.DeviceRequest.SerializeToString,
+            eebus_dot_v1_dot_dhw__service__pb2.DHWSystemFunctionEvent.FromString,
             options,
             channel_credentials,
             insecure,

--- a/custom_components/eebus/icons.json
+++ b/custom_components/eebus/icons.json
@@ -25,7 +25,11 @@
     },
     "switch": {
       "lpc_active": { "default": "mdi:power-plug" },
-      "heartbeat": { "default": "mdi:heart-pulse" }
+      "heartbeat": { "default": "mdi:heart-pulse" },
+      "dhw_boost": { "default": "mdi:water-boiler" }
+    },
+    "select": {
+      "dhw_operation_mode": { "default": "mdi:water-boiler-auto" }
     },
     "binary_sensor": {
       "connected": { "default": "mdi:lan-connect" },

--- a/custom_components/eebus/proto_stubs.py
+++ b/custom_components/eebus/proto_stubs.py
@@ -23,7 +23,13 @@ from .generated.eebus.v1.device_service_pb2 import (  # noqa: F401
 )
 from .generated.eebus.v1.device_service_pb2_grpc import DeviceServiceStub  # noqa: F401
 from .generated.eebus.v1.dhw_service_pb2 import (  # noqa: F401
+    DHWBoostStatus,
     DHWEventType,
+    DHWSystemFunctionEvent,
+    DHWSystemFunctionEventType,
+    DHWSystemFunctionState,
+    SetDHWBoostRequest,
+    SetDHWOperationModeRequest,
     SetDHWSetpointRequest,
 )
 from .generated.eebus.v1.dhw_service_pb2_grpc import DHWServiceStub  # noqa: F401
@@ -97,8 +103,12 @@ __all__ = [
     "DeviceEventType",
     "DeviceRequest",
     "DeviceServiceStub",
+    "DHWBoostStatus",
     "DHWEventType",
     "DHWServiceStub",
+    "DHWSystemFunctionEvent",
+    "DHWSystemFunctionEventType",
+    "DHWSystemFunctionState",
     "Empty",
     "GridData",
     "GridServiceStub",
@@ -114,6 +124,8 @@ __all__ = [
     "PVData",
     "PowerMeasurement",
     "RegisterSKIRequest",
+    "SetDHWBoostRequest",
+    "SetDHWOperationModeRequest",
     "SetDHWSetpointRequest",
     "VisualizationServiceStub",
     "WriteFailsafeLimitRequest",

--- a/custom_components/eebus/quality_scale.yaml
+++ b/custom_components/eebus/quality_scale.yaml
@@ -49,7 +49,7 @@ rules:
   docs-supported-devices: done
   docs-supported-functions:
     status: done
-    comment: README lists the DHW target number and its device-provided constraints.
+    comment: README lists DHW target, boost, operation mode, and their device-provided constraints/options.
   docs-troubleshooting: done
   docs-use-cases: done
   dynamic-devices:

--- a/custom_components/eebus/select.py
+++ b/custom_components/eebus/select.py
@@ -36,6 +36,7 @@ async def async_setup_entry(
     # client is active and a compatible heat pump was found.
     if coordinator.data and coordinator.data.get("ohpcf_supported"):
         entities.append(EebusCompressorFlexibilitySelect(coordinator))
+    entities.append(EebusDHWOperationModeSelect(coordinator))
     async_add_entities(entities)
 
 
@@ -113,4 +114,58 @@ class EebusCompressorFlexibilitySelect(EebusEntity, SelectEntity):
         else:
             action = proto_stubs.OHPCFAction.OHPCF_ACTION_ABORT
         await self.coordinator.async_control_compressor(action)
+        await self.coordinator.async_request_refresh()
+
+
+class EebusDHWOperationModeSelect(EebusEntity, SelectEntity):
+    """Select for domestic-hot-water operation mode."""
+
+    _attr_translation_key = "dhw_operation_mode"
+    _attr_entity_category = EntityCategory.CONFIG
+
+    def __init__(self, coordinator: EebusCoordinator) -> None:
+        """Initialize."""
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{coordinator.ski}_dhw_operation_mode"
+
+    def _state(self) -> dict[str, Any] | None:
+        if self.coordinator.data is None:
+            return None
+        return self.coordinator.data.get("dhw_system_function")
+
+    @property
+    def available(self) -> bool:
+        """Available only for writable DHW operation modes."""
+        if not super().available:
+            return False
+        data = self.coordinator.data or {}
+        state = self._state()
+        return bool(
+            data.get("dhw_sysfn_supported") is not False
+            and state is not None
+            and state.get("mode_writable")
+            and state.get("available_modes")
+        )
+
+    @property
+    def options(self) -> list[str]:
+        """Return operation modes advertised by the device."""
+        state = self._state()
+        if state is None:
+            return []
+        modes = state.get("available_modes")
+        return list(modes) if isinstance(modes, list) else []
+
+    @property
+    def current_option(self) -> str | None:
+        """Return the current DHW operation mode."""
+        state = self._state()
+        if state is None:
+            return None
+        mode = state.get("operation_mode")
+        return mode if isinstance(mode, str) and mode else None
+
+    async def async_select_option(self, option: str) -> None:
+        """Set the DHW operation mode."""
+        await self.coordinator.async_set_dhw_operation_mode(option)
         await self.coordinator.async_request_refresh()

--- a/custom_components/eebus/strings.json
+++ b/custom_components/eebus/strings.json
@@ -112,6 +112,7 @@
       "dhw_setpoint": { "name": "Domestic Hot Water Target Temperature" }
     },
     "select": {
+      "dhw_operation_mode": { "name": "Domestic Hot Water Operation Mode" },
       "compressor_flexibility": {
         "name": "Compressor Flexibility",
         "state": {
@@ -123,7 +124,8 @@
     },
     "switch": {
       "lpc_active": { "name": "LPC Active" },
-      "heartbeat": { "name": "Heartbeat" }
+      "heartbeat": { "name": "Heartbeat" },
+      "dhw_boost": { "name": "Domestic Hot Water Boost" }
     },
     "binary_sensor": {
       "connected": { "name": "Connected" },

--- a/custom_components/eebus/switch.py
+++ b/custom_components/eebus/switch.py
@@ -26,6 +26,7 @@ async def async_setup_entry(
     entities: list[SwitchEntity] = [
         EebusLPCActiveSwitch(coordinator),
         EebusHeartbeatSwitch(coordinator),
+        EebusDHWBoostSwitch(coordinator),
     ]
     async_add_entities(entities)
 
@@ -100,4 +101,60 @@ class EebusHeartbeatSwitch(EebusEntity, SwitchEntity):
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Stop heartbeat."""
         await self.coordinator.async_stop_heartbeat()
+        await self.coordinator.async_request_refresh()
+
+
+class EebusDHWBoostSwitch(EebusEntity, SwitchEntity):
+    """Switch for domestic-hot-water one-time boost."""
+
+    _attr_translation_key = "dhw_boost"
+    _attr_entity_category = EntityCategory.CONFIG
+
+    def __init__(self, coordinator: EebusCoordinator) -> None:
+        """Initialize."""
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{coordinator.ski}_dhw_boost"
+
+    def _state(self) -> dict[str, Any] | None:
+        if self.coordinator.data is None:
+            return None
+        return self.coordinator.data.get("dhw_system_function")
+
+    @property
+    def available(self) -> bool:
+        """Available only for writable DHW boost state."""
+        if not super().available:
+            return False
+        data = self.coordinator.data or {}
+        state = self._state()
+        return bool(
+            data.get("dhw_sysfn_supported") is not False
+            and state is not None
+            and state.get("boost_writable")
+        )
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return True while boost is active or running."""
+        state = self._state()
+        if state is None:
+            return None
+        return state.get("boost_status") in ("active", "running")
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any] | None:
+        """Expose the raw boost status."""
+        state = self._state()
+        if state is None:
+            return None
+        return {"boost_status": state.get("boost_status")}
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Activate DHW boost."""
+        await self.coordinator.async_set_dhw_boost(True)
+        await self.coordinator.async_request_refresh()
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Cancel DHW boost."""
+        await self.coordinator.async_set_dhw_boost(False)
         await self.coordinator.async_request_refresh()

--- a/custom_components/eebus/tests/test_dhw.py
+++ b/custom_components/eebus/tests/test_dhw.py
@@ -2,7 +2,7 @@
 
 import asyncio
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import grpc
 from grpc.aio import AioRpcError, Metadata
@@ -11,6 +11,8 @@ from custom_components.eebus import proto_stubs
 from custom_components.eebus.coordinator import EebusCoordinator
 from custom_components.eebus.generated.eebus.v1 import dhw_service_pb2
 from custom_components.eebus.number import EebusDHWSetpointNumber
+from custom_components.eebus.select import EebusDHWOperationModeSelect
+from custom_components.eebus.switch import EebusDHWBoostSwitch
 
 
 def _coordinator(data=None):
@@ -18,6 +20,7 @@ def _coordinator(data=None):
     coordinator.ski = "test-ski"
     coordinator.data = data
     coordinator._dhw_supported = None
+    coordinator._dhw_sysfn_supported = None
     return coordinator
 
 
@@ -120,3 +123,123 @@ def test_dhw_event_pushes_setpoint():
 
     assert pushed["dhw_setpoint"]["value_celsius"] == 47
     assert pushed["dhw_supported"] is True
+
+
+def test_read_dhw_system_function_maps_state():
+    """The coordinator retains boost and device-advertised mode options."""
+    response = dhw_service_pb2.DHWSystemFunctionState(
+        boost_status=dhw_service_pb2.DHW_BOOST_STATUS_RUNNING,
+        boost_writable=True,
+        operation_mode="auto",
+        available_modes=["auto", "on", "off"],
+        mode_writable=True,
+    )
+    stub = SimpleNamespace(GetDHWSystemFunction=AsyncMock(return_value=response))
+    coordinator = _coordinator()
+
+    result = asyncio.run(
+        coordinator._async_read_dhw_system_function(
+            None, _fake_proto(stub), proto_stubs.DeviceRequest(ski=coordinator.ski)
+        )
+    )
+
+    assert result == {
+        "boost_status": "running",
+        "boost_writable": True,
+        "operation_mode": "auto",
+        "available_modes": ["auto", "on", "off"],
+        "mode_writable": True,
+    }
+    assert coordinator._dhw_sysfn_supported is True
+
+
+def test_read_dhw_system_function_not_found_marks_unsupported():
+    """A device without configurationOfDhwSystemFunction stays unavailable."""
+    error = AioRpcError(grpc.StatusCode.NOT_FOUND, Metadata(), Metadata(), details="no sysfn")
+    stub = SimpleNamespace(GetDHWSystemFunction=AsyncMock(side_effect=error))
+    coordinator = _coordinator()
+
+    result = asyncio.run(
+        coordinator._async_read_dhw_system_function(
+            None, _fake_proto(stub), proto_stubs.DeviceRequest(ski=coordinator.ski)
+        )
+    )
+
+    assert result is None
+    assert coordinator._dhw_sysfn_supported is False
+
+
+def test_dhw_system_function_writes_map_validation_errors():
+    """Device-side rejections become Home Assistant validation errors."""
+    error = AioRpcError(
+        grpc.StatusCode.FAILED_PRECONDITION, Metadata(), Metadata(), details="not writable"
+    )
+    stub = SimpleNamespace(SetDHWBoost=AsyncMock(side_effect=error))
+    coordinator = _coordinator()
+    coordinator._ensure_channel = AsyncMock(return_value=None)
+
+    with patch.object(proto_stubs, "dhw_service_stub", return_value=stub):
+        try:
+            asyncio.run(coordinator.async_set_dhw_boost(True))
+        except Exception as err:  # noqa: BLE001
+            assert err.__class__.__name__ == "ServiceValidationError"
+        else:
+            raise AssertionError("expected ServiceValidationError")
+
+
+def test_dhw_system_function_event_pushes_state():
+    """DHW system-function stream events update coordinator data."""
+    coordinator = _coordinator(data={"connected": True})
+    pushed = {}
+    coordinator.async_set_updated_data = pushed.update
+    event = dhw_service_pb2.DHWSystemFunctionEvent(
+        ski="test-ski",
+        event_type=dhw_service_pb2.DHW_SYSTEM_FUNCTION_EVENT_STATE_UPDATED,
+        state=dhw_service_pb2.DHWSystemFunctionState(
+            boost_status=dhw_service_pb2.DHW_BOOST_STATUS_ACTIVE,
+            boost_writable=True,
+            operation_mode="on",
+            available_modes=["auto", "on", "off"],
+            mode_writable=True,
+        ),
+    )
+
+    coordinator._handle_dhw_sysfn_event(event)
+
+    assert pushed["dhw_system_function"]["boost_status"] == "active"
+    assert pushed["dhw_system_function"]["operation_mode"] == "on"
+    assert pushed["dhw_sysfn_supported"] is True
+
+
+def test_dhw_boost_switch_and_operation_mode_select():
+    """The HA entities mirror coordinator state and call the DHW sysfn RPCs."""
+    coordinator = MagicMock()
+    coordinator.ski = "test-ski"
+    coordinator.data = {
+        "connected": True,
+        "dhw_sysfn_supported": True,
+        "dhw_system_function": {
+            "boost_status": "running",
+            "boost_writable": True,
+            "operation_mode": "auto",
+            "available_modes": ["auto", "on", "off"],
+            "mode_writable": True,
+        },
+    }
+    coordinator.async_set_dhw_boost = AsyncMock()
+    coordinator.async_set_dhw_operation_mode = AsyncMock()
+    coordinator.async_request_refresh = AsyncMock()
+
+    switch = EebusDHWBoostSwitch(coordinator)
+    assert switch.available is True
+    assert switch.is_on is True
+    assert switch.extra_state_attributes == {"boost_status": "running"}
+    asyncio.run(switch.async_turn_off())
+    coordinator.async_set_dhw_boost.assert_awaited_once_with(False)
+
+    select = EebusDHWOperationModeSelect(coordinator)
+    assert select.available is True
+    assert select.options == ["auto", "on", "off"]
+    assert select.current_option == "auto"
+    asyncio.run(select.async_select_option("off"))
+    coordinator.async_set_dhw_operation_mode.assert_awaited_once_with("off")

--- a/custom_components/eebus/translations/de.json
+++ b/custom_components/eebus/translations/de.json
@@ -112,6 +112,7 @@
       "dhw_setpoint": { "name": "Warmwasser-Solltemperatur" }
     },
     "select": {
+      "dhw_operation_mode": { "name": "Warmwasser Betriebsart" },
       "compressor_flexibility": {
         "name": "Verdichter-Flexibilität",
         "state": {
@@ -123,7 +124,8 @@
     },
     "switch": {
       "lpc_active": { "name": "LPC aktiv" },
-      "heartbeat": { "name": "Heartbeat" }
+      "heartbeat": { "name": "Heartbeat" },
+      "dhw_boost": { "name": "Warmwasser Einmalladung" }
     },
     "binary_sensor": {
       "connected": { "name": "Verbunden" },

--- a/custom_components/eebus/translations/en.json
+++ b/custom_components/eebus/translations/en.json
@@ -112,6 +112,7 @@
       "dhw_setpoint": { "name": "Domestic Hot Water Target Temperature" }
     },
     "select": {
+      "dhw_operation_mode": { "name": "Domestic Hot Water Operation Mode" },
       "compressor_flexibility": {
         "name": "Compressor Flexibility",
         "state": {
@@ -123,7 +124,8 @@
     },
     "switch": {
       "lpc_active": { "name": "LPC Active" },
-      "heartbeat": { "name": "Heartbeat" }
+      "heartbeat": { "name": "Heartbeat" },
+      "dhw_boost": { "name": "Domestic Hot Water Boost" }
     },
     "binary_sensor": {
       "connected": { "name": "Connected" },

--- a/eebus-bridge/cmd/eebus-bridge/main.go
+++ b/eebus-bridge/cmd/eebus-bridge/main.go
@@ -86,6 +86,7 @@ func main() {
 	lpcWrapper.Setup(localEntity)
 	monitoringWrapper.Setup(localEntity)
 	dhwTemperature := usecases.NewDHWTemperature(localEntity, bus, registry, cfg.Logging.DebugEvents)
+	dhwSystemFunction := usecases.NewDHWSystemFunction(localEntity, bus, registry, cfg.Logging.DebugEvents)
 	if err := bridgeSvc.Service().AddUseCase(lpcWrapper.UseCase()); err != nil {
 		log.Fatalf("adding LPC use case: %v", err)
 	}
@@ -95,7 +96,10 @@ func main() {
 	if err := bridgeSvc.Service().AddUseCase(dhwTemperature.UseCase()); err != nil {
 		log.Fatalf("adding DHW temperature use case: %v", err)
 	}
-	registeredUseCases := []string{"LPC", "Monitoring", "DHWTemperature"}
+	if err := bridgeSvc.Service().AddUseCase(dhwSystemFunction.UseCase()); err != nil {
+		log.Fatalf("adding DHW system function use case: %v", err)
+	}
+	registeredUseCases := []string{"LPC", "Monitoring", "DHWTemperature", "DHWSystemFunction"}
 
 	// SPIKE: experimental MGCP grid-connection-point provider. Off by default.
 	var mgcpProvider *usecases.MGCPProvider
@@ -230,7 +234,7 @@ func main() {
 	gridSvc := bridgegrpc.NewGridService(mgcpProvider)
 	visualizationSvc := bridgegrpc.NewVisualizationService(vapdProvider, vabdProvider)
 	ohpcfSvc := bridgegrpc.NewOHPCFService(ohpcfWrapper, bus, registry)
-	dhwSvc := bridgegrpc.NewDHWService(dhwTemperature, bus)
+	dhwSvc := bridgegrpc.NewDHWService(dhwTemperature, dhwSystemFunction, bus)
 
 	pb.RegisterDeviceServiceServer(grpcSrv.GRPCServer(), deviceSvc)
 	pb.RegisterLPCServiceServer(grpcSrv.GRPCServer(), lpcSvc)

--- a/eebus-bridge/gen/proto/eebus/v1/dhw_service.pb.go
+++ b/eebus-bridge/gen/proto/eebus/v1/dhw_service.pb.go
@@ -70,6 +70,110 @@ func (DHWEventType) EnumDescriptor() ([]byte, []int) {
 	return file_eebus_v1_dhw_service_proto_rawDescGZIP(), []int{0}
 }
 
+type DHWBoostStatus int32
+
+const (
+	DHWBoostStatus_DHW_BOOST_STATUS_UNSPECIFIED DHWBoostStatus = 0
+	DHWBoostStatus_DHW_BOOST_STATUS_INACTIVE    DHWBoostStatus = 1
+	DHWBoostStatus_DHW_BOOST_STATUS_ACTIVE      DHWBoostStatus = 2
+	DHWBoostStatus_DHW_BOOST_STATUS_RUNNING     DHWBoostStatus = 3
+	DHWBoostStatus_DHW_BOOST_STATUS_FINISHED    DHWBoostStatus = 4
+)
+
+// Enum value maps for DHWBoostStatus.
+var (
+	DHWBoostStatus_name = map[int32]string{
+		0: "DHW_BOOST_STATUS_UNSPECIFIED",
+		1: "DHW_BOOST_STATUS_INACTIVE",
+		2: "DHW_BOOST_STATUS_ACTIVE",
+		3: "DHW_BOOST_STATUS_RUNNING",
+		4: "DHW_BOOST_STATUS_FINISHED",
+	}
+	DHWBoostStatus_value = map[string]int32{
+		"DHW_BOOST_STATUS_UNSPECIFIED": 0,
+		"DHW_BOOST_STATUS_INACTIVE":    1,
+		"DHW_BOOST_STATUS_ACTIVE":      2,
+		"DHW_BOOST_STATUS_RUNNING":     3,
+		"DHW_BOOST_STATUS_FINISHED":    4,
+	}
+)
+
+func (x DHWBoostStatus) Enum() *DHWBoostStatus {
+	p := new(DHWBoostStatus)
+	*p = x
+	return p
+}
+
+func (x DHWBoostStatus) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (DHWBoostStatus) Descriptor() protoreflect.EnumDescriptor {
+	return file_eebus_v1_dhw_service_proto_enumTypes[1].Descriptor()
+}
+
+func (DHWBoostStatus) Type() protoreflect.EnumType {
+	return &file_eebus_v1_dhw_service_proto_enumTypes[1]
+}
+
+func (x DHWBoostStatus) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use DHWBoostStatus.Descriptor instead.
+func (DHWBoostStatus) EnumDescriptor() ([]byte, []int) {
+	return file_eebus_v1_dhw_service_proto_rawDescGZIP(), []int{1}
+}
+
+type DHWSystemFunctionEventType int32
+
+const (
+	DHWSystemFunctionEventType_DHW_SYSTEM_FUNCTION_EVENT_UNSPECIFIED     DHWSystemFunctionEventType = 0
+	DHWSystemFunctionEventType_DHW_SYSTEM_FUNCTION_EVENT_SUPPORT_UPDATED DHWSystemFunctionEventType = 1
+	DHWSystemFunctionEventType_DHW_SYSTEM_FUNCTION_EVENT_STATE_UPDATED   DHWSystemFunctionEventType = 2
+)
+
+// Enum value maps for DHWSystemFunctionEventType.
+var (
+	DHWSystemFunctionEventType_name = map[int32]string{
+		0: "DHW_SYSTEM_FUNCTION_EVENT_UNSPECIFIED",
+		1: "DHW_SYSTEM_FUNCTION_EVENT_SUPPORT_UPDATED",
+		2: "DHW_SYSTEM_FUNCTION_EVENT_STATE_UPDATED",
+	}
+	DHWSystemFunctionEventType_value = map[string]int32{
+		"DHW_SYSTEM_FUNCTION_EVENT_UNSPECIFIED":     0,
+		"DHW_SYSTEM_FUNCTION_EVENT_SUPPORT_UPDATED": 1,
+		"DHW_SYSTEM_FUNCTION_EVENT_STATE_UPDATED":   2,
+	}
+)
+
+func (x DHWSystemFunctionEventType) Enum() *DHWSystemFunctionEventType {
+	p := new(DHWSystemFunctionEventType)
+	*p = x
+	return p
+}
+
+func (x DHWSystemFunctionEventType) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (DHWSystemFunctionEventType) Descriptor() protoreflect.EnumDescriptor {
+	return file_eebus_v1_dhw_service_proto_enumTypes[2].Descriptor()
+}
+
+func (DHWSystemFunctionEventType) Type() protoreflect.EnumType {
+	return &file_eebus_v1_dhw_service_proto_enumTypes[2]
+}
+
+func (x DHWSystemFunctionEventType) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use DHWSystemFunctionEventType.Descriptor instead.
+func (DHWSystemFunctionEventType) EnumDescriptor() ([]byte, []int) {
+	return file_eebus_v1_dhw_service_proto_rawDescGZIP(), []int{2}
+}
+
 type DHWSetpoint struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	ValueCelsius  float64                `protobuf:"fixed64,1,opt,name=value_celsius,json=valueCelsius,proto3" json:"value_celsius,omitempty"`
@@ -258,6 +362,246 @@ func (x *DHWEvent) GetSetpoint() *DHWSetpoint {
 	return nil
 }
 
+type DHWSystemFunctionState struct {
+	state          protoimpl.MessageState `protogen:"open.v1"`
+	BoostStatus    DHWBoostStatus         `protobuf:"varint,1,opt,name=boost_status,json=boostStatus,proto3,enum=eebus.v1.DHWBoostStatus" json:"boost_status,omitempty"`
+	BoostWritable  bool                   `protobuf:"varint,2,opt,name=boost_writable,json=boostWritable,proto3" json:"boost_writable,omitempty"`
+	OperationMode  string                 `protobuf:"bytes,3,opt,name=operation_mode,json=operationMode,proto3" json:"operation_mode,omitempty"`
+	AvailableModes []string               `protobuf:"bytes,4,rep,name=available_modes,json=availableModes,proto3" json:"available_modes,omitempty"`
+	ModeWritable   bool                   `protobuf:"varint,5,opt,name=mode_writable,json=modeWritable,proto3" json:"mode_writable,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *DHWSystemFunctionState) Reset() {
+	*x = DHWSystemFunctionState{}
+	mi := &file_eebus_v1_dhw_service_proto_msgTypes[3]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DHWSystemFunctionState) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DHWSystemFunctionState) ProtoMessage() {}
+
+func (x *DHWSystemFunctionState) ProtoReflect() protoreflect.Message {
+	mi := &file_eebus_v1_dhw_service_proto_msgTypes[3]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DHWSystemFunctionState.ProtoReflect.Descriptor instead.
+func (*DHWSystemFunctionState) Descriptor() ([]byte, []int) {
+	return file_eebus_v1_dhw_service_proto_rawDescGZIP(), []int{3}
+}
+
+func (x *DHWSystemFunctionState) GetBoostStatus() DHWBoostStatus {
+	if x != nil {
+		return x.BoostStatus
+	}
+	return DHWBoostStatus_DHW_BOOST_STATUS_UNSPECIFIED
+}
+
+func (x *DHWSystemFunctionState) GetBoostWritable() bool {
+	if x != nil {
+		return x.BoostWritable
+	}
+	return false
+}
+
+func (x *DHWSystemFunctionState) GetOperationMode() string {
+	if x != nil {
+		return x.OperationMode
+	}
+	return ""
+}
+
+func (x *DHWSystemFunctionState) GetAvailableModes() []string {
+	if x != nil {
+		return x.AvailableModes
+	}
+	return nil
+}
+
+func (x *DHWSystemFunctionState) GetModeWritable() bool {
+	if x != nil {
+		return x.ModeWritable
+	}
+	return false
+}
+
+type SetDHWBoostRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Ski           string                 `protobuf:"bytes,1,opt,name=ski,proto3" json:"ski,omitempty"`
+	Active        bool                   `protobuf:"varint,2,opt,name=active,proto3" json:"active,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SetDHWBoostRequest) Reset() {
+	*x = SetDHWBoostRequest{}
+	mi := &file_eebus_v1_dhw_service_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SetDHWBoostRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SetDHWBoostRequest) ProtoMessage() {}
+
+func (x *SetDHWBoostRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_eebus_v1_dhw_service_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SetDHWBoostRequest.ProtoReflect.Descriptor instead.
+func (*SetDHWBoostRequest) Descriptor() ([]byte, []int) {
+	return file_eebus_v1_dhw_service_proto_rawDescGZIP(), []int{4}
+}
+
+func (x *SetDHWBoostRequest) GetSki() string {
+	if x != nil {
+		return x.Ski
+	}
+	return ""
+}
+
+func (x *SetDHWBoostRequest) GetActive() bool {
+	if x != nil {
+		return x.Active
+	}
+	return false
+}
+
+type SetDHWOperationModeRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Ski           string                 `protobuf:"bytes,1,opt,name=ski,proto3" json:"ski,omitempty"`
+	Mode          string                 `protobuf:"bytes,2,opt,name=mode,proto3" json:"mode,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SetDHWOperationModeRequest) Reset() {
+	*x = SetDHWOperationModeRequest{}
+	mi := &file_eebus_v1_dhw_service_proto_msgTypes[5]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SetDHWOperationModeRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SetDHWOperationModeRequest) ProtoMessage() {}
+
+func (x *SetDHWOperationModeRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_eebus_v1_dhw_service_proto_msgTypes[5]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SetDHWOperationModeRequest.ProtoReflect.Descriptor instead.
+func (*SetDHWOperationModeRequest) Descriptor() ([]byte, []int) {
+	return file_eebus_v1_dhw_service_proto_rawDescGZIP(), []int{5}
+}
+
+func (x *SetDHWOperationModeRequest) GetSki() string {
+	if x != nil {
+		return x.Ski
+	}
+	return ""
+}
+
+func (x *SetDHWOperationModeRequest) GetMode() string {
+	if x != nil {
+		return x.Mode
+	}
+	return ""
+}
+
+type DHWSystemFunctionEvent struct {
+	state         protoimpl.MessageState     `protogen:"open.v1"`
+	Ski           string                     `protobuf:"bytes,1,opt,name=ski,proto3" json:"ski,omitempty"`
+	EventType     DHWSystemFunctionEventType `protobuf:"varint,2,opt,name=event_type,json=eventType,proto3,enum=eebus.v1.DHWSystemFunctionEventType" json:"event_type,omitempty"`
+	State         *DHWSystemFunctionState    `protobuf:"bytes,3,opt,name=state,proto3" json:"state,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DHWSystemFunctionEvent) Reset() {
+	*x = DHWSystemFunctionEvent{}
+	mi := &file_eebus_v1_dhw_service_proto_msgTypes[6]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DHWSystemFunctionEvent) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DHWSystemFunctionEvent) ProtoMessage() {}
+
+func (x *DHWSystemFunctionEvent) ProtoReflect() protoreflect.Message {
+	mi := &file_eebus_v1_dhw_service_proto_msgTypes[6]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DHWSystemFunctionEvent.ProtoReflect.Descriptor instead.
+func (*DHWSystemFunctionEvent) Descriptor() ([]byte, []int) {
+	return file_eebus_v1_dhw_service_proto_rawDescGZIP(), []int{6}
+}
+
+func (x *DHWSystemFunctionEvent) GetSki() string {
+	if x != nil {
+		return x.Ski
+	}
+	return ""
+}
+
+func (x *DHWSystemFunctionEvent) GetEventType() DHWSystemFunctionEventType {
+	if x != nil {
+		return x.EventType
+	}
+	return DHWSystemFunctionEventType_DHW_SYSTEM_FUNCTION_EVENT_UNSPECIFIED
+}
+
+func (x *DHWSystemFunctionEvent) GetState() *DHWSystemFunctionState {
+	if x != nil {
+		return x.State
+	}
+	return nil
+}
+
 var File_eebus_v1_dhw_service_proto protoreflect.FileDescriptor
 
 const file_eebus_v1_dhw_service_proto_rawDesc = "" +
@@ -278,16 +622,47 @@ const file_eebus_v1_dhw_service_proto_rawDesc = "" +
 	"\x03ski\x18\x01 \x01(\tR\x03ski\x125\n" +
 	"\n" +
 	"event_type\x18\x02 \x01(\x0e2\x16.eebus.v1.DHWEventTypeR\teventType\x121\n" +
-	"\bsetpoint\x18\x03 \x01(\v2\x15.eebus.v1.DHWSetpointR\bsetpoint*h\n" +
+	"\bsetpoint\x18\x03 \x01(\v2\x15.eebus.v1.DHWSetpointR\bsetpoint\"\xf1\x01\n" +
+	"\x16DHWSystemFunctionState\x12;\n" +
+	"\fboost_status\x18\x01 \x01(\x0e2\x18.eebus.v1.DHWBoostStatusR\vboostStatus\x12%\n" +
+	"\x0eboost_writable\x18\x02 \x01(\bR\rboostWritable\x12%\n" +
+	"\x0eoperation_mode\x18\x03 \x01(\tR\roperationMode\x12'\n" +
+	"\x0favailable_modes\x18\x04 \x03(\tR\x0eavailableModes\x12#\n" +
+	"\rmode_writable\x18\x05 \x01(\bR\fmodeWritable\">\n" +
+	"\x12SetDHWBoostRequest\x12\x10\n" +
+	"\x03ski\x18\x01 \x01(\tR\x03ski\x12\x16\n" +
+	"\x06active\x18\x02 \x01(\bR\x06active\"B\n" +
+	"\x1aSetDHWOperationModeRequest\x12\x10\n" +
+	"\x03ski\x18\x01 \x01(\tR\x03ski\x12\x12\n" +
+	"\x04mode\x18\x02 \x01(\tR\x04mode\"\xa7\x01\n" +
+	"\x16DHWSystemFunctionEvent\x12\x10\n" +
+	"\x03ski\x18\x01 \x01(\tR\x03ski\x12C\n" +
+	"\n" +
+	"event_type\x18\x02 \x01(\x0e2$.eebus.v1.DHWSystemFunctionEventTypeR\teventType\x126\n" +
+	"\x05state\x18\x03 \x01(\v2 .eebus.v1.DHWSystemFunctionStateR\x05state*h\n" +
 	"\fDHWEventType\x12\x19\n" +
 	"\x15DHW_EVENT_UNSPECIFIED\x10\x00\x12\x1d\n" +
 	"\x19DHW_EVENT_SUPPORT_UPDATED\x10\x01\x12\x1e\n" +
-	"\x1aDHW_EVENT_SETPOINT_UPDATED\x10\x022\xd7\x01\n" +
+	"\x1aDHW_EVENT_SETPOINT_UPDATED\x10\x02*\xab\x01\n" +
+	"\x0eDHWBoostStatus\x12 \n" +
+	"\x1cDHW_BOOST_STATUS_UNSPECIFIED\x10\x00\x12\x1d\n" +
+	"\x19DHW_BOOST_STATUS_INACTIVE\x10\x01\x12\x1b\n" +
+	"\x17DHW_BOOST_STATUS_ACTIVE\x10\x02\x12\x1c\n" +
+	"\x18DHW_BOOST_STATUS_RUNNING\x10\x03\x12\x1d\n" +
+	"\x19DHW_BOOST_STATUS_FINISHED\x10\x04*\xa3\x01\n" +
+	"\x1aDHWSystemFunctionEventType\x12)\n" +
+	"%DHW_SYSTEM_FUNCTION_EVENT_UNSPECIFIED\x10\x00\x12-\n" +
+	")DHW_SYSTEM_FUNCTION_EVENT_SUPPORT_UPDATED\x10\x01\x12+\n" +
+	"'DHW_SYSTEM_FUNCTION_EVENT_STATE_UPDATED\x10\x022\x97\x04\n" +
 	"\n" +
 	"DHWService\x12@\n" +
 	"\x0eGetDHWSetpoint\x12\x17.eebus.v1.DeviceRequest\x1a\x15.eebus.v1.DHWSetpoint\x12B\n" +
 	"\x0eSetDHWSetpoint\x12\x1f.eebus.v1.SetDHWSetpointRequest\x1a\x0f.eebus.v1.Empty\x12C\n" +
-	"\x12SubscribeDHWEvents\x12\x17.eebus.v1.DeviceRequest\x1a\x12.eebus.v1.DHWEvent0\x01B=Z;github.com/volschin/eebus-bridge/gen/proto/eebus/v1;eebusv1b\x06proto3"
+	"\x12SubscribeDHWEvents\x12\x17.eebus.v1.DeviceRequest\x1a\x12.eebus.v1.DHWEvent0\x01\x12Q\n" +
+	"\x14GetDHWSystemFunction\x12\x17.eebus.v1.DeviceRequest\x1a .eebus.v1.DHWSystemFunctionState\x12<\n" +
+	"\vSetDHWBoost\x12\x1c.eebus.v1.SetDHWBoostRequest\x1a\x0f.eebus.v1.Empty\x12L\n" +
+	"\x13SetDHWOperationMode\x12$.eebus.v1.SetDHWOperationModeRequest\x1a\x0f.eebus.v1.Empty\x12_\n" +
+	" SubscribeDHWSystemFunctionEvents\x12\x17.eebus.v1.DeviceRequest\x1a .eebus.v1.DHWSystemFunctionEvent0\x01B=Z;github.com/volschin/eebus-bridge/gen/proto/eebus/v1;eebusv1b\x06proto3"
 
 var (
 	file_eebus_v1_dhw_service_proto_rawDescOnce sync.Once
@@ -301,30 +676,47 @@ func file_eebus_v1_dhw_service_proto_rawDescGZIP() []byte {
 	return file_eebus_v1_dhw_service_proto_rawDescData
 }
 
-var file_eebus_v1_dhw_service_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_eebus_v1_dhw_service_proto_msgTypes = make([]protoimpl.MessageInfo, 3)
+var file_eebus_v1_dhw_service_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
+var file_eebus_v1_dhw_service_proto_msgTypes = make([]protoimpl.MessageInfo, 7)
 var file_eebus_v1_dhw_service_proto_goTypes = []any{
-	(DHWEventType)(0),             // 0: eebus.v1.DHWEventType
-	(*DHWSetpoint)(nil),           // 1: eebus.v1.DHWSetpoint
-	(*SetDHWSetpointRequest)(nil), // 2: eebus.v1.SetDHWSetpointRequest
-	(*DHWEvent)(nil),              // 3: eebus.v1.DHWEvent
-	(*DeviceRequest)(nil),         // 4: eebus.v1.DeviceRequest
-	(*Empty)(nil),                 // 5: eebus.v1.Empty
+	(DHWEventType)(0),                  // 0: eebus.v1.DHWEventType
+	(DHWBoostStatus)(0),                // 1: eebus.v1.DHWBoostStatus
+	(DHWSystemFunctionEventType)(0),    // 2: eebus.v1.DHWSystemFunctionEventType
+	(*DHWSetpoint)(nil),                // 3: eebus.v1.DHWSetpoint
+	(*SetDHWSetpointRequest)(nil),      // 4: eebus.v1.SetDHWSetpointRequest
+	(*DHWEvent)(nil),                   // 5: eebus.v1.DHWEvent
+	(*DHWSystemFunctionState)(nil),     // 6: eebus.v1.DHWSystemFunctionState
+	(*SetDHWBoostRequest)(nil),         // 7: eebus.v1.SetDHWBoostRequest
+	(*SetDHWOperationModeRequest)(nil), // 8: eebus.v1.SetDHWOperationModeRequest
+	(*DHWSystemFunctionEvent)(nil),     // 9: eebus.v1.DHWSystemFunctionEvent
+	(*DeviceRequest)(nil),              // 10: eebus.v1.DeviceRequest
+	(*Empty)(nil),                      // 11: eebus.v1.Empty
 }
 var file_eebus_v1_dhw_service_proto_depIdxs = []int32{
-	0, // 0: eebus.v1.DHWEvent.event_type:type_name -> eebus.v1.DHWEventType
-	1, // 1: eebus.v1.DHWEvent.setpoint:type_name -> eebus.v1.DHWSetpoint
-	4, // 2: eebus.v1.DHWService.GetDHWSetpoint:input_type -> eebus.v1.DeviceRequest
-	2, // 3: eebus.v1.DHWService.SetDHWSetpoint:input_type -> eebus.v1.SetDHWSetpointRequest
-	4, // 4: eebus.v1.DHWService.SubscribeDHWEvents:input_type -> eebus.v1.DeviceRequest
-	1, // 5: eebus.v1.DHWService.GetDHWSetpoint:output_type -> eebus.v1.DHWSetpoint
-	5, // 6: eebus.v1.DHWService.SetDHWSetpoint:output_type -> eebus.v1.Empty
-	3, // 7: eebus.v1.DHWService.SubscribeDHWEvents:output_type -> eebus.v1.DHWEvent
-	5, // [5:8] is the sub-list for method output_type
-	2, // [2:5] is the sub-list for method input_type
-	2, // [2:2] is the sub-list for extension type_name
-	2, // [2:2] is the sub-list for extension extendee
-	0, // [0:2] is the sub-list for field type_name
+	0,  // 0: eebus.v1.DHWEvent.event_type:type_name -> eebus.v1.DHWEventType
+	3,  // 1: eebus.v1.DHWEvent.setpoint:type_name -> eebus.v1.DHWSetpoint
+	1,  // 2: eebus.v1.DHWSystemFunctionState.boost_status:type_name -> eebus.v1.DHWBoostStatus
+	2,  // 3: eebus.v1.DHWSystemFunctionEvent.event_type:type_name -> eebus.v1.DHWSystemFunctionEventType
+	6,  // 4: eebus.v1.DHWSystemFunctionEvent.state:type_name -> eebus.v1.DHWSystemFunctionState
+	10, // 5: eebus.v1.DHWService.GetDHWSetpoint:input_type -> eebus.v1.DeviceRequest
+	4,  // 6: eebus.v1.DHWService.SetDHWSetpoint:input_type -> eebus.v1.SetDHWSetpointRequest
+	10, // 7: eebus.v1.DHWService.SubscribeDHWEvents:input_type -> eebus.v1.DeviceRequest
+	10, // 8: eebus.v1.DHWService.GetDHWSystemFunction:input_type -> eebus.v1.DeviceRequest
+	7,  // 9: eebus.v1.DHWService.SetDHWBoost:input_type -> eebus.v1.SetDHWBoostRequest
+	8,  // 10: eebus.v1.DHWService.SetDHWOperationMode:input_type -> eebus.v1.SetDHWOperationModeRequest
+	10, // 11: eebus.v1.DHWService.SubscribeDHWSystemFunctionEvents:input_type -> eebus.v1.DeviceRequest
+	3,  // 12: eebus.v1.DHWService.GetDHWSetpoint:output_type -> eebus.v1.DHWSetpoint
+	11, // 13: eebus.v1.DHWService.SetDHWSetpoint:output_type -> eebus.v1.Empty
+	5,  // 14: eebus.v1.DHWService.SubscribeDHWEvents:output_type -> eebus.v1.DHWEvent
+	6,  // 15: eebus.v1.DHWService.GetDHWSystemFunction:output_type -> eebus.v1.DHWSystemFunctionState
+	11, // 16: eebus.v1.DHWService.SetDHWBoost:output_type -> eebus.v1.Empty
+	11, // 17: eebus.v1.DHWService.SetDHWOperationMode:output_type -> eebus.v1.Empty
+	9,  // 18: eebus.v1.DHWService.SubscribeDHWSystemFunctionEvents:output_type -> eebus.v1.DHWSystemFunctionEvent
+	12, // [12:19] is the sub-list for method output_type
+	5,  // [5:12] is the sub-list for method input_type
+	5,  // [5:5] is the sub-list for extension type_name
+	5,  // [5:5] is the sub-list for extension extendee
+	0,  // [0:5] is the sub-list for field type_name
 }
 
 func init() { file_eebus_v1_dhw_service_proto_init() }
@@ -338,8 +730,8 @@ func file_eebus_v1_dhw_service_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_eebus_v1_dhw_service_proto_rawDesc), len(file_eebus_v1_dhw_service_proto_rawDesc)),
-			NumEnums:      1,
-			NumMessages:   3,
+			NumEnums:      3,
+			NumMessages:   7,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/eebus-bridge/gen/proto/eebus/v1/dhw_service_grpc.pb.go
+++ b/eebus-bridge/gen/proto/eebus/v1/dhw_service_grpc.pb.go
@@ -19,9 +19,13 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	DHWService_GetDHWSetpoint_FullMethodName     = "/eebus.v1.DHWService/GetDHWSetpoint"
-	DHWService_SetDHWSetpoint_FullMethodName     = "/eebus.v1.DHWService/SetDHWSetpoint"
-	DHWService_SubscribeDHWEvents_FullMethodName = "/eebus.v1.DHWService/SubscribeDHWEvents"
+	DHWService_GetDHWSetpoint_FullMethodName                   = "/eebus.v1.DHWService/GetDHWSetpoint"
+	DHWService_SetDHWSetpoint_FullMethodName                   = "/eebus.v1.DHWService/SetDHWSetpoint"
+	DHWService_SubscribeDHWEvents_FullMethodName               = "/eebus.v1.DHWService/SubscribeDHWEvents"
+	DHWService_GetDHWSystemFunction_FullMethodName             = "/eebus.v1.DHWService/GetDHWSystemFunction"
+	DHWService_SetDHWBoost_FullMethodName                      = "/eebus.v1.DHWService/SetDHWBoost"
+	DHWService_SetDHWOperationMode_FullMethodName              = "/eebus.v1.DHWService/SetDHWOperationMode"
+	DHWService_SubscribeDHWSystemFunctionEvents_FullMethodName = "/eebus.v1.DHWService/SubscribeDHWSystemFunctionEvents"
 )
 
 // DHWServiceClient is the client API for DHWService service.
@@ -35,6 +39,10 @@ type DHWServiceClient interface {
 	GetDHWSetpoint(ctx context.Context, in *DeviceRequest, opts ...grpc.CallOption) (*DHWSetpoint, error)
 	SetDHWSetpoint(ctx context.Context, in *SetDHWSetpointRequest, opts ...grpc.CallOption) (*Empty, error)
 	SubscribeDHWEvents(ctx context.Context, in *DeviceRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[DHWEvent], error)
+	GetDHWSystemFunction(ctx context.Context, in *DeviceRequest, opts ...grpc.CallOption) (*DHWSystemFunctionState, error)
+	SetDHWBoost(ctx context.Context, in *SetDHWBoostRequest, opts ...grpc.CallOption) (*Empty, error)
+	SetDHWOperationMode(ctx context.Context, in *SetDHWOperationModeRequest, opts ...grpc.CallOption) (*Empty, error)
+	SubscribeDHWSystemFunctionEvents(ctx context.Context, in *DeviceRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[DHWSystemFunctionEvent], error)
 }
 
 type dHWServiceClient struct {
@@ -84,6 +92,55 @@ func (c *dHWServiceClient) SubscribeDHWEvents(ctx context.Context, in *DeviceReq
 // This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
 type DHWService_SubscribeDHWEventsClient = grpc.ServerStreamingClient[DHWEvent]
 
+func (c *dHWServiceClient) GetDHWSystemFunction(ctx context.Context, in *DeviceRequest, opts ...grpc.CallOption) (*DHWSystemFunctionState, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(DHWSystemFunctionState)
+	err := c.cc.Invoke(ctx, DHWService_GetDHWSystemFunction_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *dHWServiceClient) SetDHWBoost(ctx context.Context, in *SetDHWBoostRequest, opts ...grpc.CallOption) (*Empty, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(Empty)
+	err := c.cc.Invoke(ctx, DHWService_SetDHWBoost_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *dHWServiceClient) SetDHWOperationMode(ctx context.Context, in *SetDHWOperationModeRequest, opts ...grpc.CallOption) (*Empty, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(Empty)
+	err := c.cc.Invoke(ctx, DHWService_SetDHWOperationMode_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *dHWServiceClient) SubscribeDHWSystemFunctionEvents(ctx context.Context, in *DeviceRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[DHWSystemFunctionEvent], error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	stream, err := c.cc.NewStream(ctx, &DHWService_ServiceDesc.Streams[1], DHWService_SubscribeDHWSystemFunctionEvents_FullMethodName, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	x := &grpc.GenericClientStream[DeviceRequest, DHWSystemFunctionEvent]{ClientStream: stream}
+	if err := x.ClientStream.SendMsg(in); err != nil {
+		return nil, err
+	}
+	if err := x.ClientStream.CloseSend(); err != nil {
+		return nil, err
+	}
+	return x, nil
+}
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type DHWService_SubscribeDHWSystemFunctionEventsClient = grpc.ServerStreamingClient[DHWSystemFunctionEvent]
+
 // DHWServiceServer is the server API for DHWService service.
 // All implementations must embed UnimplementedDHWServiceServer
 // for forward compatibility.
@@ -95,6 +152,10 @@ type DHWServiceServer interface {
 	GetDHWSetpoint(context.Context, *DeviceRequest) (*DHWSetpoint, error)
 	SetDHWSetpoint(context.Context, *SetDHWSetpointRequest) (*Empty, error)
 	SubscribeDHWEvents(*DeviceRequest, grpc.ServerStreamingServer[DHWEvent]) error
+	GetDHWSystemFunction(context.Context, *DeviceRequest) (*DHWSystemFunctionState, error)
+	SetDHWBoost(context.Context, *SetDHWBoostRequest) (*Empty, error)
+	SetDHWOperationMode(context.Context, *SetDHWOperationModeRequest) (*Empty, error)
+	SubscribeDHWSystemFunctionEvents(*DeviceRequest, grpc.ServerStreamingServer[DHWSystemFunctionEvent]) error
 	mustEmbedUnimplementedDHWServiceServer()
 }
 
@@ -113,6 +174,18 @@ func (UnimplementedDHWServiceServer) SetDHWSetpoint(context.Context, *SetDHWSetp
 }
 func (UnimplementedDHWServiceServer) SubscribeDHWEvents(*DeviceRequest, grpc.ServerStreamingServer[DHWEvent]) error {
 	return status.Error(codes.Unimplemented, "method SubscribeDHWEvents not implemented")
+}
+func (UnimplementedDHWServiceServer) GetDHWSystemFunction(context.Context, *DeviceRequest) (*DHWSystemFunctionState, error) {
+	return nil, status.Error(codes.Unimplemented, "method GetDHWSystemFunction not implemented")
+}
+func (UnimplementedDHWServiceServer) SetDHWBoost(context.Context, *SetDHWBoostRequest) (*Empty, error) {
+	return nil, status.Error(codes.Unimplemented, "method SetDHWBoost not implemented")
+}
+func (UnimplementedDHWServiceServer) SetDHWOperationMode(context.Context, *SetDHWOperationModeRequest) (*Empty, error) {
+	return nil, status.Error(codes.Unimplemented, "method SetDHWOperationMode not implemented")
+}
+func (UnimplementedDHWServiceServer) SubscribeDHWSystemFunctionEvents(*DeviceRequest, grpc.ServerStreamingServer[DHWSystemFunctionEvent]) error {
+	return status.Error(codes.Unimplemented, "method SubscribeDHWSystemFunctionEvents not implemented")
 }
 func (UnimplementedDHWServiceServer) mustEmbedUnimplementedDHWServiceServer() {}
 func (UnimplementedDHWServiceServer) testEmbeddedByValue()                    {}
@@ -182,6 +255,71 @@ func _DHWService_SubscribeDHWEvents_Handler(srv interface{}, stream grpc.ServerS
 // This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
 type DHWService_SubscribeDHWEventsServer = grpc.ServerStreamingServer[DHWEvent]
 
+func _DHWService_GetDHWSystemFunction_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(DeviceRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(DHWServiceServer).GetDHWSystemFunction(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: DHWService_GetDHWSystemFunction_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(DHWServiceServer).GetDHWSystemFunction(ctx, req.(*DeviceRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _DHWService_SetDHWBoost_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(SetDHWBoostRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(DHWServiceServer).SetDHWBoost(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: DHWService_SetDHWBoost_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(DHWServiceServer).SetDHWBoost(ctx, req.(*SetDHWBoostRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _DHWService_SetDHWOperationMode_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(SetDHWOperationModeRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(DHWServiceServer).SetDHWOperationMode(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: DHWService_SetDHWOperationMode_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(DHWServiceServer).SetDHWOperationMode(ctx, req.(*SetDHWOperationModeRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _DHWService_SubscribeDHWSystemFunctionEvents_Handler(srv interface{}, stream grpc.ServerStream) error {
+	m := new(DeviceRequest)
+	if err := stream.RecvMsg(m); err != nil {
+		return err
+	}
+	return srv.(DHWServiceServer).SubscribeDHWSystemFunctionEvents(m, &grpc.GenericServerStream[DeviceRequest, DHWSystemFunctionEvent]{ServerStream: stream})
+}
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type DHWService_SubscribeDHWSystemFunctionEventsServer = grpc.ServerStreamingServer[DHWSystemFunctionEvent]
+
 // DHWService_ServiceDesc is the grpc.ServiceDesc for DHWService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -197,11 +335,28 @@ var DHWService_ServiceDesc = grpc.ServiceDesc{
 			MethodName: "SetDHWSetpoint",
 			Handler:    _DHWService_SetDHWSetpoint_Handler,
 		},
+		{
+			MethodName: "GetDHWSystemFunction",
+			Handler:    _DHWService_GetDHWSystemFunction_Handler,
+		},
+		{
+			MethodName: "SetDHWBoost",
+			Handler:    _DHWService_SetDHWBoost_Handler,
+		},
+		{
+			MethodName: "SetDHWOperationMode",
+			Handler:    _DHWService_SetDHWOperationMode_Handler,
+		},
 	},
 	Streams: []grpc.StreamDesc{
 		{
 			StreamName:    "SubscribeDHWEvents",
 			Handler:       _DHWService_SubscribeDHWEvents_Handler,
+			ServerStreams: true,
+		},
+		{
+			StreamName:    "SubscribeDHWSystemFunctionEvents",
+			Handler:       _DHWService_SubscribeDHWSystemFunctionEvents_Handler,
 			ServerStreams: true,
 		},
 	},

--- a/eebus-bridge/internal/grpc/dhw_service.go
+++ b/eebus-bridge/internal/grpc/dhw_service.go
@@ -18,15 +18,23 @@ type dhwController interface {
 	Write(context.Context, spineapi.EntityRemoteInterface, float64) error
 }
 
+type dhwSysFnController interface {
+	CompatibleEntity(string) spineapi.EntityRemoteInterface
+	State(spineapi.EntityRemoteInterface) (usecases.DHWSystemFunctionState, error)
+	WriteBoost(context.Context, spineapi.EntityRemoteInterface, bool) error
+	WriteOperationMode(context.Context, spineapi.EntityRemoteInterface, string) error
+}
+
 // DHWService exposes the DHWCircuit target temperature over gRPC.
 type DHWService struct {
 	pb.UnimplementedDHWServiceServer
-	dhw dhwController
-	bus *eebus.EventBus
+	dhw      dhwController
+	dhwSysFn dhwSysFnController
+	bus      *eebus.EventBus
 }
 
-func NewDHWService(dhw dhwController, bus *eebus.EventBus) *DHWService {
-	return &DHWService{dhw: dhw, bus: bus}
+func NewDHWService(dhw dhwController, dhwSysFn dhwSysFnController, bus *eebus.EventBus) *DHWService {
+	return &DHWService{dhw: dhw, dhwSysFn: dhwSysFn, bus: bus}
 }
 
 func (s *DHWService) GetDHWSetpoint(_ context.Context, req *pb.DeviceRequest) (*pb.DHWSetpoint, error) {
@@ -57,6 +65,55 @@ func (s *DHWService) SetDHWSetpoint(ctx context.Context, req *pb.SetDHWSetpointR
 	}
 	if err := s.dhw.Write(ctx, entity, req.ValueCelsius); err != nil {
 		return nil, mapDHWError("writing DHW setpoint", err)
+	}
+	return &pb.Empty{}, nil
+}
+
+func (s *DHWService) GetDHWSystemFunction(_ context.Context, req *pb.DeviceRequest) (*pb.DHWSystemFunctionState, error) {
+	if req == nil {
+		return nil, status.Error(codes.InvalidArgument, "request is required")
+	}
+	entity, err := s.resolveSysFnEntity(req.Ski)
+	if err != nil {
+		return nil, err
+	}
+	state, err := s.dhwSysFn.State(entity)
+	if err != nil {
+		return nil, mapDHWError("reading DHW system function", err)
+	}
+	return convertDHWSystemFunctionState(state), nil
+}
+
+func (s *DHWService) SetDHWBoost(ctx context.Context, req *pb.SetDHWBoostRequest) (*pb.Empty, error) {
+	if req == nil {
+		return nil, status.Error(codes.InvalidArgument, "request is required")
+	}
+	if req.Ski == "" {
+		return nil, status.Error(codes.InvalidArgument, "ski is required for write operations")
+	}
+	entity, err := s.resolveSysFnEntity(req.Ski)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.dhwSysFn.WriteBoost(ctx, entity, req.Active); err != nil {
+		return nil, mapDHWError("writing DHW boost", err)
+	}
+	return &pb.Empty{}, nil
+}
+
+func (s *DHWService) SetDHWOperationMode(ctx context.Context, req *pb.SetDHWOperationModeRequest) (*pb.Empty, error) {
+	if req == nil {
+		return nil, status.Error(codes.InvalidArgument, "request is required")
+	}
+	if req.Ski == "" {
+		return nil, status.Error(codes.InvalidArgument, "ski is required for write operations")
+	}
+	entity, err := s.resolveSysFnEntity(req.Ski)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.dhwSysFn.WriteOperationMode(ctx, entity, req.Mode); err != nil {
+		return nil, mapDHWError("writing DHW operation mode", err)
 	}
 	return &pb.Empty{}, nil
 }
@@ -101,11 +158,67 @@ func (s *DHWService) SubscribeDHWEvents(req *pb.DeviceRequest, stream pb.DHWServ
 	}
 }
 
+func (s *DHWService) SubscribeDHWSystemFunctionEvents(
+	req *pb.DeviceRequest,
+	stream pb.DHWService_SubscribeDHWSystemFunctionEventsServer,
+) error {
+	if req == nil {
+		return status.Error(codes.InvalidArgument, "request is required")
+	}
+	ch := s.bus.Subscribe()
+	defer s.bus.Unsubscribe(ch)
+
+	for {
+		select {
+		case evt, ok := <-ch:
+			if !ok {
+				return nil
+			}
+			if req.Ski != "" && eebus.NormalizeSKI(evt.SKI) != eebus.NormalizeSKI(req.Ski) {
+				continue
+			}
+			var eventType pb.DHWSystemFunctionEventType
+			switch evt.Type {
+			case "dhwsysfn.use_case_support_updated":
+				eventType = pb.DHWSystemFunctionEventType_DHW_SYSTEM_FUNCTION_EVENT_SUPPORT_UPDATED
+			case "dhwsysfn.updated":
+				eventType = pb.DHWSystemFunctionEventType_DHW_SYSTEM_FUNCTION_EVENT_STATE_UPDATED
+			default:
+				continue
+			}
+			event := &pb.DHWSystemFunctionEvent{Ski: evt.SKI, EventType: eventType}
+			if s.dhwSysFn != nil {
+				if entity := s.dhwSysFn.CompatibleEntity(evt.SKI); entity != nil {
+					if state, err := s.dhwSysFn.State(entity); err == nil {
+						event.State = convertDHWSystemFunctionState(state)
+					}
+				}
+			}
+			if err := stream.Send(event); err != nil {
+				return err
+			}
+		case <-stream.Context().Done():
+			return stream.Context().Err()
+		}
+	}
+}
+
 func (s *DHWService) resolveEntity(ski string) (spineapi.EntityRemoteInterface, error) {
 	if s.dhw == nil {
 		return nil, status.Error(codes.Unavailable, "DHW temperature use case not initialized")
 	}
 	entity := s.dhw.CompatibleEntity(ski)
+	if entity == nil {
+		return nil, status.Errorf(codes.NotFound, "no compatible DHWCircuit found for ski %s", ski)
+	}
+	return entity, nil
+}
+
+func (s *DHWService) resolveSysFnEntity(ski string) (spineapi.EntityRemoteInterface, error) {
+	if s.dhwSysFn == nil {
+		return nil, status.Error(codes.Unavailable, "DHW system function use case not initialized")
+	}
+	entity := s.dhwSysFn.CompatibleEntity(ski)
 	if entity == nil {
 		return nil, status.Errorf(codes.NotFound, "no compatible DHWCircuit found for ski %s", ski)
 	}
@@ -122,13 +235,39 @@ func convertDHWSetpoint(state usecases.DHWSetpoint) *pb.DHWSetpoint {
 	}
 }
 
+func convertDHWSystemFunctionState(state usecases.DHWSystemFunctionState) *pb.DHWSystemFunctionState {
+	return &pb.DHWSystemFunctionState{
+		BoostStatus:    convertDHWBoostStatus(state.BoostStatus),
+		BoostWritable:  state.BoostWritable,
+		OperationMode:  state.OperationMode,
+		AvailableModes: state.AvailableModes,
+		ModeWritable:   state.ModeWritable,
+	}
+}
+
+func convertDHWBoostStatus(status string) pb.DHWBoostStatus {
+	switch status {
+	case "inactive":
+		return pb.DHWBoostStatus_DHW_BOOST_STATUS_INACTIVE
+	case "active":
+		return pb.DHWBoostStatus_DHW_BOOST_STATUS_ACTIVE
+	case "running":
+		return pb.DHWBoostStatus_DHW_BOOST_STATUS_RUNNING
+	case "finished":
+		return pb.DHWBoostStatus_DHW_BOOST_STATUS_FINISHED
+	default:
+		return pb.DHWBoostStatus_DHW_BOOST_STATUS_UNSPECIFIED
+	}
+}
+
 func mapDHWError(action string, err error) error {
 	switch {
-	case errors.Is(err, usecases.ErrDHWOutOfRange), errors.Is(err, usecases.ErrDHWInvalidStep):
+	case errors.Is(err, usecases.ErrDHWOutOfRange), errors.Is(err, usecases.ErrDHWInvalidStep),
+		errors.Is(err, usecases.ErrDHWSysFnInvalidMode):
 		return status.Errorf(codes.InvalidArgument, "%s: %v", action, err)
-	case errors.Is(err, usecases.ErrDHWNotWritable):
+	case errors.Is(err, usecases.ErrDHWNotWritable), errors.Is(err, usecases.ErrDHWSysFnNotWritable):
 		return status.Errorf(codes.FailedPrecondition, "%s: %v", action, err)
-	case errors.Is(err, usecases.ErrDHWDataUnavailable):
+	case errors.Is(err, usecases.ErrDHWDataUnavailable), errors.Is(err, usecases.ErrDHWSysFnDataUnavailable):
 		return status.Errorf(codes.NotFound, "%s: %v", action, err)
 	case errors.Is(err, context.Canceled):
 		return status.Errorf(codes.Canceled, "%s: %v", action, err)

--- a/eebus-bridge/internal/grpc/dhw_service.go
+++ b/eebus-bridge/internal/grpc/dhw_service.go
@@ -265,7 +265,8 @@ func mapDHWError(action string, err error) error {
 	case errors.Is(err, usecases.ErrDHWOutOfRange), errors.Is(err, usecases.ErrDHWInvalidStep),
 		errors.Is(err, usecases.ErrDHWSysFnInvalidMode):
 		return status.Errorf(codes.InvalidArgument, "%s: %v", action, err)
-	case errors.Is(err, usecases.ErrDHWNotWritable), errors.Is(err, usecases.ErrDHWSysFnNotWritable):
+	case errors.Is(err, usecases.ErrDHWNotWritable), errors.Is(err, usecases.ErrDHWSysFnNotWritable),
+		errors.Is(err, usecases.ErrDHWSysFnRejected):
 		return status.Errorf(codes.FailedPrecondition, "%s: %v", action, err)
 	case errors.Is(err, usecases.ErrDHWDataUnavailable), errors.Is(err, usecases.ErrDHWSysFnDataUnavailable):
 		return status.Errorf(codes.NotFound, "%s: %v", action, err)

--- a/eebus-bridge/internal/grpc/dhw_service_test.go
+++ b/eebus-bridge/internal/grpc/dhw_service_test.go
@@ -35,6 +35,34 @@ func (f *fakeDHWController) Write(_ context.Context, _ spineapi.EntityRemoteInte
 	return f.writeErr
 }
 
+type fakeDHWSysFnController struct {
+	entity       spineapi.EntityRemoteInterface
+	state        usecases.DHWSystemFunctionState
+	stateErr     error
+	boostErr     error
+	modeErr      error
+	writtenBoost *bool
+	writtenMode  string
+}
+
+func (f *fakeDHWSysFnController) CompatibleEntity(string) spineapi.EntityRemoteInterface {
+	return f.entity
+}
+
+func (f *fakeDHWSysFnController) State(spineapi.EntityRemoteInterface) (usecases.DHWSystemFunctionState, error) {
+	return f.state, f.stateErr
+}
+
+func (f *fakeDHWSysFnController) WriteBoost(_ context.Context, _ spineapi.EntityRemoteInterface, active bool) error {
+	f.writtenBoost = &active
+	return f.boostErr
+}
+
+func (f *fakeDHWSysFnController) WriteOperationMode(_ context.Context, _ spineapi.EntityRemoteInterface, mode string) error {
+	f.writtenMode = mode
+	return f.modeErr
+}
+
 func TestDHWServiceGetAndSet(t *testing.T) {
 	controller := &fakeDHWController{
 		entity: mocks.NewEntityRemoteInterface(t),
@@ -42,7 +70,7 @@ func TestDHWServiceGetAndSet(t *testing.T) {
 			Value: 46, Minimum: 35, Maximum: 70, Step: 1, Writable: true,
 		},
 	}
-	service := NewDHWService(controller, eebus.NewEventBus())
+	service := NewDHWService(controller, nil, eebus.NewEventBus())
 
 	response, err := service.GetDHWSetpoint(context.Background(), &pb.DeviceRequest{Ski: "test"})
 	if err != nil {
@@ -69,7 +97,7 @@ func TestDHWServiceMapsValidationErrors(t *testing.T) {
 		entity:   mocks.NewEntityRemoteInterface(t),
 		writeErr: fmtWrap(usecases.ErrDHWOutOfRange),
 	}
-	service := NewDHWService(controller, eebus.NewEventBus())
+	service := NewDHWService(controller, nil, eebus.NewEventBus())
 
 	_, err := service.SetDHWSetpoint(
 		context.Background(),
@@ -81,12 +109,69 @@ func TestDHWServiceMapsValidationErrors(t *testing.T) {
 }
 
 func TestDHWServiceRequiresControllerAndSKI(t *testing.T) {
-	service := NewDHWService(nil, eebus.NewEventBus())
+	service := NewDHWService(nil, nil, eebus.NewEventBus())
 	if _, err := service.GetDHWSetpoint(context.Background(), &pb.DeviceRequest{}); status.Code(err) != codes.Unavailable {
 		t.Errorf("GetDHWSetpoint() code = %v, want Unavailable", status.Code(err))
 	}
 	if _, err := service.SetDHWSetpoint(context.Background(), &pb.SetDHWSetpointRequest{}); status.Code(err) != codes.InvalidArgument {
 		t.Errorf("SetDHWSetpoint() code = %v, want InvalidArgument", status.Code(err))
+	}
+	if _, err := service.GetDHWSystemFunction(context.Background(), &pb.DeviceRequest{}); status.Code(err) != codes.Unavailable {
+		t.Errorf("GetDHWSystemFunction() code = %v, want Unavailable", status.Code(err))
+	}
+}
+
+func TestDHWServiceSystemFunctionGetAndSet(t *testing.T) {
+	activeEntity := mocks.NewEntityRemoteInterface(t)
+	controller := &fakeDHWSysFnController{
+		entity: activeEntity,
+		state: usecases.DHWSystemFunctionState{
+			BoostStatus:    "running",
+			BoostWritable:  true,
+			OperationMode:  "auto",
+			AvailableModes: []string{"auto", "on", "off"},
+			ModeWritable:   true,
+		},
+	}
+	service := NewDHWService(nil, controller, eebus.NewEventBus())
+
+	response, err := service.GetDHWSystemFunction(context.Background(), &pb.DeviceRequest{Ski: "test"})
+	if err != nil {
+		t.Fatalf("GetDHWSystemFunction() error = %v", err)
+	}
+	if response.BoostStatus != pb.DHWBoostStatus_DHW_BOOST_STATUS_RUNNING ||
+		!response.BoostWritable || response.OperationMode != "auto" || !response.ModeWritable ||
+		len(response.AvailableModes) != 3 {
+		t.Fatalf("GetDHWSystemFunction() = %+v", response)
+	}
+
+	if _, err := service.SetDHWBoost(context.Background(), &pb.SetDHWBoostRequest{Ski: "test", Active: true}); err != nil {
+		t.Fatalf("SetDHWBoost() error = %v", err)
+	}
+	if controller.writtenBoost == nil || !*controller.writtenBoost {
+		t.Fatalf("written boost = %v, want true", controller.writtenBoost)
+	}
+	if _, err := service.SetDHWOperationMode(context.Background(), &pb.SetDHWOperationModeRequest{Ski: "test", Mode: "off"}); err != nil {
+		t.Fatalf("SetDHWOperationMode() error = %v", err)
+	}
+	if controller.writtenMode != "off" {
+		t.Fatalf("written mode = %q, want off", controller.writtenMode)
+	}
+}
+
+func TestDHWServiceMapsSystemFunctionErrors(t *testing.T) {
+	controller := &fakeDHWSysFnController{
+		entity:  mocks.NewEntityRemoteInterface(t),
+		modeErr: fmtWrap(usecases.ErrDHWSysFnInvalidMode),
+	}
+	service := NewDHWService(nil, controller, eebus.NewEventBus())
+
+	_, err := service.SetDHWOperationMode(
+		context.Background(),
+		&pb.SetDHWOperationModeRequest{Ski: "test", Mode: "eco"},
+	)
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("SetDHWOperationMode() code = %v, want InvalidArgument", status.Code(err))
 	}
 }
 

--- a/eebus-bridge/internal/usecases/dhwsysfn.go
+++ b/eebus-bridge/internal/usecases/dhwsysfn.go
@@ -20,6 +20,7 @@ var (
 	ErrDHWSysFnDataUnavailable = errors.New("DHW system function data unavailable")
 	ErrDHWSysFnNotWritable     = errors.New("DHW system function is not writable")
 	ErrDHWSysFnInvalidMode     = errors.New("DHW operation mode is not advertised")
+	ErrDHWSysFnRejected        = errors.New("DHW system function write rejected by device")
 )
 
 // DHWSystemFunctionState is the current DHW boost state and operation mode
@@ -225,8 +226,10 @@ func (d *DHWSystemFunction) State(entity spineapi.EntityRemoteInterface) (DHWSys
 		BoostWritable:  overrunOp != nil && overrunOp.Write() && boolPtrNotFalse(resolved.overrun.IsOverrunStatusChangeable),
 		OperationMode:  string(resolved.currentModeType),
 		AvailableModes: resolved.availableModeTypes,
+		// Like the boost path, a missing changeability flag must not hide a
+		// write the device advertises via operations; only explicit false blocks.
 		ModeWritable: systemOp != nil && systemOp.Write() &&
-			resolved.system.IsOperationModeIdChangeable != nil && *resolved.system.IsOperationModeIdChangeable,
+			boolPtrNotFalse(resolved.system.IsOperationModeIdChangeable),
 	}, nil
 }
 
@@ -348,7 +351,7 @@ func (d *DHWSystemFunction) write(
 	select {
 	case response := <-result:
 		if response.ErrorNumber != nil && *response.ErrorNumber != 0 {
-			return fmt.Errorf("%s rejected by device: error=%d", label, *response.ErrorNumber)
+			return fmt.Errorf("%w: %s error=%d", ErrDHWSysFnRejected, label, *response.ErrorNumber)
 		}
 		d.request(entity, refresh)
 		return nil

--- a/eebus-bridge/internal/usecases/dhwsysfn.go
+++ b/eebus-bridge/internal/usecases/dhwsysfn.go
@@ -1,0 +1,541 @@
+package usecases
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"time"
+
+	eebusapi "github.com/enbility/eebus-go/api"
+	usecase "github.com/enbility/eebus-go/usecases/usecase"
+	spineapi "github.com/enbility/spine-go/api"
+	"github.com/enbility/spine-go/model"
+	"github.com/volschin/eebus-bridge/internal/eebus"
+)
+
+const dhwSysFnUseCaseSupportUpdate eebusapi.EventType = "bridge-dhw-system-function-support-update"
+
+var (
+	ErrDHWSysFnDataUnavailable = errors.New("DHW system function data unavailable")
+	ErrDHWSysFnNotWritable     = errors.New("DHW system function is not writable")
+	ErrDHWSysFnInvalidMode     = errors.New("DHW operation mode is not advertised")
+)
+
+// DHWSystemFunctionState is the current DHW boost state and operation mode
+// resolved from the remote DHWCircuit HVAC server metadata.
+type DHWSystemFunctionState struct {
+	BoostStatus    string
+	BoostWritable  bool
+	OperationMode  string
+	AvailableModes []string
+	ModeWritable   bool
+}
+
+// DHWSystemFunction implements the Configuration of DHW System Function client
+// role for one-time DHW overrun/boost and DHW operation mode.
+type DHWSystemFunction struct {
+	*usecase.UseCaseBase
+	localEntity spineapi.EntityLocalInterface
+	bus         *eebus.EventBus
+	registry    *eebus.DeviceRegistry
+	debug       bool
+}
+
+// NewDHWSystemFunction creates the Configuration Appliance client use case.
+func NewDHWSystemFunction(
+	localEntity spineapi.EntityLocalInterface,
+	bus *eebus.EventBus,
+	registry *eebus.DeviceRegistry,
+	debug bool,
+) *DHWSystemFunction {
+	d := &DHWSystemFunction{
+		localEntity: localEntity,
+		bus:         bus,
+		registry:    registry,
+		debug:       debug,
+	}
+	d.UseCaseBase = usecase.NewUseCaseBase(
+		localEntity,
+		model.UseCaseActorTypeConfigurationAppliance,
+		model.UseCaseNameTypeConfigurationOfDhwSystemFunction,
+		"1.0.0",
+		"release",
+		[]eebusapi.UseCaseScenario{
+			{
+				Scenario:       model.UseCaseScenarioSupportType(1),
+				Mandatory:      true,
+				ServerFeatures: []model.FeatureTypeType{model.FeatureTypeTypeHvac},
+			},
+			{
+				Scenario:       model.UseCaseScenarioSupportType(2),
+				Mandatory:      false,
+				ServerFeatures: []model.FeatureTypeType{model.FeatureTypeTypeHvac},
+			},
+			{
+				Scenario:       model.UseCaseScenarioSupportType(3),
+				Mandatory:      false,
+				ServerFeatures: []model.FeatureTypeType{model.FeatureTypeTypeHvac},
+			},
+		},
+		d.handleUseCaseEvent,
+		dhwSysFnUseCaseSupportUpdate,
+		[]model.UseCaseActorType{model.UseCaseActorTypeDHWCircuit},
+		[]model.EntityTypeType{model.EntityTypeTypeDHWCircuit},
+		false,
+	)
+	_ = localEntity.Device().Events().Subscribe(d)
+	return d
+}
+
+// UseCase returns this use case for Service.AddUseCase.
+func (d *DHWSystemFunction) UseCase() eebusapi.UseCaseInterface { return d }
+
+// AddFeatures creates the local HVAC client required by the use case.
+func (d *DHWSystemFunction) AddFeatures() error {
+	if d.localEntity == nil {
+		return errors.New("DHW system function local entity is nil")
+	}
+	if feature := d.localEntity.GetOrAddFeature(model.FeatureTypeTypeHvac, model.RoleTypeClient); feature == nil {
+		return errors.New("could not add DHW HVAC client feature")
+	}
+	return nil
+}
+
+// HandleEvent establishes the HVAC relationship and turns cache updates into
+// bridge events consumed by the DHW system-function gRPC stream.
+func (d *DHWSystemFunction) HandleEvent(payload spineapi.EventPayload) {
+	if payload.Entity == nil || !d.IsCompatibleEntityType(payload.Entity) {
+		return
+	}
+	if payload.EventType == spineapi.EventTypeEntityChange && payload.ChangeType == spineapi.ElementChangeAdd {
+		d.connect(payload.Entity)
+		return
+	}
+	if payload.EventType != spineapi.EventTypeDataChange || payload.ChangeType != spineapi.ElementChangeUpdate {
+		return
+	}
+
+	switch payload.Data.(type) {
+	case *model.HvacSystemFunctionDescriptionListDataType,
+		*model.HvacOperationModeDescriptionListDataType,
+		*model.HvacSystemFunctionOperationModeRelationListDataType,
+		*model.HvacOverrunDescriptionListDataType:
+		if _, err := d.State(payload.Entity); err == nil && d.bus != nil {
+			d.bus.Publish(eebus.Event{SKI: payload.Ski, Type: "dhwsysfn.use_case_support_updated"})
+		}
+	case *model.HvacSystemFunctionListDataType, *model.HvacOverrunListDataType:
+		if _, err := d.State(payload.Entity); err == nil && d.bus != nil {
+			d.bus.Publish(eebus.Event{SKI: payload.Ski, Type: "dhwsysfn.updated"})
+		}
+	}
+}
+
+func (d *DHWSystemFunction) handleUseCaseEvent(
+	ski string,
+	device spineapi.DeviceRemoteInterface,
+	entity spineapi.EntityRemoteInterface,
+	_ eebusapi.EventType,
+) {
+	if d.registry != nil {
+		d.registry.UpsertObservation(ski, device, entity, "dhw_system_function")
+	}
+	if d.bus != nil {
+		d.bus.Publish(eebus.Event{SKI: ski, Type: "dhwsysfn.use_case_support_updated"})
+	}
+}
+
+func (d *DHWSystemFunction) connect(entity spineapi.EntityRemoteInterface) {
+	remote := hvacServer(entity)
+	local := d.localHvacFeature()
+	if remote == nil || local == nil {
+		return
+	}
+	if !local.HasSubscriptionToRemote(remote.Address()) {
+		if _, err := local.SubscribeToRemote(remote.Address()); err != nil && d.debug {
+			log.Printf("[DHWSYSFN] HVAC subscription failed: %s", err.String())
+		}
+	}
+	if !local.HasBindingToRemote(remote.Address()) {
+		if _, err := local.BindToRemote(remote.Address()); err != nil && d.debug {
+			log.Printf("[DHWSYSFN] HVAC binding failed: %s", err.String())
+		}
+	}
+	d.Refresh(entity)
+}
+
+// Refresh requests current HVAC metadata and values.
+func (d *DHWSystemFunction) Refresh(entity spineapi.EntityRemoteInterface) {
+	for _, function := range []model.FunctionType{
+		model.FunctionTypeHvacSystemFunctionDescriptionListData,
+		model.FunctionTypeHvacSystemFunctionListData,
+		model.FunctionTypeHvacOperationModeDescriptionListData,
+		model.FunctionTypeHvacSystemFunctionOperationModeRelationListData,
+		model.FunctionTypeHvacOverrunDescriptionListData,
+		model.FunctionTypeHvacOverrunListData,
+	} {
+		d.request(entity, function)
+	}
+}
+
+func (d *DHWSystemFunction) request(entity spineapi.EntityRemoteInterface, function model.FunctionType) {
+	remote := hvacServer(entity)
+	local := d.localHvacFeature()
+	if remote == nil || local == nil {
+		return
+	}
+	operation := remote.Operations()[function]
+	if operation == nil || !operation.Read() {
+		return
+	}
+	if _, err := local.RequestRemoteData(function, nil, nil, remote); err != nil && d.debug {
+		log.Printf("[DHWSYSFN] requesting %s failed: %s", function, err.String())
+	}
+}
+
+// CompatibleEntity returns the negotiated DHWCircuit for a device SKI.
+func (d *DHWSystemFunction) CompatibleEntity(ski string) spineapi.EntityRemoteInterface {
+	want := eebus.NormalizeSKI(ski)
+	for _, remote := range d.RemoteEntitiesScenarios() {
+		entity := remote.Entity
+		if entity == nil || entity.Device() == nil {
+			continue
+		}
+		if want == "" || eebus.NormalizeSKI(entity.Device().Ski()) == want {
+			return entity
+		}
+	}
+	return nil
+}
+
+// State resolves DHW boost and operation mode from the remote HVAC cache.
+func (d *DHWSystemFunction) State(entity spineapi.EntityRemoteInterface) (DHWSystemFunctionState, error) {
+	remote := hvacServer(entity)
+	if remote == nil {
+		return DHWSystemFunctionState{}, ErrDHWSysFnDataUnavailable
+	}
+	resolved, err := resolveDHWSystemFunction(remote)
+	if err != nil {
+		return DHWSystemFunctionState{}, err
+	}
+	overrunOp := remote.Operations()[model.FunctionTypeHvacOverrunListData]
+	systemOp := remote.Operations()[model.FunctionTypeHvacSystemFunctionListData]
+	return DHWSystemFunctionState{
+		BoostStatus:    string(*resolved.overrun.OverrunStatus),
+		BoostWritable:  overrunOp != nil && overrunOp.Write() && boolPtrNotFalse(resolved.overrun.IsOverrunStatusChangeable),
+		OperationMode:  string(resolved.currentModeType),
+		AvailableModes: resolved.availableModeTypes,
+		ModeWritable: systemOp != nil && systemOp.Write() &&
+			resolved.system.IsOperationModeIdChangeable != nil && *resolved.system.IsOperationModeIdChangeable,
+	}, nil
+}
+
+// WriteBoost activates or deactivates the one-time DHW overrun.
+func (d *DHWSystemFunction) WriteBoost(ctx context.Context, entity spineapi.EntityRemoteInterface, active bool) error {
+	state, err := d.State(entity)
+	if err != nil {
+		return err
+	}
+	if !state.BoostWritable {
+		return ErrDHWSysFnNotWritable
+	}
+	remote := hvacServer(entity)
+	local := d.localHvacFeature()
+	if remote == nil || local == nil {
+		return ErrDHWSysFnDataUnavailable
+	}
+	resolved, err := resolveDHWSystemFunction(remote)
+	if err != nil {
+		return err
+	}
+	data, ok := remote.DataCopy(model.FunctionTypeHvacOverrunListData).(*model.HvacOverrunListDataType)
+	if !ok || data == nil {
+		return ErrDHWSysFnDataUnavailable
+	}
+	entries := make([]model.HvacOverrunDataType, len(data.HvacOverrunData))
+	copy(entries, data.HvacOverrunData)
+	status := model.HvacOverrunStatusTypeInactive
+	if active {
+		status = model.HvacOverrunStatusTypeActive
+	}
+	found := false
+	for index := range entries {
+		if entries[index].OverrunId != nil && *entries[index].OverrunId == resolved.overrunID {
+			entries[index].OverrunStatus = &status
+			found = true
+			break
+		}
+	}
+	if !found {
+		return ErrDHWSysFnDataUnavailable
+	}
+	return d.write(ctx, entity, remote, local, model.CmdType{
+		HvacOverrunListData: &model.HvacOverrunListDataType{HvacOverrunData: entries},
+	}, model.FunctionTypeHvacOverrunListData, "DHW boost")
+}
+
+// WriteOperationMode switches the DHW operation mode by device-advertised type.
+func (d *DHWSystemFunction) WriteOperationMode(ctx context.Context, entity spineapi.EntityRemoteInterface, modeType string) error {
+	state, err := d.State(entity)
+	if err != nil {
+		return err
+	}
+	if !state.ModeWritable {
+		return ErrDHWSysFnNotWritable
+	}
+	remote := hvacServer(entity)
+	local := d.localHvacFeature()
+	if remote == nil || local == nil {
+		return ErrDHWSysFnDataUnavailable
+	}
+	resolved, err := resolveDHWSystemFunction(remote)
+	if err != nil {
+		return err
+	}
+	id, ok := resolved.modeIDForType[modeType]
+	if !ok {
+		return fmt.Errorf("%w: %s", ErrDHWSysFnInvalidMode, modeType)
+	}
+	data, ok := remote.DataCopy(model.FunctionTypeHvacSystemFunctionListData).(*model.HvacSystemFunctionListDataType)
+	if !ok || data == nil {
+		return ErrDHWSysFnDataUnavailable
+	}
+	entries := make([]model.HvacSystemFunctionDataType, len(data.HvacSystemFunctionData))
+	copy(entries, data.HvacSystemFunctionData)
+	found := false
+	for index := range entries {
+		if entries[index].SystemFunctionId != nil && *entries[index].SystemFunctionId == resolved.systemID {
+			entries[index].CurrentOperationModeId = &id
+			found = true
+			break
+		}
+	}
+	if !found {
+		return ErrDHWSysFnDataUnavailable
+	}
+	return d.write(ctx, entity, remote, local, model.CmdType{
+		HvacSystemFunctionListData: &model.HvacSystemFunctionListDataType{HvacSystemFunctionData: entries},
+	}, model.FunctionTypeHvacSystemFunctionListData, "DHW operation mode")
+}
+
+func (d *DHWSystemFunction) write(
+	ctx context.Context,
+	entity spineapi.EntityRemoteInterface,
+	remote spineapi.FeatureRemoteInterface,
+	local spineapi.FeatureLocalInterface,
+	cmd model.CmdType,
+	refresh model.FunctionType,
+	label string,
+) error {
+	counter, err := entity.Device().Sender().Write(local.Address(), remote.Address(), cmd)
+	if err != nil {
+		return fmt.Errorf("sending %s: %w", label, err)
+	}
+	if counter == nil {
+		return fmt.Errorf("sending %s returned no message counter", label)
+	}
+	result := make(chan model.ResultDataType, 1)
+	if err := local.AddResponseCallback(*counter, func(message spineapi.ResponseMessage) {
+		if data, ok := message.Data.(*model.ResultDataType); ok && data != nil {
+			result <- *data
+		}
+	}); err != nil {
+		return fmt.Errorf("waiting for %s result: %w", label, err)
+	}
+
+	timer := time.NewTimer(dhwWriteTimeout)
+	defer timer.Stop()
+	select {
+	case response := <-result:
+		if response.ErrorNumber != nil && *response.ErrorNumber != 0 {
+			return fmt.Errorf("%s rejected by device: error=%d", label, *response.ErrorNumber)
+		}
+		d.request(entity, refresh)
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return fmt.Errorf("timed out waiting for %s result", label)
+	}
+}
+
+func (d *DHWSystemFunction) localHvacFeature() spineapi.FeatureLocalInterface {
+	if d.localEntity == nil {
+		return nil
+	}
+	return d.localEntity.FeatureOfTypeAndRole(model.FeatureTypeTypeHvac, model.RoleTypeClient)
+}
+
+type resolvedDHWSysFn struct {
+	system             model.HvacSystemFunctionDataType
+	systemID           model.HvacSystemFunctionIdType
+	overrun            model.HvacOverrunDataType
+	overrunID          model.HvacOverrunIdType
+	currentModeType    model.HvacOperationModeTypeType
+	availableModeTypes []string
+	modeIDForType      map[string]model.HvacOperationModeIdType
+}
+
+func hvacServer(entity spineapi.EntityRemoteInterface) spineapi.FeatureRemoteInterface {
+	if entity == nil {
+		return nil
+	}
+	return entity.FeatureOfTypeAndRole(model.FeatureTypeTypeHvac, model.RoleTypeServer)
+}
+
+func resolveDHWSystemFunction(feature spineapi.FeatureRemoteInterface) (resolvedDHWSysFn, error) {
+	systemID, ok := dhwSystemFunctionID(feature)
+	if !ok {
+		return resolvedDHWSysFn{}, ErrDHWSysFnDataUnavailable
+	}
+	system, ok := hvacSystemFunction(feature, systemID)
+	if !ok || system.CurrentOperationModeId == nil {
+		return resolvedDHWSysFn{}, ErrDHWSysFnDataUnavailable
+	}
+	overrunID, ok := oneTimeDHWOverrunID(feature, systemID)
+	if !ok {
+		return resolvedDHWSysFn{}, ErrDHWSysFnDataUnavailable
+	}
+	overrun, ok := hvacOverrun(feature, overrunID)
+	if !ok || overrun.OverrunStatus == nil {
+		return resolvedDHWSysFn{}, ErrDHWSysFnDataUnavailable
+	}
+	modes, idForType, ok := operationModesForSystem(feature, systemID)
+	if !ok {
+		return resolvedDHWSysFn{}, ErrDHWSysFnDataUnavailable
+	}
+	currentMode, ok := operationModeType(feature, *system.CurrentOperationModeId)
+	if !ok {
+		return resolvedDHWSysFn{}, ErrDHWSysFnDataUnavailable
+	}
+	return resolvedDHWSysFn{
+		system:             system,
+		systemID:           systemID,
+		overrun:            overrun,
+		overrunID:          overrunID,
+		currentModeType:    currentMode,
+		availableModeTypes: modes,
+		modeIDForType:      idForType,
+	}, nil
+}
+
+func dhwSystemFunctionID(feature spineapi.FeatureRemoteInterface) (model.HvacSystemFunctionIdType, bool) {
+	data, ok := feature.DataCopy(model.FunctionTypeHvacSystemFunctionDescriptionListData).(*model.HvacSystemFunctionDescriptionListDataType)
+	if !ok || data == nil {
+		return 0, false
+	}
+	var found []model.HvacSystemFunctionIdType
+	for _, description := range data.HvacSystemFunctionDescriptionData {
+		if description.SystemFunctionId != nil && description.SystemFunctionType != nil &&
+			*description.SystemFunctionType == model.HvacSystemFunctionTypeTypeDhw {
+			found = append(found, *description.SystemFunctionId)
+		}
+	}
+	if len(found) != 1 {
+		return 0, false
+	}
+	return found[0], true
+}
+
+func hvacSystemFunction(feature spineapi.FeatureRemoteInterface, id model.HvacSystemFunctionIdType) (model.HvacSystemFunctionDataType, bool) {
+	data, ok := feature.DataCopy(model.FunctionTypeHvacSystemFunctionListData).(*model.HvacSystemFunctionListDataType)
+	if !ok || data == nil {
+		return model.HvacSystemFunctionDataType{}, false
+	}
+	for _, entry := range data.HvacSystemFunctionData {
+		if entry.SystemFunctionId != nil && *entry.SystemFunctionId == id {
+			return entry, true
+		}
+	}
+	return model.HvacSystemFunctionDataType{}, false
+}
+
+func oneTimeDHWOverrunID(feature spineapi.FeatureRemoteInterface, systemID model.HvacSystemFunctionIdType) (model.HvacOverrunIdType, bool) {
+	data, ok := feature.DataCopy(model.FunctionTypeHvacOverrunDescriptionListData).(*model.HvacOverrunDescriptionListDataType)
+	if !ok || data == nil {
+		return 0, false
+	}
+	var found []model.HvacOverrunIdType
+	for _, description := range data.HvacOverrunDescriptionData {
+		if description.OverrunId == nil || description.OverrunType == nil ||
+			*description.OverrunType != model.HvacOverrunTypeTypeOneTimeDhw ||
+			!containsSystemFunction(description.AffectedSystemFunctionId, systemID) {
+			continue
+		}
+		found = append(found, *description.OverrunId)
+	}
+	if len(found) != 1 {
+		return 0, false
+	}
+	return found[0], true
+}
+
+func hvacOverrun(feature spineapi.FeatureRemoteInterface, id model.HvacOverrunIdType) (model.HvacOverrunDataType, bool) {
+	data, ok := feature.DataCopy(model.FunctionTypeHvacOverrunListData).(*model.HvacOverrunListDataType)
+	if !ok || data == nil {
+		return model.HvacOverrunDataType{}, false
+	}
+	for _, entry := range data.HvacOverrunData {
+		if entry.OverrunId != nil && *entry.OverrunId == id {
+			return entry, true
+		}
+	}
+	return model.HvacOverrunDataType{}, false
+}
+
+func operationModesForSystem(
+	feature spineapi.FeatureRemoteInterface,
+	systemID model.HvacSystemFunctionIdType,
+) ([]string, map[string]model.HvacOperationModeIdType, bool) {
+	data, ok := feature.DataCopy(model.FunctionTypeHvacSystemFunctionOperationModeRelationListData).(*model.HvacSystemFunctionOperationModeRelationListDataType)
+	if !ok || data == nil {
+		return nil, nil, false
+	}
+	var modeIDs []model.HvacOperationModeIdType
+	for _, relation := range data.HvacSystemFunctionOperationModeRelationData {
+		if relation.SystemFunctionId != nil && *relation.SystemFunctionId == systemID {
+			modeIDs = relation.OperationModeId
+			break
+		}
+	}
+	if len(modeIDs) == 0 {
+		return nil, nil, false
+	}
+	modes := make([]string, 0, len(modeIDs))
+	idForType := make(map[string]model.HvacOperationModeIdType, len(modeIDs))
+	for _, id := range modeIDs {
+		modeType, ok := operationModeType(feature, id)
+		if !ok {
+			return nil, nil, false
+		}
+		modes = append(modes, string(modeType))
+		idForType[string(modeType)] = id
+	}
+	return modes, idForType, true
+}
+
+func operationModeType(feature spineapi.FeatureRemoteInterface, id model.HvacOperationModeIdType) (model.HvacOperationModeTypeType, bool) {
+	data, ok := feature.DataCopy(model.FunctionTypeHvacOperationModeDescriptionListData).(*model.HvacOperationModeDescriptionListDataType)
+	if !ok || data == nil {
+		return "", false
+	}
+	for _, description := range data.HvacOperationModeDescriptionData {
+		if description.OperationModeId != nil && *description.OperationModeId == id && description.OperationModeType != nil {
+			return *description.OperationModeType, true
+		}
+	}
+	return "", false
+}
+
+func containsSystemFunction(ids []model.HvacSystemFunctionIdType, want model.HvacSystemFunctionIdType) bool {
+	for _, id := range ids {
+		if id == want {
+			return true
+		}
+	}
+	return false
+}
+
+func boolPtrNotFalse(value *bool) bool {
+	return value == nil || *value
+}

--- a/eebus-bridge/internal/usecases/dhwsysfn_test.go
+++ b/eebus-bridge/internal/usecases/dhwsysfn_test.go
@@ -1,0 +1,184 @@
+package usecases
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	spineapi "github.com/enbility/spine-go/api"
+	"github.com/enbility/spine-go/mocks"
+	"github.com/enbility/spine-go/model"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestDHWSystemFunctionStateResolvesBoostAndModes(t *testing.T) {
+	feature := dhwSysFnFeature(t, true, true, nil)
+	entity := mocks.NewEntityRemoteInterface(t)
+	entity.On("FeatureOfTypeAndRole", model.FeatureTypeTypeHvac, model.RoleTypeServer).Return(feature)
+
+	state, err := (&DHWSystemFunction{}).State(entity)
+	if err != nil {
+		t.Fatalf("State() error = %v", err)
+	}
+	if state.BoostStatus != "inactive" || !state.BoostWritable || state.OperationMode != "auto" ||
+		!state.ModeWritable || len(state.AvailableModes) != 3 || state.AvailableModes[0] != "auto" ||
+		state.AvailableModes[1] != "on" || state.AvailableModes[2] != "off" {
+		t.Fatalf("State() = %+v", state)
+	}
+}
+
+func TestDHWSystemFunctionStateFailsClosedForAmbiguousDHWFunction(t *testing.T) {
+	feature := mocks.NewFeatureRemoteInterface(t)
+	feature.On("DataCopy", model.FunctionTypeHvacSystemFunctionDescriptionListData).Return(
+		&model.HvacSystemFunctionDescriptionListDataType{HvacSystemFunctionDescriptionData: []model.HvacSystemFunctionDescriptionDataType{
+			{SystemFunctionId: ptr(model.HvacSystemFunctionIdType(0)), SystemFunctionType: ptr(model.HvacSystemFunctionTypeTypeDhw)},
+			{SystemFunctionId: ptr(model.HvacSystemFunctionIdType(1)), SystemFunctionType: ptr(model.HvacSystemFunctionTypeTypeDhw)},
+		}},
+	)
+	entity := mocks.NewEntityRemoteInterface(t)
+	entity.On("FeatureOfTypeAndRole", model.FeatureTypeTypeHvac, model.RoleTypeServer).Return(feature)
+
+	_, err := (&DHWSystemFunction{}).State(entity)
+	if !errors.Is(err, ErrDHWSysFnDataUnavailable) {
+		t.Fatalf("State() error = %v, want ErrDHWSysFnDataUnavailable", err)
+	}
+}
+
+func TestDHWSystemFunctionWriteBoostUpdatesFullOverrunList(t *testing.T) {
+	feature := dhwSysFnFeature(t, true, true, nil)
+	local, entity, written := dhwSysFnWriteHarness(t, feature)
+	dhw := &DHWSystemFunction{localEntity: local}
+
+	if err := dhw.WriteBoost(context.Background(), entity, true); err != nil {
+		t.Fatalf("WriteBoost() error = %v", err)
+	}
+	if *written.cmd.HvacOverrunListData.HvacOverrunData[0].OverrunStatus != model.HvacOverrunStatusTypeFinished ||
+		*written.cmd.HvacOverrunListData.HvacOverrunData[1].OverrunStatus != model.HvacOverrunStatusTypeActive {
+		t.Fatalf("written overrun data = %+v", written.cmd.HvacOverrunListData)
+	}
+}
+
+func TestDHWSystemFunctionWriteOperationModeResolvesModeIDFromType(t *testing.T) {
+	feature := dhwSysFnFeature(t, true, true, nil)
+	local, entity, written := dhwSysFnWriteHarness(t, feature)
+	dhw := &DHWSystemFunction{localEntity: local}
+
+	if err := dhw.WriteOperationMode(context.Background(), entity, "off"); err != nil {
+		t.Fatalf("WriteOperationMode() error = %v", err)
+	}
+	if *written.cmd.HvacSystemFunctionListData.HvacSystemFunctionData[1].CurrentOperationModeId != model.HvacOperationModeIdType(2) {
+		t.Fatalf("written system function data = %+v", written.cmd.HvacSystemFunctionListData)
+	}
+
+	err := dhw.WriteOperationMode(context.Background(), entity, "eco")
+	if !errors.Is(err, ErrDHWSysFnInvalidMode) {
+		t.Fatalf("WriteOperationMode() error = %v, want ErrDHWSysFnInvalidMode", err)
+	}
+}
+
+func dhwSysFnFeature(t *testing.T, overrunWrite, systemWrite bool, overrunChangeable *bool) *mocks.FeatureRemoteInterface {
+	t.Helper()
+	feature := mocks.NewFeatureRemoteInterface(t)
+	feature.On("DataCopy", model.FunctionTypeHvacSystemFunctionDescriptionListData).Return(
+		&model.HvacSystemFunctionDescriptionListDataType{HvacSystemFunctionDescriptionData: []model.HvacSystemFunctionDescriptionDataType{
+			{SystemFunctionId: ptr(model.HvacSystemFunctionIdType(0)), SystemFunctionType: ptr(model.HvacSystemFunctionTypeTypeHeating)},
+			{SystemFunctionId: ptr(model.HvacSystemFunctionIdType(3)), SystemFunctionType: ptr(model.HvacSystemFunctionTypeTypeDhw)},
+		}},
+	).Maybe()
+	feature.On("DataCopy", model.FunctionTypeHvacSystemFunctionListData).Return(
+		&model.HvacSystemFunctionListDataType{HvacSystemFunctionData: []model.HvacSystemFunctionDataType{
+			{SystemFunctionId: ptr(model.HvacSystemFunctionIdType(0)), CurrentOperationModeId: ptr(model.HvacOperationModeIdType(9))},
+			{
+				SystemFunctionId:            ptr(model.HvacSystemFunctionIdType(3)),
+				CurrentOperationModeId:      ptr(model.HvacOperationModeIdType(0)),
+				IsOperationModeIdChangeable: ptr(true),
+			},
+		}},
+	).Maybe()
+	feature.On("DataCopy", model.FunctionTypeHvacOperationModeDescriptionListData).Return(
+		&model.HvacOperationModeDescriptionListDataType{HvacOperationModeDescriptionData: []model.HvacOperationModeDescriptionDataType{
+			{OperationModeId: ptr(model.HvacOperationModeIdType(0)), OperationModeType: ptr(model.HvacOperationModeTypeTypeAuto)},
+			{OperationModeId: ptr(model.HvacOperationModeIdType(1)), OperationModeType: ptr(model.HvacOperationModeTypeTypeOn)},
+			{OperationModeId: ptr(model.HvacOperationModeIdType(2)), OperationModeType: ptr(model.HvacOperationModeTypeTypeOff)},
+			{OperationModeId: ptr(model.HvacOperationModeIdType(9)), OperationModeType: ptr(model.HvacOperationModeTypeTypeEco)},
+		}},
+	).Maybe()
+	feature.On("DataCopy", model.FunctionTypeHvacSystemFunctionOperationModeRelationListData).Return(
+		&model.HvacSystemFunctionOperationModeRelationListDataType{HvacSystemFunctionOperationModeRelationData: []model.HvacSystemFunctionOperationModeRelationDataType{
+			{SystemFunctionId: ptr(model.HvacSystemFunctionIdType(3)), OperationModeId: []model.HvacOperationModeIdType{0, 1, 2}},
+		}},
+	).Maybe()
+	feature.On("DataCopy", model.FunctionTypeHvacOverrunDescriptionListData).Return(
+		&model.HvacOverrunDescriptionListDataType{HvacOverrunDescriptionData: []model.HvacOverrunDescriptionDataType{
+			{
+				OverrunId:                ptr(model.HvacOverrunIdType(4)),
+				OverrunType:              ptr(model.HvacOverrunTypeTypeParty),
+				AffectedSystemFunctionId: []model.HvacSystemFunctionIdType{3},
+			},
+			{
+				OverrunId:                ptr(model.HvacOverrunIdType(7)),
+				OverrunType:              ptr(model.HvacOverrunTypeTypeOneTimeDhw),
+				AffectedSystemFunctionId: []model.HvacSystemFunctionIdType{3},
+			},
+		}},
+	).Maybe()
+	feature.On("DataCopy", model.FunctionTypeHvacOverrunListData).Return(
+		&model.HvacOverrunListDataType{HvacOverrunData: []model.HvacOverrunDataType{
+			{OverrunId: ptr(model.HvacOverrunIdType(4)), OverrunStatus: ptr(model.HvacOverrunStatusTypeFinished)},
+			{
+				OverrunId:                 ptr(model.HvacOverrunIdType(7)),
+				OverrunStatus:             ptr(model.HvacOverrunStatusTypeInactive),
+				IsOverrunStatusChangeable: overrunChangeable,
+			},
+		}},
+	).Maybe()
+	overrunOperation := mocks.NewOperationsInterface(t)
+	overrunOperation.On("Write").Return(overrunWrite).Maybe()
+	overrunOperation.On("Read").Return(true).Maybe()
+	systemOperation := mocks.NewOperationsInterface(t)
+	systemOperation.On("Write").Return(systemWrite).Maybe()
+	systemOperation.On("Read").Return(true).Maybe()
+	feature.On("Operations").Return(map[model.FunctionType]spineapi.OperationsInterface{
+		model.FunctionTypeHvacOverrunListData:            overrunOperation,
+		model.FunctionTypeHvacSystemFunctionListData:     systemOperation,
+		model.FunctionTypeHvacOverrunDescriptionListData: overrunOperation,
+	}).Maybe()
+	feature.On("Address").Return(&model.FeatureAddressType{}).Maybe()
+	feature.On("String").Return("remote hvac").Maybe()
+	return feature
+}
+
+type writtenDhwSysFn struct {
+	cmd model.CmdType
+}
+
+func dhwSysFnWriteHarness(
+	t *testing.T,
+	remote *mocks.FeatureRemoteInterface,
+) (*mocks.EntityLocalInterface, *mocks.EntityRemoteInterface, *writtenDhwSysFn) {
+	t.Helper()
+	localAddress := &model.FeatureAddressType{}
+	local := mocks.NewFeatureLocalInterface(t)
+	local.On("Address").Return(localAddress)
+	local.On("AddResponseCallback", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+		callback := args.Get(1).(func(spineapi.ResponseMessage))
+		callback(spineapi.ResponseMessage{Data: &model.ResultDataType{ErrorNumber: ptr(model.ErrorNumberType(0))}})
+	}).Return(nil)
+	local.On("RequestRemoteData", mock.Anything, mock.Anything, mock.Anything, remote).
+		Return(ptr(model.MsgCounterType(10)), (*model.ErrorType)(nil))
+
+	written := &writtenDhwSysFn{}
+	counter := model.MsgCounterType(9)
+	sender := mocks.NewSenderInterface(t)
+	sender.On("Write", localAddress, mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+		written.cmd = args.Get(2).(model.CmdType)
+	}).Return(&counter, nil)
+	device := mocks.NewDeviceRemoteInterface(t)
+	device.On("Sender").Return(sender)
+	entity := mocks.NewEntityRemoteInterface(t)
+	entity.On("FeatureOfTypeAndRole", model.FeatureTypeTypeHvac, model.RoleTypeServer).Return(remote)
+	entity.On("Device").Return(device)
+	localEntity := mocks.NewEntityLocalInterface(t)
+	localEntity.On("FeatureOfTypeAndRole", model.FeatureTypeTypeHvac, model.RoleTypeClient).Return(local)
+	return localEntity, entity, written
+}

--- a/eebus-bridge/internal/usecases/dhwsysfn_test.go
+++ b/eebus-bridge/internal/usecases/dhwsysfn_test.go
@@ -27,6 +27,44 @@ func TestDHWSystemFunctionStateResolvesBoostAndModes(t *testing.T) {
 	}
 }
 
+// Devices may omit the optional changeability flags entirely (the VR940
+// does for overruns); an advertised write operation must win then.
+func TestDHWSystemFunctionStateModeWritableWithoutChangeableFlag(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		flag         *bool
+		wantWritable bool
+	}{
+		{"nil flag stays writable", nil, true},
+		{"explicit false blocks", ptr(false), false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			feature := dhwSysFnFeatureWithModeChangeable(t, true, true, nil, tc.flag)
+			entity := mocks.NewEntityRemoteInterface(t)
+			entity.On("FeatureOfTypeAndRole", model.FeatureTypeTypeHvac, model.RoleTypeServer).Return(feature)
+
+			state, err := (&DHWSystemFunction{}).State(entity)
+			if err != nil {
+				t.Fatalf("State() error = %v", err)
+			}
+			if state.ModeWritable != tc.wantWritable {
+				t.Fatalf("ModeWritable = %t, want %t", state.ModeWritable, tc.wantWritable)
+			}
+		})
+	}
+}
+
+func TestDHWSystemFunctionWriteBoostDeviceRejection(t *testing.T) {
+	feature := dhwSysFnFeature(t, true, true, nil)
+	local, entity, _ := dhwSysFnWriteHarnessWithErrno(t, feature, 2)
+	dhw := &DHWSystemFunction{localEntity: local}
+
+	err := dhw.WriteBoost(context.Background(), entity, true)
+	if !errors.Is(err, ErrDHWSysFnRejected) {
+		t.Fatalf("WriteBoost() error = %v, want ErrDHWSysFnRejected", err)
+	}
+}
+
 func TestDHWSystemFunctionStateFailsClosedForAmbiguousDHWFunction(t *testing.T) {
 	feature := mocks.NewFeatureRemoteInterface(t)
 	feature.On("DataCopy", model.FunctionTypeHvacSystemFunctionDescriptionListData).Return(
@@ -77,6 +115,14 @@ func TestDHWSystemFunctionWriteOperationModeResolvesModeIDFromType(t *testing.T)
 }
 
 func dhwSysFnFeature(t *testing.T, overrunWrite, systemWrite bool, overrunChangeable *bool) *mocks.FeatureRemoteInterface {
+	return dhwSysFnFeatureWithModeChangeable(t, overrunWrite, systemWrite, overrunChangeable, ptr(true))
+}
+
+func dhwSysFnFeatureWithModeChangeable(
+	t *testing.T,
+	overrunWrite, systemWrite bool,
+	overrunChangeable, modeChangeable *bool,
+) *mocks.FeatureRemoteInterface {
 	t.Helper()
 	feature := mocks.NewFeatureRemoteInterface(t)
 	feature.On("DataCopy", model.FunctionTypeHvacSystemFunctionDescriptionListData).Return(
@@ -91,7 +137,7 @@ func dhwSysFnFeature(t *testing.T, overrunWrite, systemWrite bool, overrunChange
 			{
 				SystemFunctionId:            ptr(model.HvacSystemFunctionIdType(3)),
 				CurrentOperationModeId:      ptr(model.HvacOperationModeIdType(0)),
-				IsOperationModeIdChangeable: ptr(true),
+				IsOperationModeIdChangeable: modeChangeable,
 			},
 		}},
 	).Maybe()
@@ -156,16 +202,24 @@ func dhwSysFnWriteHarness(
 	t *testing.T,
 	remote *mocks.FeatureRemoteInterface,
 ) (*mocks.EntityLocalInterface, *mocks.EntityRemoteInterface, *writtenDhwSysFn) {
+	return dhwSysFnWriteHarnessWithErrno(t, remote, 0)
+}
+
+func dhwSysFnWriteHarnessWithErrno(
+	t *testing.T,
+	remote *mocks.FeatureRemoteInterface,
+	errno model.ErrorNumberType,
+) (*mocks.EntityLocalInterface, *mocks.EntityRemoteInterface, *writtenDhwSysFn) {
 	t.Helper()
 	localAddress := &model.FeatureAddressType{}
 	local := mocks.NewFeatureLocalInterface(t)
 	local.On("Address").Return(localAddress)
 	local.On("AddResponseCallback", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
 		callback := args.Get(1).(func(spineapi.ResponseMessage))
-		callback(spineapi.ResponseMessage{Data: &model.ResultDataType{ErrorNumber: ptr(model.ErrorNumberType(0))}})
+		callback(spineapi.ResponseMessage{Data: &model.ResultDataType{ErrorNumber: ptr(errno)}})
 	}).Return(nil)
 	local.On("RequestRemoteData", mock.Anything, mock.Anything, mock.Anything, remote).
-		Return(ptr(model.MsgCounterType(10)), (*model.ErrorType)(nil))
+		Return(ptr(model.MsgCounterType(10)), (*model.ErrorType)(nil)).Maybe()
 
 	written := &writtenDhwSysFn{}
 	counter := model.MsgCounterType(9)

--- a/eebus-bridge/proto/eebus/v1/dhw_service.proto
+++ b/eebus-bridge/proto/eebus/v1/dhw_service.proto
@@ -13,6 +13,10 @@ service DHWService {
   rpc GetDHWSetpoint(DeviceRequest) returns (DHWSetpoint);
   rpc SetDHWSetpoint(SetDHWSetpointRequest) returns (Empty);
   rpc SubscribeDHWEvents(DeviceRequest) returns (stream DHWEvent);
+  rpc GetDHWSystemFunction(DeviceRequest) returns (DHWSystemFunctionState);
+  rpc SetDHWBoost(SetDHWBoostRequest) returns (Empty);
+  rpc SetDHWOperationMode(SetDHWOperationModeRequest) returns (Empty);
+  rpc SubscribeDHWSystemFunctionEvents(DeviceRequest) returns (stream DHWSystemFunctionEvent);
 }
 
 message DHWSetpoint {
@@ -38,4 +42,42 @@ message DHWEvent {
   string ski = 1;
   DHWEventType event_type = 2;
   DHWSetpoint setpoint = 3;
+}
+
+enum DHWBoostStatus {
+  DHW_BOOST_STATUS_UNSPECIFIED = 0;
+  DHW_BOOST_STATUS_INACTIVE = 1;
+  DHW_BOOST_STATUS_ACTIVE = 2;
+  DHW_BOOST_STATUS_RUNNING = 3;
+  DHW_BOOST_STATUS_FINISHED = 4;
+}
+
+message DHWSystemFunctionState {
+  DHWBoostStatus boost_status = 1;
+  bool boost_writable = 2;
+  string operation_mode = 3;
+  repeated string available_modes = 4;
+  bool mode_writable = 5;
+}
+
+message SetDHWBoostRequest {
+  string ski = 1;
+  bool active = 2;
+}
+
+message SetDHWOperationModeRequest {
+  string ski = 1;
+  string mode = 2;
+}
+
+enum DHWSystemFunctionEventType {
+  DHW_SYSTEM_FUNCTION_EVENT_UNSPECIFIED = 0;
+  DHW_SYSTEM_FUNCTION_EVENT_SUPPORT_UPDATED = 1;
+  DHW_SYSTEM_FUNCTION_EVENT_STATE_UPDATED = 2;
+}
+
+message DHWSystemFunctionEvent {
+  string ski = 1;
+  DHWSystemFunctionEventType event_type = 2;
+  DHWSystemFunctionState state = 3;
 }


### PR DESCRIPTION
## What

Stage B of the DHW-boost feature (follow-up to the stage-4 probe spike, #95):

**Bridge:** new `DHWSystemFunction` client use case (`configurationOfDhwSystemFunction` v1.0.0, actor ConfigurationAppliance → DHWCircuit). Resolves the dhw system function, `oneTimeDhw` overrun and operation modes at runtime from device-advertised description/relation lists — nothing hardcoded. `WriteBoost` toggles the overrun (`active`/`inactive`), `WriteOperationMode` patches `CurrentOperationModeId`; both full-list-copy writes with awaited results + re-read (dhw.go pattern). Missing optional changeability flags don't block writes the device advertises via operations (VR940 fw 404.1.29 omits `IsOverrunStatusChangeable`) — only explicit `false` blocks.

**Proto:** `DHWService` + `GetDHWSystemFunction` / `SetDHWBoost` / `SetDHWOperationMode` / `SubscribeDHWSystemFunctionEvents`; both stub sets regenerated (buf / grpcio-tools 1.78.0).

**HA:** `switch.dhw_boost` (is_on = active/running, `boost_status` attribute) and `select.dhw_operation_mode` (options from device data: auto/on/off on the VR940), coordinator poll + stream + writes, de/en translations, icons, README.

## Hardware basis

Boost write path proven live on the VR940 in stage 4b (#95): activate → ACCEPTED → `running` in 2s → cancel → `finished`. `hvacSystemFunctionListData` also advertised rw with `isOperationModeIdChangeable=true`.

## Workflow

Implemented by Codex (Stage-B spec), verified locally (full `go test -race`, ruff, mypy strict, pytest 67 — Codex sandbox couldn't run grpc TCP tests/mypy/stub regen; Python stubs regenerated properly outside), independent Codex review found 2 P2s (mode-writable nil-flag inconsistency, rejection→Internal mapping) — both fixed with tests in 64c0a22.