### PR TITLE
Expose DHW as Home Assistant water heater

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,7 @@ docker-compose up -d eebus-bridge        # ghcr.io image, host networking
 
 ### Python integration
 - `coordinator.py` (`EebusCoordinator`) — central hub. Primary path is gRPC **streaming** (push); on stream failure it falls back to **polling** (`POLL_INTERVAL = 5min`) and reconnects the stream in the background. Polling only reconciles state streams can't carry (scoped energy, heartbeat, support flags). `FLAT_MEASUREMENT_TYPE_TO_KEY` maps bridge `GetMeasurements` entry types to per-phase/grid sensor keys.
-- Platforms: `sensor`, `number`, `switch`, `select`, `binary_sensor` — all read coordinator data; `entity.py` is the shared base. `select.eebus_compressor_flexibility` exposes OHPCF's `on`/`paused`/`off` as three distinct options — a plain switch collapses PAUSED into the same state as AVAILABLE/COMPLETED/STOPPED, losing the running-vs-stopped distinction.
+- Platforms: `sensor`, `number`, `switch`, `select`, `binary_sensor`, `water_heater` — all read coordinator data; `entity.py` is the shared base. `select.eebus_compressor_flexibility` exposes OHPCF's `on`/`paused`/`off` as three distinct options — a plain switch collapses PAUSED into the same state as AVAILABLE/COMPLETED/STOPPED, losing the running-vs-stopped distinction.
 - `config_flow.py` — bridge host/port + device SKI pairing. `iot_class: local_push`, `quality_scale: platinum` (see `quality_scale.yaml`).
 - Tests are plain unit tests (`unittest.mock.MagicMock` for HA objects, no running `hass` instance); `conftest.py` is currently empty. Protobuf messages must be real generated types, not duck-typed namespaces — mypy/tests will reject a hand-rolled stand-in.
 

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ Lokale Integration von EEBUS-faehigen Waermepumpen in Home Assistant ueber das *
 - **Leistungsmessung** -- Elektrische Verbrauchsdaten der Waermepumpe in Echtzeit
 - **Discovery & Pairing** -- mDNS-Erkennung und SKI-basiertes Pairing ueber den HA Config Flow
 - **Heartbeat-Ueberwachung** -- Sicherheitsrelevanter EEBUS-Heartbeat mit Failsafe-Fallback
-- **Warmwasser-Solltemperatur** -- Lokales Lesen und Setzen des vom Geraet
-  angebotenen DHW-Sollwerts mit dynamischen Min/Max/Schritt-Grenzen
+- **Warmwasser-Entitaet** -- Home-Assistant-`water_heater` mit Ist- und
+  Solltemperatur, dynamischen Min/Max/Schritt-Grenzen und Betriebsart
 - **Warmwasser-Isttemperatur** -- Lokales Push-Monitoring ueber den EEBUS
   `monitoringOfDhwTemperature`-Use-Case
 - **Warmwasser-Boost und Betriebsart** -- Lokales Aktivieren der Einmalladung
@@ -121,11 +121,10 @@ Die Integration nutzt **gRPC Streaming** (Server-Sent Events) fuer Echtzeit-Upda
 |--------|-----|-------------|
 | `number.eebus_lpc_limit` | number | LPC-Limit setzen (W) |
 | `number.eebus_failsafe_limit` | number | Failsafe-Grenze (W), standardmaessig deaktiviert |
-| `number.eebus_dhw_setpoint` | number | Warmwasser-Solltemperatur; Bereich und Schrittweite kommen vom Geraet |
+| `water_heater.eebus_domestic_hot_water` | water_heater | Warmwasser mit Ist-/Solltemperatur und Betriebsart; Grenzen und Optionen kommen vom Geraet |
 | `switch.eebus_lpc_active` | switch | Limit aktivieren/deaktivieren |
 | `switch.eebus_heartbeat` | switch | Heartbeat an/aus, standardmaessig deaktiviert |
 | `switch.eebus_dhw_boost` | switch | Warmwasser-Einmalladung aktivieren/deaktivieren |
-| `select.eebus_dhw_operation_mode` | select | Warmwasser-Betriebsart; Optionen kommen vom Geraet |
 | `select.eebus_compressor_flexibility` | select | OHPCF-Verdichter-Flexibilitaet: `on`/`paused`/`off`, nur vorhanden wenn WP ein Angebot meldet |
 
 ### Diagnose

--- a/custom_components/eebus/__init__.py
+++ b/custom_components/eebus/__init__.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 
 from .const import (
     CONF_BATTERY_CHARGED_ENERGY_ENTITY,
@@ -21,6 +22,7 @@ from .const import (
     CONF_PV_PEAK_POWER_ENTITY,
     CONF_PV_POWER_ENTITY,
     CONF_PV_YIELD_ENERGY_ENTITY,
+    DOMAIN,
     PLATFORMS,
 )
 from .coordinator import EebusCoordinator
@@ -57,11 +59,24 @@ async def async_setup_entry(hass: HomeAssistant, entry: EebusConfigEntry) -> boo
 
     entry.runtime_data = coordinator
 
+    _remove_replaced_dhw_entities(hass, coordinator.ski)
+
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     entry.async_on_unload(entry.add_update_listener(_async_reload_entry))
 
     return True
+
+
+def _remove_replaced_dhw_entities(hass: HomeAssistant, ski: str) -> None:
+    """Remove registry entries superseded by the combined water-heater entity."""
+    entity_registry = er.async_get(hass)
+    for domain, unique_id in (
+        ("number", f"{ski}_dhw_setpoint"),
+        ("select", f"{ski}_dhw_operation_mode"),
+    ):
+        if entity_id := entity_registry.async_get_entity_id(domain, DOMAIN, unique_id):
+            entity_registry.async_remove(entity_id)
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: EebusConfigEntry) -> bool:

--- a/custom_components/eebus/const.py
+++ b/custom_components/eebus/const.py
@@ -36,6 +36,7 @@ PLATFORMS = [
     Platform.SELECT,
     Platform.SENSOR,
     Platform.SWITCH,
+    Platform.WATER_HEATER,
 ]
 
 PARALLEL_UPDATES = 0  # Coordinator-based, no per-entity polling

--- a/custom_components/eebus/icons.json
+++ b/custom_components/eebus/icons.json
@@ -20,20 +20,20 @@
     },
     "number": {
       "lpc_limit": { "default": "mdi:speedometer" },
-      "failsafe_limit": { "default": "mdi:shield-alert" },
-      "dhw_setpoint": { "default": "mdi:water-thermometer" }
+      "failsafe_limit": { "default": "mdi:shield-alert" }
     },
     "switch": {
       "lpc_active": { "default": "mdi:power-plug" },
       "heartbeat": { "default": "mdi:heart-pulse" },
       "dhw_boost": { "default": "mdi:water-boiler" }
     },
-    "select": {
-      "dhw_operation_mode": { "default": "mdi:water-boiler-auto" }
-    },
+    "select": {},
     "binary_sensor": {
       "connected": { "default": "mdi:lan-connect" },
       "heartbeat_ok": { "default": "mdi:heart-pulse" }
+    },
+    "water_heater": {
+      "domestic_hot_water": { "default": "mdi:water-boiler" }
     }
   }
 }

--- a/custom_components/eebus/number.py
+++ b/custom_components/eebus/number.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from homeassistant.components.number import NumberDeviceClass, NumberEntity, NumberMode
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import EntityCategory, UnitOfPower, UnitOfTemperature
+from homeassistant.const import EntityCategory, UnitOfPower
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -24,7 +24,6 @@ async def async_setup_entry(
     async_add_entities([
         EebusLPCLimitNumber(coordinator),
         EebusFailsafeLimitNumber(coordinator),
-        EebusDHWSetpointNumber(coordinator),
     ])
 
 
@@ -118,61 +117,4 @@ class EebusFailsafeLimitNumber(EebusEntity, NumberEntity):
     async def async_set_native_value(self, value: float) -> None:
         """Set new failsafe limit via gRPC."""
         await self.coordinator.async_write_failsafe_limit(value)
-        await self.coordinator.async_request_refresh()
-
-
-class EebusDHWSetpointNumber(EebusEntity, NumberEntity):
-    """Domestic-hot-water target temperature advertised by the heat pump."""
-
-    _attr_device_class = NumberDeviceClass.TEMPERATURE
-    _attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
-    _attr_mode = NumberMode.BOX
-    _attr_translation_key = "dhw_setpoint"
-    _attr_entity_category = EntityCategory.CONFIG
-
-    def __init__(self, coordinator: EebusCoordinator) -> None:
-        """Initialize the DHW setpoint number."""
-        super().__init__(coordinator)
-        self._attr_unique_id = f"{coordinator.ski}_dhw_setpoint"
-
-    @property
-    def native_value(self) -> float | None:
-        """Return the current DHW target."""
-        setpoint = (self.coordinator.data or {}).get("dhw_setpoint")
-        return None if setpoint is None else float(setpoint["value_celsius"])
-
-    @property
-    def native_min_value(self) -> float:
-        """Return the device-provided lower bound."""
-        setpoint = (self.coordinator.data or {}).get("dhw_setpoint")
-        return float(setpoint["min_celsius"]) if setpoint is not None else 0.0
-
-    @property
-    def native_max_value(self) -> float:
-        """Return the device-provided upper bound."""
-        setpoint = (self.coordinator.data or {}).get("dhw_setpoint")
-        return float(setpoint["max_celsius"]) if setpoint is not None else 100.0
-
-    @property
-    def native_step(self) -> float:
-        """Return the device-provided increment."""
-        setpoint = (self.coordinator.data or {}).get("dhw_setpoint")
-        return float(setpoint["step_celsius"]) if setpoint is not None else 1.0
-
-    @property
-    def available(self) -> bool:
-        """Expose control only for a negotiated writable DHW setpoint."""
-        if not super().available:
-            return False
-        data = self.coordinator.data or {}
-        setpoint = data.get("dhw_setpoint")
-        return bool(
-            data.get("dhw_supported") is not False
-            and setpoint is not None
-            and setpoint.get("writable")
-        )
-
-    async def async_set_native_value(self, value: float) -> None:
-        """Set the DHW target via gRPC."""
-        await self.coordinator.async_write_dhw_setpoint(value)
         await self.coordinator.async_request_refresh()

--- a/custom_components/eebus/quality_scale.yaml
+++ b/custom_components/eebus/quality_scale.yaml
@@ -49,7 +49,7 @@ rules:
   docs-supported-devices: done
   docs-supported-functions:
     status: done
-    comment: README lists DHW target, boost, operation mode, and their device-provided constraints/options.
+    comment: README lists the DHW water heater, boost, and their device-provided constraints/options.
   docs-troubleshooting: done
   docs-use-cases: done
   dynamic-devices:

--- a/custom_components/eebus/select.py
+++ b/custom_components/eebus/select.py
@@ -36,7 +36,6 @@ async def async_setup_entry(
     # client is active and a compatible heat pump was found.
     if coordinator.data and coordinator.data.get("ohpcf_supported"):
         entities.append(EebusCompressorFlexibilitySelect(coordinator))
-    entities.append(EebusDHWOperationModeSelect(coordinator))
     async_add_entities(entities)
 
 
@@ -114,58 +113,4 @@ class EebusCompressorFlexibilitySelect(EebusEntity, SelectEntity):
         else:
             action = proto_stubs.OHPCFAction.OHPCF_ACTION_ABORT
         await self.coordinator.async_control_compressor(action)
-        await self.coordinator.async_request_refresh()
-
-
-class EebusDHWOperationModeSelect(EebusEntity, SelectEntity):
-    """Select for domestic-hot-water operation mode."""
-
-    _attr_translation_key = "dhw_operation_mode"
-    _attr_entity_category = EntityCategory.CONFIG
-
-    def __init__(self, coordinator: EebusCoordinator) -> None:
-        """Initialize."""
-        super().__init__(coordinator)
-        self._attr_unique_id = f"{coordinator.ski}_dhw_operation_mode"
-
-    def _state(self) -> dict[str, Any] | None:
-        if self.coordinator.data is None:
-            return None
-        return self.coordinator.data.get("dhw_system_function")
-
-    @property
-    def available(self) -> bool:
-        """Available only for writable DHW operation modes."""
-        if not super().available:
-            return False
-        data = self.coordinator.data or {}
-        state = self._state()
-        return bool(
-            data.get("dhw_sysfn_supported") is not False
-            and state is not None
-            and state.get("mode_writable")
-            and state.get("available_modes")
-        )
-
-    @property
-    def options(self) -> list[str]:
-        """Return operation modes advertised by the device."""
-        state = self._state()
-        if state is None:
-            return []
-        modes = state.get("available_modes")
-        return list(modes) if isinstance(modes, list) else []
-
-    @property
-    def current_option(self) -> str | None:
-        """Return the current DHW operation mode."""
-        state = self._state()
-        if state is None:
-            return None
-        mode = state.get("operation_mode")
-        return mode if isinstance(mode, str) and mode else None
-
-    async def async_select_option(self, option: str) -> None:
-        """Set the DHW operation mode."""
-        await self.coordinator.async_set_dhw_operation_mode(option)
         await self.coordinator.async_request_refresh()

--- a/custom_components/eebus/strings.json
+++ b/custom_components/eebus/strings.json
@@ -108,11 +108,9 @@
     },
     "number": {
       "lpc_limit": { "name": "LPC Limit" },
-      "failsafe_limit": { "name": "Failsafe Limit" },
-      "dhw_setpoint": { "name": "Domestic Hot Water Target Temperature" }
+      "failsafe_limit": { "name": "Failsafe Limit" }
     },
     "select": {
-      "dhw_operation_mode": { "name": "Domestic Hot Water Operation Mode" },
       "compressor_flexibility": {
         "name": "Compressor Flexibility",
         "state": {
@@ -130,6 +128,9 @@
     "binary_sensor": {
       "connected": { "name": "Connected" },
       "heartbeat_ok": { "name": "Heartbeat OK" }
+    },
+    "water_heater": {
+      "domestic_hot_water": { "name": "Domestic Hot Water" }
     }
   }
 }

--- a/custom_components/eebus/tests/test_dhw.py
+++ b/custom_components/eebus/tests/test_dhw.py
@@ -6,13 +6,14 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import grpc
 from grpc.aio import AioRpcError, Metadata
+from homeassistant.components.water_heater import WaterHeaterEntityFeature
+from homeassistant.const import ATTR_TEMPERATURE
 
 from custom_components.eebus import proto_stubs
 from custom_components.eebus.coordinator import EebusCoordinator
 from custom_components.eebus.generated.eebus.v1 import dhw_service_pb2
-from custom_components.eebus.number import EebusDHWSetpointNumber
-from custom_components.eebus.select import EebusDHWOperationModeSelect
 from custom_components.eebus.switch import EebusDHWBoostSwitch
+from custom_components.eebus.water_heater import EebusDHWWaterHeater
 
 
 def _coordinator(data=None):
@@ -72,12 +73,13 @@ def test_read_dhw_setpoint_not_found_marks_unsupported():
     assert coordinator._dhw_supported is False
 
 
-def test_dhw_number_uses_dynamic_constraints_and_writes():
-    """The HA number mirrors the heat pump range and calls the DHW RPC."""
+def test_dhw_water_heater_combines_temperatures_modes_and_writes():
+    """The water heater combines measured temperature, target, and operation mode."""
     coordinator = MagicMock()
     coordinator.ski = "test-ski"
     coordinator.data = {
         "connected": True,
+        "dhw_temperature_c": 44.5,
         "dhw_supported": True,
         "dhw_setpoint": {
             "value_celsius": 46,
@@ -86,20 +88,78 @@ def test_dhw_number_uses_dynamic_constraints_and_writes():
             "step_celsius": 1,
             "writable": True,
         },
+        "dhw_sysfn_supported": True,
+        "dhw_system_function": {
+            "boost_status": "inactive",
+            "boost_writable": True,
+            "operation_mode": "auto",
+            "available_modes": ["auto", "on", "off"],
+            "mode_writable": True,
+        },
     }
     coordinator.async_write_dhw_setpoint = AsyncMock()
+    coordinator.async_set_dhw_operation_mode = AsyncMock()
     coordinator.async_request_refresh = AsyncMock()
-    number = EebusDHWSetpointNumber(coordinator)
+    water_heater = EebusDHWWaterHeater(coordinator)
 
-    assert number.native_value == 46
-    assert number.native_min_value == 35
-    assert number.native_max_value == 70
-    assert number.native_step == 1
-    assert number.available is True
+    assert water_heater.current_temperature == 44.5
+    assert water_heater.target_temperature == 46
+    assert water_heater.min_temp == 35
+    assert water_heater.max_temp == 70
+    assert water_heater.target_temperature_step == 1
+    assert water_heater.current_operation == "auto"
+    assert water_heater.operation_list == ["auto", "on", "off"]
+    assert water_heater.supported_features == (
+        WaterHeaterEntityFeature.TARGET_TEMPERATURE
+        | WaterHeaterEntityFeature.OPERATION_MODE
+    )
+    assert water_heater.available is True
 
-    asyncio.run(number.async_set_native_value(47))
+    asyncio.run(water_heater.async_set_temperature(**{ATTR_TEMPERATURE: 47}))
     coordinator.async_write_dhw_setpoint.assert_awaited_once_with(47)
-    coordinator.async_request_refresh.assert_awaited_once()
+    asyncio.run(water_heater.async_set_operation_mode("off"))
+    coordinator.async_set_dhw_operation_mode.assert_awaited_once_with("off")
+    assert coordinator.async_request_refresh.await_count == 2
+
+
+def test_dhw_water_heater_is_read_only_when_controls_are_not_writable():
+    """Measured DHW data remains visible without advertising write controls."""
+    coordinator = MagicMock()
+    coordinator.ski = "test-ski"
+    coordinator.data = {"connected": True, "dhw_temperature_c": 44.5}
+
+    water_heater = EebusDHWWaterHeater(coordinator)
+
+    assert water_heater.available is True
+    assert water_heater.current_temperature == 44.5
+    assert water_heater.target_temperature is None
+    assert water_heater.supported_features == WaterHeaterEntityFeature(0)
+
+
+def test_dhw_water_heater_ignores_stale_unsupported_controls():
+    """Support updates hide stale target and mode data retained between refreshes."""
+    coordinator = MagicMock()
+    coordinator.ski = "test-ski"
+    coordinator.data = {
+        "connected": True,
+        "dhw_temperature_c": 44.5,
+        "dhw_supported": False,
+        "dhw_setpoint": {"value_celsius": 46, "writable": True},
+        "dhw_sysfn_supported": False,
+        "dhw_system_function": {
+            "operation_mode": "auto",
+            "available_modes": ["auto", "off"],
+            "mode_writable": True,
+        },
+    }
+
+    water_heater = EebusDHWWaterHeater(coordinator)
+
+    assert water_heater.available is True
+    assert water_heater.target_temperature is None
+    assert water_heater.current_operation is None
+    assert water_heater.operation_list is None
+    assert water_heater.supported_features == WaterHeaterEntityFeature(0)
 
 
 def test_dhw_event_pushes_setpoint():
@@ -211,8 +271,8 @@ def test_dhw_system_function_event_pushes_state():
     assert pushed["dhw_sysfn_supported"] is True
 
 
-def test_dhw_boost_switch_and_operation_mode_select():
-    """The HA entities mirror coordinator state and call the DHW sysfn RPCs."""
+def test_dhw_boost_switch():
+    """The HA switch mirrors coordinator boost state and calls the DHW RPC."""
     coordinator = MagicMock()
     coordinator.ski = "test-ski"
     coordinator.data = {
@@ -227,7 +287,6 @@ def test_dhw_boost_switch_and_operation_mode_select():
         },
     }
     coordinator.async_set_dhw_boost = AsyncMock()
-    coordinator.async_set_dhw_operation_mode = AsyncMock()
     coordinator.async_request_refresh = AsyncMock()
 
     switch = EebusDHWBoostSwitch(coordinator)
@@ -236,10 +295,3 @@ def test_dhw_boost_switch_and_operation_mode_select():
     assert switch.extra_state_attributes == {"boost_status": "running"}
     asyncio.run(switch.async_turn_off())
     coordinator.async_set_dhw_boost.assert_awaited_once_with(False)
-
-    select = EebusDHWOperationModeSelect(coordinator)
-    assert select.available is True
-    assert select.options == ["auto", "on", "off"]
-    assert select.current_option == "auto"
-    asyncio.run(select.async_select_option("off"))
-    coordinator.async_set_dhw_operation_mode.assert_awaited_once_with("off")

--- a/custom_components/eebus/tests/test_init.py
+++ b/custom_components/eebus/tests/test_init.py
@@ -1,6 +1,6 @@
 """Tests for EEBUS integration setup and unload."""
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
 
@@ -21,16 +21,25 @@ async def test_setup_entry():
     entry.async_on_unload = MagicMock()
     entry.add_update_listener = MagicMock()
 
-    with patch(
-        "custom_components.eebus.EebusCoordinator"
-    ) as mock_coordinator_cls:
+    with (
+        patch("custom_components.eebus.EebusCoordinator") as mock_coordinator_cls,
+        patch("custom_components.eebus.er.async_get") as async_get_entity_registry,
+    ):
         coordinator = AsyncMock()
         coordinator.async_config_entry_first_refresh = AsyncMock()
         coordinator.async_start_streams = MagicMock()
         coordinator.async_start_grid_push = MagicMock()
         coordinator.async_start_pv_push = MagicMock()
         coordinator.async_start_battery_push = MagicMock()
+        coordinator.ski = "test-ski"
         mock_coordinator_cls.return_value = coordinator
+
+        entity_registry = MagicMock()
+        entity_registry.async_get_entity_id.side_effect = [
+            "number.eebus_dhw_setpoint",
+            "select.eebus_dhw_operation_mode",
+        ]
+        async_get_entity_registry.return_value = entity_registry
 
         hass.config_entries.async_forward_entry_setups = AsyncMock()
 
@@ -43,6 +52,10 @@ async def test_setup_entry():
         coordinator.async_start_grid_push.assert_called_once()
         coordinator.async_start_pv_push.assert_called_once()
         coordinator.async_start_battery_push.assert_called_once()
+        assert entity_registry.async_remove.call_args_list == [
+            call("number.eebus_dhw_setpoint"),
+            call("select.eebus_dhw_operation_mode"),
+        ]
 
 
 @pytest.mark.asyncio

--- a/custom_components/eebus/translations/de.json
+++ b/custom_components/eebus/translations/de.json
@@ -108,11 +108,9 @@
     },
     "number": {
       "lpc_limit": { "name": "LPC Limit" },
-      "failsafe_limit": { "name": "Failsafe Limit" },
-      "dhw_setpoint": { "name": "Warmwasser-Solltemperatur" }
+      "failsafe_limit": { "name": "Failsafe Limit" }
     },
     "select": {
-      "dhw_operation_mode": { "name": "Warmwasser Betriebsart" },
       "compressor_flexibility": {
         "name": "Verdichter-Flexibilität",
         "state": {
@@ -130,6 +128,9 @@
     "binary_sensor": {
       "connected": { "name": "Verbunden" },
       "heartbeat_ok": { "name": "Heartbeat OK" }
+    },
+    "water_heater": {
+      "domestic_hot_water": { "name": "Warmwasser" }
     }
   }
 }

--- a/custom_components/eebus/translations/en.json
+++ b/custom_components/eebus/translations/en.json
@@ -108,11 +108,9 @@
     },
     "number": {
       "lpc_limit": { "name": "LPC Limit" },
-      "failsafe_limit": { "name": "Failsafe Limit" },
-      "dhw_setpoint": { "name": "Domestic Hot Water Target Temperature" }
+      "failsafe_limit": { "name": "Failsafe Limit" }
     },
     "select": {
-      "dhw_operation_mode": { "name": "Domestic Hot Water Operation Mode" },
       "compressor_flexibility": {
         "name": "Compressor Flexibility",
         "state": {
@@ -130,6 +128,9 @@
     "binary_sensor": {
       "connected": { "name": "Connected" },
       "heartbeat_ok": { "name": "Heartbeat OK" }
+    },
+    "water_heater": {
+      "domestic_hot_water": { "name": "Domestic Hot Water" }
     }
   }
 }

--- a/custom_components/eebus/water_heater.py
+++ b/custom_components/eebus/water_heater.py
@@ -1,0 +1,136 @@
+"""Water heater entity for EEBUS domestic-hot-water control."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.water_heater import WaterHeaterEntity, WaterHeaterEntityFeature
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .coordinator import EebusCoordinator
+from .entity import EebusEntity
+
+PARALLEL_UPDATES = 0  # Coordinator-based, no per-entity polling
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the EEBUS domestic-hot-water entity."""
+    coordinator: EebusCoordinator = entry.runtime_data
+    async_add_entities([EebusDHWWaterHeater(coordinator)])
+
+
+class EebusDHWWaterHeater(EebusEntity, WaterHeaterEntity):
+    """Domestic-hot-water tank exposed by the EEBUS heat pump."""
+
+    _attr_temperature_unit = UnitOfTemperature.CELSIUS
+    _attr_translation_key = "domestic_hot_water"
+
+    def __init__(self, coordinator: EebusCoordinator) -> None:
+        """Initialize the domestic-hot-water entity."""
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{coordinator.ski}_domestic_hot_water"
+
+    def _setpoint(self) -> dict[str, Any] | None:
+        data = self.coordinator.data or {}
+        if data.get("dhw_supported") is False:
+            return None
+        return data.get("dhw_setpoint")
+
+    def _system_function(self) -> dict[str, Any] | None:
+        data = self.coordinator.data or {}
+        if data.get("dhw_sysfn_supported") is False:
+            return None
+        return data.get("dhw_system_function")
+
+    @property
+    def available(self) -> bool:
+        """Return whether the bridge is connected and DHW data is available."""
+        if not super().available:
+            return False
+        data = self.coordinator.data or {}
+        return bool(
+            data.get("dhw_temperature_c") is not None
+            or self._setpoint() is not None
+            or self._system_function() is not None
+        )
+
+    @property
+    def supported_features(self) -> WaterHeaterEntityFeature:
+        """Return the controls currently advertised as writable by the device."""
+        features = WaterHeaterEntityFeature(0)
+        setpoint = self._setpoint()
+        if setpoint is not None and setpoint.get("writable"):
+            features |= WaterHeaterEntityFeature.TARGET_TEMPERATURE
+        system_function = self._system_function()
+        if (
+            system_function is not None
+            and system_function.get("mode_writable")
+            and system_function.get("available_modes")
+        ):
+            features |= WaterHeaterEntityFeature.OPERATION_MODE
+        return features
+
+    @property
+    def current_temperature(self) -> float | None:
+        """Return the measured domestic-hot-water temperature."""
+        value = (self.coordinator.data or {}).get("dhw_temperature_c")
+        return None if value is None else float(value)
+
+    @property
+    def target_temperature(self) -> float | None:
+        """Return the configured domestic-hot-water target."""
+        setpoint = self._setpoint()
+        return None if setpoint is None else float(setpoint["value_celsius"])
+
+    @property
+    def min_temp(self) -> float:
+        """Return the device-provided lower target-temperature bound."""
+        setpoint = self._setpoint()
+        return float(setpoint["min_celsius"]) if setpoint is not None else 0.0
+
+    @property
+    def max_temp(self) -> float:
+        """Return the device-provided upper target-temperature bound."""
+        setpoint = self._setpoint()
+        return float(setpoint["max_celsius"]) if setpoint is not None else 100.0
+
+    @property
+    def target_temperature_step(self) -> float | None:
+        """Return the device-provided target-temperature increment."""
+        setpoint = self._setpoint()
+        return None if setpoint is None else float(setpoint["step_celsius"])
+
+    @property
+    def operation_list(self) -> list[str] | None:
+        """Return operation modes advertised by the device."""
+        system_function = self._system_function()
+        if system_function is None:
+            return None
+        modes = system_function.get("available_modes")
+        return list(modes) if isinstance(modes, list) else None
+
+    @property
+    def current_operation(self) -> str | None:
+        """Return the active domestic-hot-water operation mode."""
+        system_function = self._system_function()
+        if system_function is None:
+            return None
+        mode = system_function.get("operation_mode")
+        return mode if isinstance(mode, str) and mode else None
+
+    async def async_set_temperature(self, **kwargs: Any) -> None:
+        """Set the domestic-hot-water target temperature."""
+        await self.coordinator.async_write_dhw_setpoint(float(kwargs[ATTR_TEMPERATURE]))
+        await self.coordinator.async_request_refresh()
+
+    async def async_set_operation_mode(self, operation_mode: str) -> None:
+        """Set the domestic-hot-water operation mode."""
+        await self.coordinator.async_set_dhw_operation_mode(operation_mode)
+        await self.coordinator.async_request_refresh()


### PR DESCRIPTION
## Summary

- expose domestic hot water as a native Home Assistant `water_heater` entity
- combine current temperature, target temperature, dynamic device constraints, and operation modes
- replace the former DHW number/select entities and remove their stale registry entries during migration
- retain the separate DHW boost switch and update translations, icons, docs, and quality-scale metadata

## Tests

- `ruff check custom_components/`
- `.venv/bin/mypy custom_components/eebus`
- `PYTHONPATH=. .venv/bin/pytest -q` (70 passed)