### PR TITLE
Add device operating state diagnostic sensor

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ Lokale Integration von EEBUS-faehigen Waermepumpen in Home Assistant ueber das *
   und Auswahl der vom Geraet angebotenen DHW-Betriebsarten
 - **Raumheizung** -- Home-Assistant-`climate` mit Ist-/Solltemperatur,
   dynamischen Geraetegrenzen und den angebotenen Modi `auto`/`on`/`off`
+- **Geraete-Betriebszustand** -- Read-only Diagnose des standardisierten EEBUS
+  `DeviceDiagnosis.operatingState`, inklusive unbekannter zukuenftiger Werte
 - **Energy Dashboard** -- Volle Integration mit dem HA Energy Dashboard
 - **Erweiterbar** -- Architektur vorbereitet fuer zukuenftige EEBUS-HVAC-Use-Cases
 
@@ -136,6 +138,7 @@ Die Integration nutzt **gRPC Streaming** (Server-Sent Events) fuer Echtzeit-Upda
 |--------|-----|-------------|
 | `binary_sensor.eebus_connected` | binary_sensor | EEBUS-Verbindungsstatus |
 | `binary_sensor.eebus_heartbeat_ok` | binary_sensor | Heartbeat innerhalb Toleranz, standardmaessig deaktiviert |
+| `sensor.eebus_device_operating_state` | sensor | EEBUS-Geraete-Betriebszustand, z. B. `normalOperation` |
 | `sensor.eebus_compressor_flexibility_power_estimate` | sensor | OHPCF geschaetzte Leistung des Angebots (W), standardmaessig deaktiviert |
 | `sensor.eebus_compressor_flexibility_power_max` | sensor | OHPCF maximale Leistung des Angebots (W), standardmaessig deaktiviert |
 

--- a/custom_components/eebus/coordinator.py
+++ b/custom_components/eebus/coordinator.py
@@ -561,6 +561,9 @@ class EebusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 data["room_heating_system_function"],
             ) = await self._async_read_room_heating(channel, proto_stubs, request)
             data["room_heating_supported"] = self._room_heating_supported
+            data["device_operating_state"] = await self._async_read_device_diagnostics(
+                channel, proto_stubs, request
+            )
 
             if saw_not_found:
                 self._not_found_streak += 1
@@ -1035,6 +1038,28 @@ class EebusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         if state.HasField("current_temperature_celsius"):
             self._push_data({"room_temperature_c": state.current_temperature_celsius})
         return setpoint, system_function
+
+    async def _async_read_device_diagnostics(
+        self, channel: grpc.aio.Channel, proto_stubs: Any, request: Any
+    ) -> str | None:
+        """Read the device operating state without mutating coordinator data."""
+        try:
+            diagnostics = await proto_stubs.monitoring_service_stub(
+                channel
+            ).GetDeviceDiagnostics(request, timeout=RPC_TIMEOUT)
+        except grpc.aio.AioRpcError as err:
+            if not (
+                _is_unimplemented(err)
+                or err.code()
+                in (grpc.StatusCode.NOT_FOUND, grpc.StatusCode.UNAVAILABLE)
+            ):
+                _LOGGER.debug(
+                    "EEBUS device diagnosis read failed for SKI %s: %s",
+                    self.ski,
+                    _rpc_error_text(err),
+                )
+            return None
+        return diagnostics.operating_state or None
 
     async def async_set_room_heating_temperature(self, value_celsius: float) -> None:
         """Set the room-heating target temperature."""
@@ -1652,6 +1677,19 @@ class EebusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         ):
             if event.HasField("measurement"):
                 self._push_data({"return_temperature_c": event.measurement.value})
+            else:
+                self.hass.async_create_task(self.async_request_refresh())
+        elif event_type == (
+            proto_stubs.MeasurementEventType.MEASUREMENT_EVENT_DEVICE_OPERATING_STATE_UPDATED
+        ):
+            if event.HasField("device_diagnostics"):
+                self._push_data(
+                    {
+                        "device_operating_state": (
+                            event.device_diagnostics.operating_state or None
+                        )
+                    }
+                )
             else:
                 self.hass.async_create_task(self.async_request_refresh())
 

--- a/custom_components/eebus/generated/eebus/v1/monitoring_service_pb2.py
+++ b/custom_components/eebus/generated/eebus/v1/monitoring_service_pb2.py
@@ -26,7 +26,7 @@ from . import common_pb2 as eebus_dot_v1_dot_common__pb2
 from google.protobuf import timestamp_pb2 as google_dot_protobuf_dot_timestamp__pb2
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n!eebus/v1/monitoring_service.proto\x12\x08\x65\x65\x62us.v1\x1a\x15\x65\x65\x62us/v1/common.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"Z\n\x11\x45nergyMeasurement\x12\x16\n\x0ekilowatt_hours\x18\x01 \x01(\x01\x12-\n\ttimestamp\x18\x02 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\"C\n\x0fMeasurementList\x12\x30\n\x0cmeasurements\x18\x01 \x03(\x0b\x32\x1a.eebus.v1.MeasurementEntry\"\xea\x01\n\x10MeasurementEvent\x12\x0b\n\x03ski\x18\x01 \x01(\t\x12\x32\n\nevent_type\x18\x02 \x01(\x0e\x32\x1e.eebus.v1.MeasurementEventType\x12+\n\x05power\x18\x03 \x01(\x0b\x32\x1a.eebus.v1.PowerMeasurementH\x00\x12-\n\x06\x65nergy\x18\x04 \x01(\x0b\x32\x1b.eebus.v1.EnergyMeasurementH\x00\x12\x31\n\x0bmeasurement\x18\x05 \x01(\x0b\x32\x1a.eebus.v1.MeasurementEntryH\x00\x42\x06\n\x04\x64\x61ta*\xa2\x04\n\x14MeasurementEventType\x12!\n\x1dMEASUREMENT_EVENT_UNSPECIFIED\x10\x00\x12#\n\x1fMEASUREMENT_EVENT_POWER_UPDATED\x10\x01\x12$\n MEASUREMENT_EVENT_ENERGY_UPDATED\x10\x02\x12-\n)MEASUREMENT_EVENT_DHW_TEMPERATURE_UPDATED\x10\x03\x12\x35\n1MEASUREMENT_EVENT_DHW_TEMPERATURE_SUPPORT_UPDATED\x10\x04\x12.\n*MEASUREMENT_EVENT_ROOM_TEMPERATURE_UPDATED\x10\x05\x12\x36\n2MEASUREMENT_EVENT_ROOM_TEMPERATURE_SUPPORT_UPDATED\x10\x06\x12\x31\n-MEASUREMENT_EVENT_OUTDOOR_TEMPERATURE_UPDATED\x10\x07\x12\x39\n5MEASUREMENT_EVENT_OUTDOOR_TEMPERATURE_SUPPORT_UPDATED\x10\x08\x12.\n*MEASUREMENT_EVENT_FLOW_TEMPERATURE_UPDATED\x10\t\x12\x30\n,MEASUREMENT_EVENT_RETURN_TEMPERATURE_UPDATED\x10\n2\xc1\x02\n\x11MonitoringService\x12J\n\x13GetPowerConsumption\x12\x17.eebus.v1.DeviceRequest\x1a\x1a.eebus.v1.PowerMeasurement\x12I\n\x11GetEnergyConsumed\x12\x17.eebus.v1.DeviceRequest\x1a\x1b.eebus.v1.EnergyMeasurement\x12\x45\n\x0fGetMeasurements\x12\x17.eebus.v1.DeviceRequest\x1a\x19.eebus.v1.MeasurementList\x12N\n\x15SubscribeMeasurements\x12\x17.eebus.v1.DeviceRequest\x1a\x1a.eebus.v1.MeasurementEvent0\x01\x42=Z;github.com/volschin/eebus-bridge/gen/proto/eebus/v1;eebusv1b\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n!eebus/v1/monitoring_service.proto\x12\x08\x65\x65\x62us.v1\x1a\x15\x65\x65\x62us/v1/common.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"Z\n\x11\x45nergyMeasurement\x12\x16\n\x0ekilowatt_hours\x18\x01 \x01(\x01\x12-\n\ttimestamp\x18\x02 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\"C\n\x0fMeasurementList\x12\x30\n\x0cmeasurements\x18\x01 \x03(\x0b\x32\x1a.eebus.v1.MeasurementEntry\"_\n\x15\x44\x65viceDiagnosticsData\x12\x17\n\x0foperating_state\x18\x01 \x01(\t\x12-\n\ttimestamp\x18\x02 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\"\xa9\x02\n\x10MeasurementEvent\x12\x0b\n\x03ski\x18\x01 \x01(\t\x12\x32\n\nevent_type\x18\x02 \x01(\x0e\x32\x1e.eebus.v1.MeasurementEventType\x12+\n\x05power\x18\x03 \x01(\x0b\x32\x1a.eebus.v1.PowerMeasurementH\x00\x12-\n\x06\x65nergy\x18\x04 \x01(\x0b\x32\x1b.eebus.v1.EnergyMeasurementH\x00\x12\x31\n\x0bmeasurement\x18\x05 \x01(\x0b\x32\x1a.eebus.v1.MeasurementEntryH\x00\x12=\n\x12\x64\x65vice_diagnostics\x18\x06 \x01(\x0b\x32\x1f.eebus.v1.DeviceDiagnosticsDataH\x00\x42\x06\n\x04\x64\x61ta*\xd8\x04\n\x14MeasurementEventType\x12!\n\x1dMEASUREMENT_EVENT_UNSPECIFIED\x10\x00\x12#\n\x1fMEASUREMENT_EVENT_POWER_UPDATED\x10\x01\x12$\n MEASUREMENT_EVENT_ENERGY_UPDATED\x10\x02\x12-\n)MEASUREMENT_EVENT_DHW_TEMPERATURE_UPDATED\x10\x03\x12\x35\n1MEASUREMENT_EVENT_DHW_TEMPERATURE_SUPPORT_UPDATED\x10\x04\x12.\n*MEASUREMENT_EVENT_ROOM_TEMPERATURE_UPDATED\x10\x05\x12\x36\n2MEASUREMENT_EVENT_ROOM_TEMPERATURE_SUPPORT_UPDATED\x10\x06\x12\x31\n-MEASUREMENT_EVENT_OUTDOOR_TEMPERATURE_UPDATED\x10\x07\x12\x39\n5MEASUREMENT_EVENT_OUTDOOR_TEMPERATURE_SUPPORT_UPDATED\x10\x08\x12.\n*MEASUREMENT_EVENT_FLOW_TEMPERATURE_UPDATED\x10\t\x12\x30\n,MEASUREMENT_EVENT_RETURN_TEMPERATURE_UPDATED\x10\n\x12\x34\n0MEASUREMENT_EVENT_DEVICE_OPERATING_STATE_UPDATED\x10\x0b\x32\x93\x03\n\x11MonitoringService\x12J\n\x13GetPowerConsumption\x12\x17.eebus.v1.DeviceRequest\x1a\x1a.eebus.v1.PowerMeasurement\x12I\n\x11GetEnergyConsumed\x12\x17.eebus.v1.DeviceRequest\x1a\x1b.eebus.v1.EnergyMeasurement\x12\x45\n\x0fGetMeasurements\x12\x17.eebus.v1.DeviceRequest\x1a\x19.eebus.v1.MeasurementList\x12P\n\x14GetDeviceDiagnostics\x12\x17.eebus.v1.DeviceRequest\x1a\x1f.eebus.v1.DeviceDiagnosticsData\x12N\n\x15SubscribeMeasurements\x12\x17.eebus.v1.DeviceRequest\x1a\x1a.eebus.v1.MeasurementEvent0\x01\x42=Z;github.com/volschin/eebus-bridge/gen/proto/eebus/v1;eebusv1b\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -34,14 +34,16 @@ _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'eebus.v1.monitoring_service
 if not _descriptor._USE_C_DESCRIPTORS:
   _globals['DESCRIPTOR']._loaded_options = None
   _globals['DESCRIPTOR']._serialized_options = b'Z;github.com/volschin/eebus-bridge/gen/proto/eebus/v1;eebusv1'
-  _globals['_MEASUREMENTEVENTTYPE']._serialized_start=502
-  _globals['_MEASUREMENTEVENTTYPE']._serialized_end=1048
+  _globals['_MEASUREMENTEVENTTYPE']._serialized_start=662
+  _globals['_MEASUREMENTEVENTTYPE']._serialized_end=1262
   _globals['_ENERGYMEASUREMENT']._serialized_start=103
   _globals['_ENERGYMEASUREMENT']._serialized_end=193
   _globals['_MEASUREMENTLIST']._serialized_start=195
   _globals['_MEASUREMENTLIST']._serialized_end=262
-  _globals['_MEASUREMENTEVENT']._serialized_start=265
-  _globals['_MEASUREMENTEVENT']._serialized_end=499
-  _globals['_MONITORINGSERVICE']._serialized_start=1051
-  _globals['_MONITORINGSERVICE']._serialized_end=1372
+  _globals['_DEVICEDIAGNOSTICSDATA']._serialized_start=264
+  _globals['_DEVICEDIAGNOSTICSDATA']._serialized_end=359
+  _globals['_MEASUREMENTEVENT']._serialized_start=362
+  _globals['_MEASUREMENTEVENT']._serialized_end=659
+  _globals['_MONITORINGSERVICE']._serialized_start=1265
+  _globals['_MONITORINGSERVICE']._serialized_end=1668
 # @@protoc_insertion_point(module_scope)

--- a/custom_components/eebus/generated/eebus/v1/monitoring_service_pb2.pyi
+++ b/custom_components/eebus/generated/eebus/v1/monitoring_service_pb2.pyi
@@ -24,6 +24,7 @@ class MeasurementEventType(int, metaclass=_enum_type_wrapper.EnumTypeWrapper):
     MEASUREMENT_EVENT_OUTDOOR_TEMPERATURE_SUPPORT_UPDATED: _ClassVar[MeasurementEventType]
     MEASUREMENT_EVENT_FLOW_TEMPERATURE_UPDATED: _ClassVar[MeasurementEventType]
     MEASUREMENT_EVENT_RETURN_TEMPERATURE_UPDATED: _ClassVar[MeasurementEventType]
+    MEASUREMENT_EVENT_DEVICE_OPERATING_STATE_UPDATED: _ClassVar[MeasurementEventType]
 MEASUREMENT_EVENT_UNSPECIFIED: MeasurementEventType
 MEASUREMENT_EVENT_POWER_UPDATED: MeasurementEventType
 MEASUREMENT_EVENT_ENERGY_UPDATED: MeasurementEventType
@@ -35,6 +36,7 @@ MEASUREMENT_EVENT_OUTDOOR_TEMPERATURE_UPDATED: MeasurementEventType
 MEASUREMENT_EVENT_OUTDOOR_TEMPERATURE_SUPPORT_UPDATED: MeasurementEventType
 MEASUREMENT_EVENT_FLOW_TEMPERATURE_UPDATED: MeasurementEventType
 MEASUREMENT_EVENT_RETURN_TEMPERATURE_UPDATED: MeasurementEventType
+MEASUREMENT_EVENT_DEVICE_OPERATING_STATE_UPDATED: MeasurementEventType
 
 class EnergyMeasurement(_message.Message):
     __slots__ = ("kilowatt_hours", "timestamp")
@@ -50,16 +52,26 @@ class MeasurementList(_message.Message):
     measurements: _containers.RepeatedCompositeFieldContainer[_common_pb2.MeasurementEntry]
     def __init__(self, measurements: _Optional[_Iterable[_Union[_common_pb2.MeasurementEntry, _Mapping]]] = ...) -> None: ...
 
+class DeviceDiagnosticsData(_message.Message):
+    __slots__ = ("operating_state", "timestamp")
+    OPERATING_STATE_FIELD_NUMBER: _ClassVar[int]
+    TIMESTAMP_FIELD_NUMBER: _ClassVar[int]
+    operating_state: str
+    timestamp: _timestamp_pb2.Timestamp
+    def __init__(self, operating_state: _Optional[str] = ..., timestamp: _Optional[_Union[datetime.datetime, _timestamp_pb2.Timestamp, _Mapping]] = ...) -> None: ...
+
 class MeasurementEvent(_message.Message):
-    __slots__ = ("ski", "event_type", "power", "energy", "measurement")
+    __slots__ = ("ski", "event_type", "power", "energy", "measurement", "device_diagnostics")
     SKI_FIELD_NUMBER: _ClassVar[int]
     EVENT_TYPE_FIELD_NUMBER: _ClassVar[int]
     POWER_FIELD_NUMBER: _ClassVar[int]
     ENERGY_FIELD_NUMBER: _ClassVar[int]
     MEASUREMENT_FIELD_NUMBER: _ClassVar[int]
+    DEVICE_DIAGNOSTICS_FIELD_NUMBER: _ClassVar[int]
     ski: str
     event_type: MeasurementEventType
     power: _common_pb2.PowerMeasurement
     energy: EnergyMeasurement
     measurement: _common_pb2.MeasurementEntry
-    def __init__(self, ski: _Optional[str] = ..., event_type: _Optional[_Union[MeasurementEventType, str]] = ..., power: _Optional[_Union[_common_pb2.PowerMeasurement, _Mapping]] = ..., energy: _Optional[_Union[EnergyMeasurement, _Mapping]] = ..., measurement: _Optional[_Union[_common_pb2.MeasurementEntry, _Mapping]] = ...) -> None: ...
+    device_diagnostics: DeviceDiagnosticsData
+    def __init__(self, ski: _Optional[str] = ..., event_type: _Optional[_Union[MeasurementEventType, str]] = ..., power: _Optional[_Union[_common_pb2.PowerMeasurement, _Mapping]] = ..., energy: _Optional[_Union[EnergyMeasurement, _Mapping]] = ..., measurement: _Optional[_Union[_common_pb2.MeasurementEntry, _Mapping]] = ..., device_diagnostics: _Optional[_Union[DeviceDiagnosticsData, _Mapping]] = ...) -> None: ...

--- a/custom_components/eebus/generated/eebus/v1/monitoring_service_pb2_grpc.py
+++ b/custom_components/eebus/generated/eebus/v1/monitoring_service_pb2_grpc.py
@@ -50,6 +50,11 @@ class MonitoringServiceStub(object):
                 request_serializer=eebus_dot_v1_dot_common__pb2.DeviceRequest.SerializeToString,
                 response_deserializer=eebus_dot_v1_dot_monitoring__service__pb2.MeasurementList.FromString,
                 _registered_method=True)
+        self.GetDeviceDiagnostics = channel.unary_unary(
+                '/eebus.v1.MonitoringService/GetDeviceDiagnostics',
+                request_serializer=eebus_dot_v1_dot_common__pb2.DeviceRequest.SerializeToString,
+                response_deserializer=eebus_dot_v1_dot_monitoring__service__pb2.DeviceDiagnosticsData.FromString,
+                _registered_method=True)
         self.SubscribeMeasurements = channel.unary_stream(
                 '/eebus.v1.MonitoringService/SubscribeMeasurements',
                 request_serializer=eebus_dot_v1_dot_common__pb2.DeviceRequest.SerializeToString,
@@ -78,6 +83,12 @@ class MonitoringServiceServicer(object):
         context.set_details('Method not implemented!')
         raise NotImplementedError('Method not implemented!')
 
+    def GetDeviceDiagnostics(self, request, context):
+        """Missing associated documentation comment in .proto file."""
+        context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+        context.set_details('Method not implemented!')
+        raise NotImplementedError('Method not implemented!')
+
     def SubscribeMeasurements(self, request, context):
         """Missing associated documentation comment in .proto file."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
@@ -101,6 +112,11 @@ def add_MonitoringServiceServicer_to_server(servicer, server):
                     servicer.GetMeasurements,
                     request_deserializer=eebus_dot_v1_dot_common__pb2.DeviceRequest.FromString,
                     response_serializer=eebus_dot_v1_dot_monitoring__service__pb2.MeasurementList.SerializeToString,
+            ),
+            'GetDeviceDiagnostics': grpc.unary_unary_rpc_method_handler(
+                    servicer.GetDeviceDiagnostics,
+                    request_deserializer=eebus_dot_v1_dot_common__pb2.DeviceRequest.FromString,
+                    response_serializer=eebus_dot_v1_dot_monitoring__service__pb2.DeviceDiagnosticsData.SerializeToString,
             ),
             'SubscribeMeasurements': grpc.unary_stream_rpc_method_handler(
                     servicer.SubscribeMeasurements,
@@ -189,6 +205,33 @@ class MonitoringService(object):
             '/eebus.v1.MonitoringService/GetMeasurements',
             eebus_dot_v1_dot_common__pb2.DeviceRequest.SerializeToString,
             eebus_dot_v1_dot_monitoring__service__pb2.MeasurementList.FromString,
+            options,
+            channel_credentials,
+            insecure,
+            call_credentials,
+            compression,
+            wait_for_ready,
+            timeout,
+            metadata,
+            _registered_method=True)
+
+    @staticmethod
+    def GetDeviceDiagnostics(request,
+            target,
+            options=(),
+            channel_credentials=None,
+            call_credentials=None,
+            insecure=False,
+            compression=None,
+            wait_for_ready=None,
+            timeout=None,
+            metadata=None):
+        return grpc.experimental.unary_unary(
+            request,
+            target,
+            '/eebus.v1.MonitoringService/GetDeviceDiagnostics',
+            eebus_dot_v1_dot_common__pb2.DeviceRequest.SerializeToString,
+            eebus_dot_v1_dot_monitoring__service__pb2.DeviceDiagnosticsData.FromString,
             options,
             channel_credentials,
             insecure,

--- a/custom_components/eebus/icons.json
+++ b/custom_components/eebus/icons.json
@@ -6,6 +6,7 @@
       "energy_consumed_heating": { "default": "mdi:radiator" },
       "energy_consumed_dhw": { "default": "mdi:water-boiler" },
       "consumption_limit": { "default": "mdi:speedometer" },
+      "device_operating_state": { "default": "mdi:state-machine" },
       "power_l1": { "default": "mdi:flash" },
       "power_l2": { "default": "mdi:flash" },
       "power_l3": { "default": "mdi:flash" },

--- a/custom_components/eebus/proto_stubs.py
+++ b/custom_components/eebus/proto_stubs.py
@@ -51,6 +51,8 @@ from .generated.eebus.v1.lpc_service_pb2 import (  # noqa: F401
     WriteLoadLimitRequest,
 )
 from .generated.eebus.v1.monitoring_service_pb2 import (  # noqa: F401
+    DeviceDiagnosticsData,
+    MEASUREMENT_EVENT_DEVICE_OPERATING_STATE_UPDATED,
     MeasurementEventType,
 )
 from .generated.eebus.v1.lpc_service_pb2_grpc import LPCServiceStub  # noqa: F401
@@ -115,6 +117,7 @@ __all__ = [
     "CompressorPowerConsumptionState",
     "ControlCompressorRequest",
     "DeviceEventType",
+    "DeviceDiagnosticsData",
     "DeviceRequest",
     "DeviceServiceStub",
     "DHWBoostStatus",
@@ -131,6 +134,7 @@ __all__ = [
     "LPCServiceStub",
     "LoadLimit",
     "MeasurementEntry",
+    "MEASUREMENT_EVENT_DEVICE_OPERATING_STATE_UPDATED",
     "MeasurementEventType",
     "MonitoringServiceStub",
     "OHPCFAction",

--- a/custom_components/eebus/quality_scale.yaml
+++ b/custom_components/eebus/quality_scale.yaml
@@ -49,13 +49,15 @@ rules:
   docs-supported-devices: done
   docs-supported-functions:
     status: done
-    comment: README lists the DHW water heater, boost, room-heating climate control, and their device-provided constraints/options.
+    comment: README lists the DHW water heater, boost, room-heating climate control, device operating state diagnostic, and device-provided constraints/options.
   docs-troubleshooting: done
   docs-use-cases: done
   dynamic-devices:
     status: exempt
     comment: One EEBUS device per config entry.
-  entity-category: done
+  entity-category:
+    status: done
+    comment: Read-only operational state and limit/status entities are categorized as diagnostics.
   entity-device-class: done
   entity-disabled-by-default: done
   entity-translations: done

--- a/custom_components/eebus/sensor.py
+++ b/custom_components/eebus/sensor.py
@@ -41,6 +41,13 @@ class EebusMeasurementDescription(SensorEntityDescription):
 # single-phase heat pumps) that never populate them.
 MEASUREMENT_SENSORS: tuple[EebusMeasurementDescription, ...] = (
     EebusMeasurementDescription(
+        key="device_operating_state",
+        data_key="device_operating_state",
+        translation_key="device_operating_state",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=True,
+    ),
+    EebusMeasurementDescription(
         key="dhw_temperature",
         data_key="dhw_temperature_c",
         translation_key="dhw_temperature",
@@ -199,7 +206,7 @@ class EebusMeasurementSensor(EebusEntity, SensorEntity):
         self._attr_unique_id = f"{coordinator.ski}_{description.key}"
 
     @property
-    def native_value(self) -> float | None:
+    def native_value(self) -> float | str | None:
         """Return the measurement value, or None when unavailable."""
         if self.coordinator.data is None:
             return None

--- a/custom_components/eebus/tests/test_coordinator.py
+++ b/custom_components/eebus/tests/test_coordinator.py
@@ -6,6 +6,9 @@ from datetime import timedelta
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
+import grpc
+from grpc.aio import AioRpcError, Metadata
+
 from custom_components.eebus import proto_stubs
 from custom_components.eebus.coordinator import EebusCoordinator, POLL_INTERVAL
 from custom_components.eebus.generated.eebus.v1 import (
@@ -90,6 +93,65 @@ def test_measurement_energy_event_pushes_data():
     )
     coordinator._handle_measurement_event(event)
     assert pushed["energy_consumed_kwh"] == 42.0
+
+
+def test_device_operating_state_event_pushes_data():
+    """DeviceDiagnosis stream events update the diagnostic sensor directly."""
+    coordinator, pushed = _make_coordinator(
+        data={"device_operating_state": "standby"}
+    )
+    event = monitoring_service_pb2.MeasurementEvent(
+        ski="test-ski",
+        event_type=(
+            monitoring_service_pb2.MEASUREMENT_EVENT_DEVICE_OPERATING_STATE_UPDATED
+        ),
+        device_diagnostics=proto_stubs.DeviceDiagnosticsData(
+            operating_state="futureVendorState"
+        ),
+    )
+
+    coordinator._handle_measurement_event(event)
+
+    assert pushed["device_operating_state"] == "futureVendorState"
+
+
+async def test_read_device_diagnostics_returns_operating_state():
+    """Polling returns the bridge operating-state string unchanged."""
+
+    class MonitoringStub:
+        async def GetDeviceDiagnostics(self, _request, timeout=None):
+            return proto_stubs.DeviceDiagnosticsData(operating_state="normalOperation")
+
+    coordinator, _ = _make_coordinator()
+    module = SimpleNamespace(monitoring_service_stub=lambda _channel: MonitoringStub())
+
+    result = await coordinator._async_read_device_diagnostics(
+        MagicMock(), module, proto_stubs.DeviceRequest(ski="test-ski")
+    )
+
+    assert result == "normalOperation"
+
+
+async def test_read_device_diagnostics_unavailable_returns_none():
+    """Missing diagnosis data remains unavailable without failing the poll."""
+
+    class MonitoringStub:
+        async def GetDeviceDiagnostics(self, _request, timeout=None):
+            raise AioRpcError(
+                grpc.StatusCode.NOT_FOUND,
+                Metadata(),
+                Metadata(),
+                details="device operating state unavailable",
+            )
+
+    coordinator, _ = _make_coordinator()
+    module = SimpleNamespace(monitoring_service_stub=lambda _channel: MonitoringStub())
+
+    result = await coordinator._async_read_device_diagnostics(
+        MagicMock(), module, proto_stubs.DeviceRequest(ski="test-ski")
+    )
+
+    assert result is None
 
 
 def test_measurement_event_other_ski_ignored():

--- a/custom_components/eebus/tests/test_sensor.py
+++ b/custom_components/eebus/tests/test_sensor.py
@@ -2,12 +2,15 @@
 
 from unittest.mock import MagicMock
 
+from homeassistant.const import EntityCategory
+
 from custom_components.eebus.sensor import (
     EebusFailsafeDurationSensor,
     EebusFailsafeLimitSensor,
     EebusMeasurementDescription,
     EebusMeasurementSensor,
     EebusPowerSensor,
+    MEASUREMENT_SENSORS,
 )
 
 
@@ -85,3 +88,36 @@ def test_measurement_sensor_vaillant_temperature_value():
 
     sensor = EebusMeasurementSensor(coordinator, description)
     assert sensor.native_value == 48.5
+
+
+def _device_operating_state_sensor(value):
+    """Build the device operating state sensor with the supplied value."""
+    coordinator = MagicMock()
+    coordinator.data = {"device_operating_state": value, "connected": True}
+    coordinator.ski = "test-ski-123"
+    description = next(
+        item for item in MEASUREMENT_SENSORS if item.key == "device_operating_state"
+    )
+    return EebusMeasurementSensor(coordinator, description)
+
+
+def test_device_operating_state_sensor_value():
+    """Device operating state is an enabled diagnostic sensor."""
+    sensor = _device_operating_state_sensor("normalOperation")
+    assert sensor.native_value == "normalOperation"
+    assert sensor.entity_description.entity_category == EntityCategory.DIAGNOSTIC
+    assert sensor.entity_description.entity_registry_enabled_default is True
+    assert sensor.entity_description.device_class is None
+
+
+def test_device_operating_state_sensor_unavailable():
+    """Missing device operating state produces no native value."""
+    assert _device_operating_state_sensor(None).native_value is None
+
+
+def test_device_operating_state_sensor_passes_through_unknown_value():
+    """Unknown future device states remain visible as their raw string."""
+    assert (
+        _device_operating_state_sensor("futureVendorState").native_value
+        == "futureVendorState"
+    )

--- a/custom_components/eebus/translations/de.json
+++ b/custom_components/eebus/translations/de.json
@@ -72,6 +72,7 @@
       "energy_consumed_heating": { "name": "Energieverbrauch Heizung" },
       "energy_consumed_dhw": { "name": "Energieverbrauch Warmwasser" },
       "consumption_limit": { "name": "Leistungslimit" },
+      "device_operating_state": { "name": "Betriebszustand" },
       "dhw_temperature": { "name": "Warmwassertemperatur" },
       "room_temperature": { "name": "Raumtemperatur" },
       "outdoor_temperature": { "name": "Außentemperatur" },

--- a/custom_components/eebus/translations/en.json
+++ b/custom_components/eebus/translations/en.json
@@ -72,6 +72,7 @@
       "energy_consumed_heating": { "name": "Energy Consumed Heating" },
       "energy_consumed_dhw": { "name": "Energy Consumed Domestic Hot Water" },
       "consumption_limit": { "name": "Consumption Limit" },
+      "device_operating_state": { "name": "Device Operating State" },
       "dhw_temperature": { "name": "Domestic Hot Water Temperature" },
       "room_temperature": { "name": "Room Temperature" },
       "outdoor_temperature": { "name": "Outdoor Temperature" },

--- a/docs/superpowers/plans/2026-07-13-device-operating-state-plan.md
+++ b/docs/superpowers/plans/2026-07-13-device-operating-state-plan.md
@@ -1,0 +1,220 @@
+# Device operating state — implementation plan
+
+**Date:** 2026-07-13
+**Branch:** `feat/device-operating-state` (based on `main` at merge of PR #101)
+**Design basis:** `docs/superpowers/specs/2026-07-13-vr940-extended-capture-findings.md`,
+Phase 2 item 1 ("Device operating state" — confirmed present, high confidence).
+
+## What we're building
+
+A new read-only diagnostic: the VR940's `DeviceDiagnosis.operatingState` (SPINE
+`DeviceDiagnosisStateDataType.OperatingState`), read from the `HeatPumpAppliance`
+entity, exposed as a new Home Assistant diagnostic sensor
+(`sensor.eebus_operating_state` or similar, entity category `diagnostic`).
+
+Confirmed live on the VR940 (idle capture, 2026-07-13):
+`{"operatingState": "normalOperation"}`. No `vendorStateCode` or error-code field
+was present — do not add fields for those; they simply weren't advertised.
+
+Known enum values in the vendored `spine-go` model
+(`model.DeviceDiagnosisOperatingStateType`, `internal/eebus` vendor dir under
+`github.com/enbility/spine-go/model/devicediagnosis.go`): `normalOperation`,
+`standby`, `failure`, `serviceNeeded`, `overrideDetected`, `inAlarm`,
+`notReachable`, `finished`, `temporarilyNotReady`, `off`. Only `normalOperation`
+has actually been observed live — treat the field as a pass-through string on
+both the wire and in Home Assistant (not a hardcoded Python `StrEnum` limited to
+observed values), since the device may report any of these at runtime.
+
+## Why this needs a from-scratch read path (no existing use case covers it)
+
+Unlike temperature/setpoint reads, **no existing eebus-go use case negotiates the
+`DeviceDiagnosis` feature type** between the bridge's local CEM entity and the
+remote device. The DHW/room-heating/monitoring reads all work by piggybacking on
+a feature that some *other* already-added eebus-go use case (Monitoring,
+DHWTemperature, etc.) already binds/subscribes as part of its own setup — see
+`internal/usecases/hydraulictemp.go`, which reads flow/return temperature purely
+from the local cache via `entity.FeatureOfTypeAndRole(model.FeatureTypeTypeMeasurement, model.RoleTypeServer)`
+with **no active request of its own**, because the Monitoring use case already
+keeps that feature's cache warm.
+
+`DeviceDiagnosis` has no such free ride. The one proven pattern in this codebase
+for reading a feature type nothing else negotiates is
+`internal/eebus/extendedcapture.go` (on branch `feat/vr940-diagnostics-usecases`,
+not yet merged — read it directly via
+`git show origin/feat/vr940-diagnostics-usecases:eebus-bridge/internal/eebus/extendedcapture.go`
+for reference, but do **not** depend on or import that file/branch):
+
+1. **`Setup(localEntity)` — called once, before `bridgeSvc.Service().Start()`**:
+   register a local **client** feature for the type you want to read:
+   `localEntity.GetOrAddFeature(model.FeatureTypeTypeDeviceDiagnosis, model.RoleTypeClient)`.
+   This must happen before `Start()` — client features are announced at startup
+   and cannot be added to an already-running EEBUS service (see
+   `docs/vr940-extended-capture.md` for why). In `main.go`, add this call in the
+   same block as the other `*.Setup(localEntity)` calls (currently:
+   `lpcWrapper.Setup`, `monitoringWrapper.Setup`, `dhwMonitoringWrapper.Setup`,
+   `roomMonitoringWrapper.Setup`, `outdoorMonitoringWrapper.Setup` — see
+   `cmd/eebus-bridge/main.go` lines ~85-99).
+
+2. **On-demand read**: get the local client feature via
+   `local.FeatureOfTypeAndRole(model.FeatureTypeTypeDeviceDiagnosis, model.RoleTypeClient)`,
+   find the remote server feature on the `HeatPumpAppliance` entity via the
+   registry (same lookup pattern as `hydraulictemp.go`'s `scopedTemperature`:
+   iterate `registry.Entities(ski)`, match `info.Entity.FeatureOfTypeAndRole(model.FeatureTypeTypeDeviceDiagnosis, model.RoleTypeServer)`,
+   prefer `info.Type == string(model.EntityTypeTypeHeatPumpAppliance)`), then:
+   ```go
+   msgCounter, err := localFeature.RequestRemoteData(model.FunctionTypeDeviceDiagnosisStateData, nil, nil, remoteFeature)
+   ```
+   Register a response callback via `localFeature.AddResponseCallback(*msgCounter, func(message spineapi.ResponseMessage) { ... })`
+   and wait on a channel with a short timeout (a few seconds — mirror the style
+   of `dhwWriteTimeout`/similar constants already in `internal/usecases/dhw.go`,
+   but this is a read, so keep the timeout short, e.g. 5s). On timeout, fall back
+   to `remoteFeature.DataCopy(model.FunctionTypeDeviceDiagnosisStateData)` in case
+   a reply updated the cache before the callback attached (same
+   "cache fallback conclusive only when nothing was cached before" nuance as
+   `extendedcapture.go`'s `collectAndWrite` — for this feature we don't need that
+   full nuance since we're not comparing against a `CachedBefore` snapshot, just
+   attempt the direct response first, then the cache as fallback).
+   Return `(string, error)`: the string value of `*data.OperatingState`, or a
+   sentinel `ErrDeviceOperatingStateUnavailable` if neither path yields data.
+
+3. **Push path**: also subscribe to `localEntity.Device().Events()` in `Setup`
+   (`_ = localEntity.Device().Events().Subscribe(w)`, same as
+   `hydraulictemp.go`), implement `HandleEvent(payload spineapi.EventPayload)`
+   filtering `payload.EventType == spineapi.EventTypeDataChange`,
+   `payload.ChangeType == spineapi.ElementChangeUpdate`, and
+   `payload.Data.(*model.DeviceDiagnosisStateDataType)` — on match, call the
+   read method again (idempotent, cheap) and publish
+   `bus.Publish(eebus.Event{SKI: ski, Type: "monitoring.device_operating_state_updated"})`.
+   This fires whenever anything (including our own on-demand read) updates the
+   cache, and gives the streaming gRPC path a push signal without needing a
+   dedicated subscribe/bind.
+
+## Files to add/change
+
+### Go (`eebus-bridge/`)
+
+- **New** `internal/usecases/devicediagnosis.go` — `DeviceOperatingState` struct
+  (fields: `bus *eebus.EventBus`, `registry *eebus.DeviceRegistry`,
+  `localEntity spineapi.EntityLocalInterface`, `debug bool`), constructor
+  `NewDeviceOperatingState(bus, registry, debug)`, `Setup(localEntity)`,
+  `HandleEvent(payload)`, `OperatingState(ski string) (string, error)`. Mirror
+  the file layout/comment style of `internal/usecases/hydraulictemp.go` exactly
+  (package doc comment explaining "reads via already-negotiated feature" would
+  be wrong here — instead explain it registers its own client feature and
+  performs its own active reads, since no existing use case does).
+- **New** `internal/usecases/devicediagnosis_test.go` — unit tests using the
+  existing spine-go mocks. Cover: successful read via response callback,
+  read via cache fallback (data appears in cache before callback fires),
+  timeout with no data (`ErrDeviceOperatingStateUnavailable`), unknown operating
+  state string passed through unchanged, `HandleEvent` ignoring unrelated data
+  types/change types. **Known gotcha** (see project memory): testify spine-go
+  mocks need `.On("String").Return(...)` stubbed or an argument-diff failure
+  hangs the test — check `roomheatingtemp_test.go` or `hydraulictemp_test.go`
+  for the exact mock setup pattern already in use and copy it.
+- `cmd/eebus-bridge/main.go` — construct
+  `deviceOperatingState := usecases.NewDeviceOperatingState(bus, registry, cfg.Logging.DebugEvents)`
+  and call `deviceOperatingState.Setup(localEntity)` alongside the other
+  `.Setup(localEntity)` calls (before `Start()`). This does **not** need
+  `AddUseCase` — it's a plain feature registration, not a formal use case, same
+  as `hydraulicTemperatures` isn't added via `AddUseCase` either. Do not add it
+  to the `registeredUseCases` log-line slice for the same reason
+  `HydraulicTemperatures` isn't in it.
+- `proto/eebus/v1/monitoring_service.proto`:
+  ```proto
+  message DeviceDiagnosticsData {
+    string operating_state = 1;
+    google.protobuf.Timestamp timestamp = 2;
+  }
+  ```
+  Add `rpc GetDeviceDiagnostics(DeviceRequest) returns (DeviceDiagnosticsData);`
+  to `MonitoringService`. Extend `MeasurementEvent`'s `oneof data` with
+  `DeviceDiagnosticsData device_diagnostics = 6;` and add
+  `MEASUREMENT_EVENT_DEVICE_OPERATING_STATE_UPDATED = 11;` to
+  `MeasurementEventType` (next free enum value after `MEASUREMENT_EVENT_RETURN_TEMPERATURE_UPDATED = 10`).
+- `internal/grpc/monitoring_service.go` — add the `GetDeviceDiagnostics` RPC
+  handler (same shape as `GetPowerConsumption`/`GetMeasurements`: resolve SKI,
+  call the use case, map `ErrDeviceOperatingStateUnavailable` to the same gRPC
+  status code convention already used for "data not available" elsewhere in
+  this file). Wire the new event type into the existing
+  `SubscribeMeasurements` event-forwarding switch (translate the bus event into
+  a `MeasurementEvent` with the new event type + `DeviceDiagnosticsData`
+  payload), following the existing pattern for
+  `MEASUREMENT_EVENT_FLOW_TEMPERATURE_UPDATED`/etc in that same file.
+- `internal/grpc/monitoring_service_test.go` — add coverage for the new RPC
+  handler (success + not-available cases) and the new event-forwarding branch.
+- Regenerate Go proto stubs: `make proto` from `eebus-bridge/` (needs `buf`;
+  see project memory "Proto regen local tooling" — `buf` lives in `~/go/bin`).
+
+### Python (`custom_components/eebus/`)
+
+- Regenerate Python stubs: `bash generate_proto.sh` from repo root (needs
+  `grpcio-tools==1.78.0`; project memory notes PEP 668 blocks plain `pip`, use
+  `uv --with grpcio-tools==1.78.0`).
+- `proto_stubs.py` — add re-exports for `DeviceDiagnosticsData`,
+  `GetDeviceDiagnostics` (via the existing `monitoring_service_stub` factory,
+  no new factory needed), and the new `MeasurementEventType` enum member. Must
+  have explicit `__all__` entries (mypy `--strict` `no_implicit_reexport`).
+- `coordinator.py` — add a poll path (new `_async_read_device_diagnostics`
+  method, called from `_async_update_data`, mirroring the shape of
+  `_async_read_room_heating` etc. — but see the one non-blocking review nit on
+  that method from the PR #101 review: don't call `_push_data`/
+  `async_set_updated_data` from inside `_async_update_data` like it does;
+  just return the value into the assembled `data` dict, matching every other
+  sibling `_async_read_*` helper). Store the value as `data["device_operating_state"]`.
+  Also add the new event type to the existing measurement-event-stream handler
+  (`_run_monitoring_event_stream` or wherever `SubscribeMeasurements` events are
+  dispatched) so a push update sets `self.data["device_operating_state"]` and
+  calls `self.async_set_updated_data`.
+- `sensor.py` — add one new `SensorEntityDescription`: key
+  `device_operating_state`, `translation_key="device_operating_state"`,
+  `entity_category=EntityCategory.DIAGNOSTIC`, no `device_class` (free-text
+  enum, not a fixed HA device class), `entity_registry_enabled_default=True`
+  (this is a plain diagnostic read, not experimental/provider-side, so no
+  reason to default it off — contrast with the flow/return temperature sensors
+  which stayed disabled pending a still-open hardware question; this one's
+  evidence is settled). Value comes from `coordinator.data.get("device_operating_state")`.
+- `translations/en.json` and `translations/de.json` — add the new sensor's
+  name (e.g. "Device operating state" / "Betriebszustand"). If exposing the
+  known enum values as translated state strings, add them too (English: Normal
+  operation / Standby / Failure / Service needed / Override detected / In
+  alarm / Not reachable / Finished / Temporarily not ready / Off) — but the
+  entity itself must not error or go `unavailable` on an unrecognized value;
+  fall back to displaying the raw string.
+- `icons.json` — add an icon for the new sensor key.
+- `custom_components/eebus/tests/test_sensor.py` — add coverage for the new
+  sensor entity (value present, value absent/unavailable, unknown enum string
+  passthrough).
+
+### Docs
+
+- `README.md` — add the new sensor to the feature/sensor list.
+- `custom_components/eebus/quality_scale.yaml` — this adds a new entity; check
+  whether any rule's status/comment needs updating per CLAUDE.md's rule ("A PR
+  that adds a new entity... should update the relevant rule/comment, not
+  silently leave it stale").
+
+## Explicitly out of scope for this PR
+
+Per the findings doc, do not add: firmware/hardware revision, pressure, vendor
+state code/last error code, boot count/uptime/service date, compressor cycle
+count/runtime, current energy mode, `eco` HVAC mode, or away/party mode for room
+heating — all confirmed absent on this hardware. Do not add the heating-zone
+label (`"Zone 1"`) in this PR either; that's a separate Phase 2 item with a
+different entity/feature (`DeviceClassification` on the `HeatingZone` entity,
+not `DeviceDiagnosis` on `HeatPumpAppliance`) and should be its own PR to keep
+this one small and reviewable.
+
+## Verification before calling this done
+
+- `go build ./...`, `go vet ./...`, `go test -race ./...` from `eebus-bridge/`.
+- `ruff check custom_components/`, `mypy custom_components/eebus`,
+  `PYTHONPATH=. pytest` from repo root.
+- Regenerate both proto stub sets and confirm no drift (`git diff --check`,
+  matching `proto-drift` CI job behavior).
+- This is a read-only, always-on (no experimental gate) addition — no hardware
+  write test is needed, but before merge it should be smoke-tested against the
+  live VR940 (build a throwaway-tagged image, deploy to stack 93 same as prior
+  spikes, confirm `sensor.eebus_device_operating_state` (or whatever the final
+  entity id is) shows `normalOperation` live) before being called done — this
+  mirrors how PR #101's DHW/room-heating reads were hardware-validated before
+  merge, even though there's no write path to test here.

--- a/eebus-bridge/cmd/eebus-bridge/main.go
+++ b/eebus-bridge/cmd/eebus-bridge/main.go
@@ -97,6 +97,8 @@ func main() {
 	roomHeatingSystemFunction := usecases.NewRoomHeatingSystemFunction(localEntity, bus, registry, cfg.Logging.DebugEvents)
 	hydraulicTemperatures := usecases.NewHydraulicTemperatures(bus, registry, cfg.Logging.DebugEvents)
 	hydraulicTemperatures.Setup(localEntity)
+	deviceOperatingState := usecases.NewDeviceOperatingState(bus, registry, cfg.Logging.DebugEvents)
+	deviceOperatingState.Setup(localEntity)
 	if err := bridgeSvc.Service().AddUseCase(lpcWrapper.UseCase()); err != nil {
 		log.Fatalf("adding LPC use case: %v", err)
 	}
@@ -265,6 +267,7 @@ func main() {
 		outdoorMonitoringWrapper,
 		usecases.FlowTemperatureReader{HydraulicTemperatures: hydraulicTemperatures},
 		usecases.ReturnTemperatureReader{HydraulicTemperatures: hydraulicTemperatures},
+		deviceOperatingState,
 		bus,
 		registry,
 	)

--- a/eebus-bridge/gen/proto/eebus/v1/monitoring_service.pb.go
+++ b/eebus-bridge/gen/proto/eebus/v1/monitoring_service.pb.go
@@ -36,6 +36,7 @@ const (
 	MeasurementEventType_MEASUREMENT_EVENT_OUTDOOR_TEMPERATURE_SUPPORT_UPDATED MeasurementEventType = 8
 	MeasurementEventType_MEASUREMENT_EVENT_FLOW_TEMPERATURE_UPDATED            MeasurementEventType = 9
 	MeasurementEventType_MEASUREMENT_EVENT_RETURN_TEMPERATURE_UPDATED          MeasurementEventType = 10
+	MeasurementEventType_MEASUREMENT_EVENT_DEVICE_OPERATING_STATE_UPDATED      MeasurementEventType = 11
 )
 
 // Enum value maps for MeasurementEventType.
@@ -52,6 +53,7 @@ var (
 		8:  "MEASUREMENT_EVENT_OUTDOOR_TEMPERATURE_SUPPORT_UPDATED",
 		9:  "MEASUREMENT_EVENT_FLOW_TEMPERATURE_UPDATED",
 		10: "MEASUREMENT_EVENT_RETURN_TEMPERATURE_UPDATED",
+		11: "MEASUREMENT_EVENT_DEVICE_OPERATING_STATE_UPDATED",
 	}
 	MeasurementEventType_value = map[string]int32{
 		"MEASUREMENT_EVENT_UNSPECIFIED":                         0,
@@ -65,6 +67,7 @@ var (
 		"MEASUREMENT_EVENT_OUTDOOR_TEMPERATURE_SUPPORT_UPDATED": 8,
 		"MEASUREMENT_EVENT_FLOW_TEMPERATURE_UPDATED":            9,
 		"MEASUREMENT_EVENT_RETURN_TEMPERATURE_UPDATED":          10,
+		"MEASUREMENT_EVENT_DEVICE_OPERATING_STATE_UPDATED":      11,
 	}
 )
 
@@ -191,6 +194,58 @@ func (x *MeasurementList) GetMeasurements() []*MeasurementEntry {
 	return nil
 }
 
+type DeviceDiagnosticsData struct {
+	state          protoimpl.MessageState `protogen:"open.v1"`
+	OperatingState string                 `protobuf:"bytes,1,opt,name=operating_state,json=operatingState,proto3" json:"operating_state,omitempty"`
+	Timestamp      *timestamppb.Timestamp `protobuf:"bytes,2,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *DeviceDiagnosticsData) Reset() {
+	*x = DeviceDiagnosticsData{}
+	mi := &file_eebus_v1_monitoring_service_proto_msgTypes[2]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DeviceDiagnosticsData) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DeviceDiagnosticsData) ProtoMessage() {}
+
+func (x *DeviceDiagnosticsData) ProtoReflect() protoreflect.Message {
+	mi := &file_eebus_v1_monitoring_service_proto_msgTypes[2]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DeviceDiagnosticsData.ProtoReflect.Descriptor instead.
+func (*DeviceDiagnosticsData) Descriptor() ([]byte, []int) {
+	return file_eebus_v1_monitoring_service_proto_rawDescGZIP(), []int{2}
+}
+
+func (x *DeviceDiagnosticsData) GetOperatingState() string {
+	if x != nil {
+		return x.OperatingState
+	}
+	return ""
+}
+
+func (x *DeviceDiagnosticsData) GetTimestamp() *timestamppb.Timestamp {
+	if x != nil {
+		return x.Timestamp
+	}
+	return nil
+}
+
 type MeasurementEvent struct {
 	state     protoimpl.MessageState `protogen:"open.v1"`
 	Ski       string                 `protobuf:"bytes,1,opt,name=ski,proto3" json:"ski,omitempty"`
@@ -200,6 +255,7 @@ type MeasurementEvent struct {
 	//	*MeasurementEvent_Power
 	//	*MeasurementEvent_Energy
 	//	*MeasurementEvent_Measurement
+	//	*MeasurementEvent_DeviceDiagnostics
 	Data          isMeasurementEvent_Data `protobuf_oneof:"data"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -207,7 +263,7 @@ type MeasurementEvent struct {
 
 func (x *MeasurementEvent) Reset() {
 	*x = MeasurementEvent{}
-	mi := &file_eebus_v1_monitoring_service_proto_msgTypes[2]
+	mi := &file_eebus_v1_monitoring_service_proto_msgTypes[3]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -219,7 +275,7 @@ func (x *MeasurementEvent) String() string {
 func (*MeasurementEvent) ProtoMessage() {}
 
 func (x *MeasurementEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_eebus_v1_monitoring_service_proto_msgTypes[2]
+	mi := &file_eebus_v1_monitoring_service_proto_msgTypes[3]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -232,7 +288,7 @@ func (x *MeasurementEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MeasurementEvent.ProtoReflect.Descriptor instead.
 func (*MeasurementEvent) Descriptor() ([]byte, []int) {
-	return file_eebus_v1_monitoring_service_proto_rawDescGZIP(), []int{2}
+	return file_eebus_v1_monitoring_service_proto_rawDescGZIP(), []int{3}
 }
 
 func (x *MeasurementEvent) GetSki() string {
@@ -283,6 +339,15 @@ func (x *MeasurementEvent) GetMeasurement() *MeasurementEntry {
 	return nil
 }
 
+func (x *MeasurementEvent) GetDeviceDiagnostics() *DeviceDiagnosticsData {
+	if x != nil {
+		if x, ok := x.Data.(*MeasurementEvent_DeviceDiagnostics); ok {
+			return x.DeviceDiagnostics
+		}
+	}
+	return nil
+}
+
 type isMeasurementEvent_Data interface {
 	isMeasurementEvent_Data()
 }
@@ -299,11 +364,17 @@ type MeasurementEvent_Measurement struct {
 	Measurement *MeasurementEntry `protobuf:"bytes,5,opt,name=measurement,proto3,oneof"`
 }
 
+type MeasurementEvent_DeviceDiagnostics struct {
+	DeviceDiagnostics *DeviceDiagnosticsData `protobuf:"bytes,6,opt,name=device_diagnostics,json=deviceDiagnostics,proto3,oneof"`
+}
+
 func (*MeasurementEvent_Power) isMeasurementEvent_Data() {}
 
 func (*MeasurementEvent_Energy) isMeasurementEvent_Data() {}
 
 func (*MeasurementEvent_Measurement) isMeasurementEvent_Data() {}
+
+func (*MeasurementEvent_DeviceDiagnostics) isMeasurementEvent_Data() {}
 
 var File_eebus_v1_monitoring_service_proto protoreflect.FileDescriptor
 
@@ -314,15 +385,19 @@ const file_eebus_v1_monitoring_service_proto_rawDesc = "" +
 	"\x0ekilowatt_hours\x18\x01 \x01(\x01R\rkilowattHours\x128\n" +
 	"\ttimestamp\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\ttimestamp\"Q\n" +
 	"\x0fMeasurementList\x12>\n" +
-	"\fmeasurements\x18\x01 \x03(\v2\x1a.eebus.v1.MeasurementEntryR\fmeasurements\"\x96\x02\n" +
+	"\fmeasurements\x18\x01 \x03(\v2\x1a.eebus.v1.MeasurementEntryR\fmeasurements\"z\n" +
+	"\x15DeviceDiagnosticsData\x12'\n" +
+	"\x0foperating_state\x18\x01 \x01(\tR\x0eoperatingState\x128\n" +
+	"\ttimestamp\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\ttimestamp\"\xe8\x02\n" +
 	"\x10MeasurementEvent\x12\x10\n" +
 	"\x03ski\x18\x01 \x01(\tR\x03ski\x12=\n" +
 	"\n" +
 	"event_type\x18\x02 \x01(\x0e2\x1e.eebus.v1.MeasurementEventTypeR\teventType\x122\n" +
 	"\x05power\x18\x03 \x01(\v2\x1a.eebus.v1.PowerMeasurementH\x00R\x05power\x125\n" +
 	"\x06energy\x18\x04 \x01(\v2\x1b.eebus.v1.EnergyMeasurementH\x00R\x06energy\x12>\n" +
-	"\vmeasurement\x18\x05 \x01(\v2\x1a.eebus.v1.MeasurementEntryH\x00R\vmeasurementB\x06\n" +
-	"\x04data*\xa2\x04\n" +
+	"\vmeasurement\x18\x05 \x01(\v2\x1a.eebus.v1.MeasurementEntryH\x00R\vmeasurement\x12P\n" +
+	"\x12device_diagnostics\x18\x06 \x01(\v2\x1f.eebus.v1.DeviceDiagnosticsDataH\x00R\x11deviceDiagnosticsB\x06\n" +
+	"\x04data*\xd8\x04\n" +
 	"\x14MeasurementEventType\x12!\n" +
 	"\x1dMEASUREMENT_EVENT_UNSPECIFIED\x10\x00\x12#\n" +
 	"\x1fMEASUREMENT_EVENT_POWER_UPDATED\x10\x01\x12$\n" +
@@ -335,11 +410,13 @@ const file_eebus_v1_monitoring_service_proto_rawDesc = "" +
 	"5MEASUREMENT_EVENT_OUTDOOR_TEMPERATURE_SUPPORT_UPDATED\x10\b\x12.\n" +
 	"*MEASUREMENT_EVENT_FLOW_TEMPERATURE_UPDATED\x10\t\x120\n" +
 	",MEASUREMENT_EVENT_RETURN_TEMPERATURE_UPDATED\x10\n" +
-	"2\xc1\x02\n" +
+	"\x124\n" +
+	"0MEASUREMENT_EVENT_DEVICE_OPERATING_STATE_UPDATED\x10\v2\x93\x03\n" +
 	"\x11MonitoringService\x12J\n" +
 	"\x13GetPowerConsumption\x12\x17.eebus.v1.DeviceRequest\x1a\x1a.eebus.v1.PowerMeasurement\x12I\n" +
 	"\x11GetEnergyConsumed\x12\x17.eebus.v1.DeviceRequest\x1a\x1b.eebus.v1.EnergyMeasurement\x12E\n" +
-	"\x0fGetMeasurements\x12\x17.eebus.v1.DeviceRequest\x1a\x19.eebus.v1.MeasurementList\x12N\n" +
+	"\x0fGetMeasurements\x12\x17.eebus.v1.DeviceRequest\x1a\x19.eebus.v1.MeasurementList\x12P\n" +
+	"\x14GetDeviceDiagnostics\x12\x17.eebus.v1.DeviceRequest\x1a\x1f.eebus.v1.DeviceDiagnosticsData\x12N\n" +
 	"\x15SubscribeMeasurements\x12\x17.eebus.v1.DeviceRequest\x1a\x1a.eebus.v1.MeasurementEvent0\x01B=Z;github.com/volschin/eebus-bridge/gen/proto/eebus/v1;eebusv1b\x06proto3"
 
 var (
@@ -355,37 +432,42 @@ func file_eebus_v1_monitoring_service_proto_rawDescGZIP() []byte {
 }
 
 var file_eebus_v1_monitoring_service_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_eebus_v1_monitoring_service_proto_msgTypes = make([]protoimpl.MessageInfo, 3)
+var file_eebus_v1_monitoring_service_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
 var file_eebus_v1_monitoring_service_proto_goTypes = []any{
 	(MeasurementEventType)(0),     // 0: eebus.v1.MeasurementEventType
 	(*EnergyMeasurement)(nil),     // 1: eebus.v1.EnergyMeasurement
 	(*MeasurementList)(nil),       // 2: eebus.v1.MeasurementList
-	(*MeasurementEvent)(nil),      // 3: eebus.v1.MeasurementEvent
-	(*timestamppb.Timestamp)(nil), // 4: google.protobuf.Timestamp
-	(*MeasurementEntry)(nil),      // 5: eebus.v1.MeasurementEntry
-	(*PowerMeasurement)(nil),      // 6: eebus.v1.PowerMeasurement
-	(*DeviceRequest)(nil),         // 7: eebus.v1.DeviceRequest
+	(*DeviceDiagnosticsData)(nil), // 3: eebus.v1.DeviceDiagnosticsData
+	(*MeasurementEvent)(nil),      // 4: eebus.v1.MeasurementEvent
+	(*timestamppb.Timestamp)(nil), // 5: google.protobuf.Timestamp
+	(*MeasurementEntry)(nil),      // 6: eebus.v1.MeasurementEntry
+	(*PowerMeasurement)(nil),      // 7: eebus.v1.PowerMeasurement
+	(*DeviceRequest)(nil),         // 8: eebus.v1.DeviceRequest
 }
 var file_eebus_v1_monitoring_service_proto_depIdxs = []int32{
-	4,  // 0: eebus.v1.EnergyMeasurement.timestamp:type_name -> google.protobuf.Timestamp
-	5,  // 1: eebus.v1.MeasurementList.measurements:type_name -> eebus.v1.MeasurementEntry
-	0,  // 2: eebus.v1.MeasurementEvent.event_type:type_name -> eebus.v1.MeasurementEventType
-	6,  // 3: eebus.v1.MeasurementEvent.power:type_name -> eebus.v1.PowerMeasurement
-	1,  // 4: eebus.v1.MeasurementEvent.energy:type_name -> eebus.v1.EnergyMeasurement
-	5,  // 5: eebus.v1.MeasurementEvent.measurement:type_name -> eebus.v1.MeasurementEntry
-	7,  // 6: eebus.v1.MonitoringService.GetPowerConsumption:input_type -> eebus.v1.DeviceRequest
-	7,  // 7: eebus.v1.MonitoringService.GetEnergyConsumed:input_type -> eebus.v1.DeviceRequest
-	7,  // 8: eebus.v1.MonitoringService.GetMeasurements:input_type -> eebus.v1.DeviceRequest
-	7,  // 9: eebus.v1.MonitoringService.SubscribeMeasurements:input_type -> eebus.v1.DeviceRequest
-	6,  // 10: eebus.v1.MonitoringService.GetPowerConsumption:output_type -> eebus.v1.PowerMeasurement
-	1,  // 11: eebus.v1.MonitoringService.GetEnergyConsumed:output_type -> eebus.v1.EnergyMeasurement
-	2,  // 12: eebus.v1.MonitoringService.GetMeasurements:output_type -> eebus.v1.MeasurementList
-	3,  // 13: eebus.v1.MonitoringService.SubscribeMeasurements:output_type -> eebus.v1.MeasurementEvent
-	10, // [10:14] is the sub-list for method output_type
-	6,  // [6:10] is the sub-list for method input_type
-	6,  // [6:6] is the sub-list for extension type_name
-	6,  // [6:6] is the sub-list for extension extendee
-	0,  // [0:6] is the sub-list for field type_name
+	5,  // 0: eebus.v1.EnergyMeasurement.timestamp:type_name -> google.protobuf.Timestamp
+	6,  // 1: eebus.v1.MeasurementList.measurements:type_name -> eebus.v1.MeasurementEntry
+	5,  // 2: eebus.v1.DeviceDiagnosticsData.timestamp:type_name -> google.protobuf.Timestamp
+	0,  // 3: eebus.v1.MeasurementEvent.event_type:type_name -> eebus.v1.MeasurementEventType
+	7,  // 4: eebus.v1.MeasurementEvent.power:type_name -> eebus.v1.PowerMeasurement
+	1,  // 5: eebus.v1.MeasurementEvent.energy:type_name -> eebus.v1.EnergyMeasurement
+	6,  // 6: eebus.v1.MeasurementEvent.measurement:type_name -> eebus.v1.MeasurementEntry
+	3,  // 7: eebus.v1.MeasurementEvent.device_diagnostics:type_name -> eebus.v1.DeviceDiagnosticsData
+	8,  // 8: eebus.v1.MonitoringService.GetPowerConsumption:input_type -> eebus.v1.DeviceRequest
+	8,  // 9: eebus.v1.MonitoringService.GetEnergyConsumed:input_type -> eebus.v1.DeviceRequest
+	8,  // 10: eebus.v1.MonitoringService.GetMeasurements:input_type -> eebus.v1.DeviceRequest
+	8,  // 11: eebus.v1.MonitoringService.GetDeviceDiagnostics:input_type -> eebus.v1.DeviceRequest
+	8,  // 12: eebus.v1.MonitoringService.SubscribeMeasurements:input_type -> eebus.v1.DeviceRequest
+	7,  // 13: eebus.v1.MonitoringService.GetPowerConsumption:output_type -> eebus.v1.PowerMeasurement
+	1,  // 14: eebus.v1.MonitoringService.GetEnergyConsumed:output_type -> eebus.v1.EnergyMeasurement
+	2,  // 15: eebus.v1.MonitoringService.GetMeasurements:output_type -> eebus.v1.MeasurementList
+	3,  // 16: eebus.v1.MonitoringService.GetDeviceDiagnostics:output_type -> eebus.v1.DeviceDiagnosticsData
+	4,  // 17: eebus.v1.MonitoringService.SubscribeMeasurements:output_type -> eebus.v1.MeasurementEvent
+	13, // [13:18] is the sub-list for method output_type
+	8,  // [8:13] is the sub-list for method input_type
+	8,  // [8:8] is the sub-list for extension type_name
+	8,  // [8:8] is the sub-list for extension extendee
+	0,  // [0:8] is the sub-list for field type_name
 }
 
 func init() { file_eebus_v1_monitoring_service_proto_init() }
@@ -394,10 +476,11 @@ func file_eebus_v1_monitoring_service_proto_init() {
 		return
 	}
 	file_eebus_v1_common_proto_init()
-	file_eebus_v1_monitoring_service_proto_msgTypes[2].OneofWrappers = []any{
+	file_eebus_v1_monitoring_service_proto_msgTypes[3].OneofWrappers = []any{
 		(*MeasurementEvent_Power)(nil),
 		(*MeasurementEvent_Energy)(nil),
 		(*MeasurementEvent_Measurement)(nil),
+		(*MeasurementEvent_DeviceDiagnostics)(nil),
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
@@ -405,7 +488,7 @@ func file_eebus_v1_monitoring_service_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_eebus_v1_monitoring_service_proto_rawDesc), len(file_eebus_v1_monitoring_service_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   3,
+			NumMessages:   4,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/eebus-bridge/gen/proto/eebus/v1/monitoring_service_grpc.pb.go
+++ b/eebus-bridge/gen/proto/eebus/v1/monitoring_service_grpc.pb.go
@@ -22,6 +22,7 @@ const (
 	MonitoringService_GetPowerConsumption_FullMethodName   = "/eebus.v1.MonitoringService/GetPowerConsumption"
 	MonitoringService_GetEnergyConsumed_FullMethodName     = "/eebus.v1.MonitoringService/GetEnergyConsumed"
 	MonitoringService_GetMeasurements_FullMethodName       = "/eebus.v1.MonitoringService/GetMeasurements"
+	MonitoringService_GetDeviceDiagnostics_FullMethodName  = "/eebus.v1.MonitoringService/GetDeviceDiagnostics"
 	MonitoringService_SubscribeMeasurements_FullMethodName = "/eebus.v1.MonitoringService/SubscribeMeasurements"
 )
 
@@ -32,6 +33,7 @@ type MonitoringServiceClient interface {
 	GetPowerConsumption(ctx context.Context, in *DeviceRequest, opts ...grpc.CallOption) (*PowerMeasurement, error)
 	GetEnergyConsumed(ctx context.Context, in *DeviceRequest, opts ...grpc.CallOption) (*EnergyMeasurement, error)
 	GetMeasurements(ctx context.Context, in *DeviceRequest, opts ...grpc.CallOption) (*MeasurementList, error)
+	GetDeviceDiagnostics(ctx context.Context, in *DeviceRequest, opts ...grpc.CallOption) (*DeviceDiagnosticsData, error)
 	SubscribeMeasurements(ctx context.Context, in *DeviceRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[MeasurementEvent], error)
 }
 
@@ -73,6 +75,16 @@ func (c *monitoringServiceClient) GetMeasurements(ctx context.Context, in *Devic
 	return out, nil
 }
 
+func (c *monitoringServiceClient) GetDeviceDiagnostics(ctx context.Context, in *DeviceRequest, opts ...grpc.CallOption) (*DeviceDiagnosticsData, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(DeviceDiagnosticsData)
+	err := c.cc.Invoke(ctx, MonitoringService_GetDeviceDiagnostics_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *monitoringServiceClient) SubscribeMeasurements(ctx context.Context, in *DeviceRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[MeasurementEvent], error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	stream, err := c.cc.NewStream(ctx, &MonitoringService_ServiceDesc.Streams[0], MonitoringService_SubscribeMeasurements_FullMethodName, cOpts...)
@@ -99,6 +111,7 @@ type MonitoringServiceServer interface {
 	GetPowerConsumption(context.Context, *DeviceRequest) (*PowerMeasurement, error)
 	GetEnergyConsumed(context.Context, *DeviceRequest) (*EnergyMeasurement, error)
 	GetMeasurements(context.Context, *DeviceRequest) (*MeasurementList, error)
+	GetDeviceDiagnostics(context.Context, *DeviceRequest) (*DeviceDiagnosticsData, error)
 	SubscribeMeasurements(*DeviceRequest, grpc.ServerStreamingServer[MeasurementEvent]) error
 	mustEmbedUnimplementedMonitoringServiceServer()
 }
@@ -118,6 +131,9 @@ func (UnimplementedMonitoringServiceServer) GetEnergyConsumed(context.Context, *
 }
 func (UnimplementedMonitoringServiceServer) GetMeasurements(context.Context, *DeviceRequest) (*MeasurementList, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetMeasurements not implemented")
+}
+func (UnimplementedMonitoringServiceServer) GetDeviceDiagnostics(context.Context, *DeviceRequest) (*DeviceDiagnosticsData, error) {
+	return nil, status.Error(codes.Unimplemented, "method GetDeviceDiagnostics not implemented")
 }
 func (UnimplementedMonitoringServiceServer) SubscribeMeasurements(*DeviceRequest, grpc.ServerStreamingServer[MeasurementEvent]) error {
 	return status.Error(codes.Unimplemented, "method SubscribeMeasurements not implemented")
@@ -197,6 +213,24 @@ func _MonitoringService_GetMeasurements_Handler(srv interface{}, ctx context.Con
 	return interceptor(ctx, in, info, handler)
 }
 
+func _MonitoringService_GetDeviceDiagnostics_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(DeviceRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(MonitoringServiceServer).GetDeviceDiagnostics(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: MonitoringService_GetDeviceDiagnostics_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(MonitoringServiceServer).GetDeviceDiagnostics(ctx, req.(*DeviceRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _MonitoringService_SubscribeMeasurements_Handler(srv interface{}, stream grpc.ServerStream) error {
 	m := new(DeviceRequest)
 	if err := stream.RecvMsg(m); err != nil {
@@ -226,6 +260,10 @@ var MonitoringService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "GetMeasurements",
 			Handler:    _MonitoringService_GetMeasurements_Handler,
+		},
+		{
+			MethodName: "GetDeviceDiagnostics",
+			Handler:    _MonitoringService_GetDeviceDiagnostics_Handler,
 		},
 	},
 	Streams: []grpc.StreamDesc{

--- a/eebus-bridge/internal/grpc/integration_test.go
+++ b/eebus-bridge/internal/grpc/integration_test.go
@@ -22,7 +22,7 @@ func TestIntegrationDeviceServiceRoundTrip(t *testing.T) {
 
 	deviceSvc := bridgegrpc.NewDeviceService(callbacks, bus, "integration-test-ski", registry)
 	lpcSvc := bridgegrpc.NewLPCService(nil, bus, registry)
-	monSvc := bridgegrpc.NewMonitoringService(nil, nil, nil, nil, nil, nil, bus, registry)
+	monSvc := bridgegrpc.NewMonitoringService(nil, nil, nil, nil, nil, nil, nil, bus, registry)
 
 	srv := bridgegrpc.NewServer("127.0.0.1", 0, false)
 	pb.RegisterDeviceServiceServer(srv.GRPCServer(), deviceSvc)

--- a/eebus-bridge/internal/grpc/monitoring_service.go
+++ b/eebus-bridge/internal/grpc/monitoring_service.go
@@ -2,6 +2,7 @@ package grpc
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 
@@ -17,18 +18,23 @@ import (
 
 type MonitoringService struct {
 	pb.UnimplementedMonitoringServiceServer
-	monitoring *usecases.MonitoringWrapper
-	dhw        temperatureReader
-	room       temperatureReader
-	outdoor    temperatureReader
-	flow       temperatureReader
-	returnTemp temperatureReader
-	bus        *eebus.EventBus
-	registry   *eebus.DeviceRegistry
+	monitoring  *usecases.MonitoringWrapper
+	dhw         temperatureReader
+	room        temperatureReader
+	outdoor     temperatureReader
+	flow        temperatureReader
+	returnTemp  temperatureReader
+	diagnostics deviceOperatingStateReader
+	bus         *eebus.EventBus
+	registry    *eebus.DeviceRegistry
 }
 
 type temperatureReader interface {
 	Temperature(string) (float64, error)
+}
+
+type deviceOperatingStateReader interface {
+	OperatingState(string) (string, error)
 }
 
 func NewMonitoringService(
@@ -38,19 +44,41 @@ func NewMonitoringService(
 	outdoor temperatureReader,
 	flow temperatureReader,
 	returnTemp temperatureReader,
+	diagnostics deviceOperatingStateReader,
 	bus *eebus.EventBus,
 	registry *eebus.DeviceRegistry,
 ) *MonitoringService {
 	return &MonitoringService{
-		monitoring: monitoring,
-		dhw:        dhw,
-		room:       room,
-		outdoor:    outdoor,
-		flow:       flow,
-		returnTemp: returnTemp,
-		bus:        bus,
-		registry:   registry,
+		monitoring:  monitoring,
+		dhw:         dhw,
+		room:        room,
+		outdoor:     outdoor,
+		flow:        flow,
+		returnTemp:  returnTemp,
+		diagnostics: diagnostics,
+		bus:         bus,
+		registry:    registry,
 	}
+}
+
+func (s *MonitoringService) GetDeviceDiagnostics(_ context.Context, req *pb.DeviceRequest) (*pb.DeviceDiagnosticsData, error) {
+	if req == nil {
+		return nil, status.Error(codes.InvalidArgument, "request is required")
+	}
+	if s.diagnostics == nil {
+		return nil, status.Error(codes.Unavailable, "device diagnosis reader not initialized")
+	}
+	state, err := s.diagnostics.OperatingState(req.Ski)
+	if err != nil {
+		if errors.Is(err, usecases.ErrDeviceOperatingStateUnavailable) {
+			return nil, status.Errorf(codes.NotFound, "reading device operating state: %v", err)
+		}
+		return nil, status.Errorf(codes.Internal, "reading device operating state: %v", err)
+	}
+	return &pb.DeviceDiagnosticsData{
+		OperatingState: state,
+		Timestamp:      timestamppb.Now(),
+	}, nil
 }
 
 func (s *MonitoringService) GetPowerConsumption(_ context.Context, req *pb.DeviceRequest) (*pb.PowerMeasurement, error) {
@@ -229,6 +257,8 @@ func (s *MonitoringService) SubscribeMeasurements(req *pb.DeviceRequest, stream 
 				eventType = pb.MeasurementEventType_MEASUREMENT_EVENT_FLOW_TEMPERATURE_UPDATED
 			case "monitoring.return_temperature_updated":
 				eventType = pb.MeasurementEventType_MEASUREMENT_EVENT_RETURN_TEMPERATURE_UPDATED
+			case "monitoring.device_operating_state_updated":
+				eventType = pb.MeasurementEventType_MEASUREMENT_EVENT_DEVICE_OPERATING_STATE_UPDATED
 			default:
 				continue
 			}
@@ -273,6 +303,16 @@ func (s *MonitoringService) attachMeasurementPayload(event *pb.MeasurementEvent,
 		s.attachTemperaturePayload(event, ski, s.flow, "flow_temperature")
 	case pb.MeasurementEventType_MEASUREMENT_EVENT_RETURN_TEMPERATURE_UPDATED:
 		s.attachTemperaturePayload(event, ski, s.returnTemp, "return_temperature")
+	case pb.MeasurementEventType_MEASUREMENT_EVENT_DEVICE_OPERATING_STATE_UPDATED:
+		if s.diagnostics == nil {
+			return
+		}
+		if state, err := s.diagnostics.OperatingState(ski); err == nil {
+			event.Data = &pb.MeasurementEvent_DeviceDiagnostics{DeviceDiagnostics: &pb.DeviceDiagnosticsData{
+				OperatingState: state,
+				Timestamp:      timestamppb.Now(),
+			}}
+		}
 	}
 }
 

--- a/eebus-bridge/internal/grpc/monitoring_service_test.go
+++ b/eebus-bridge/internal/grpc/monitoring_service_test.go
@@ -2,6 +2,7 @@ package grpc_test
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -10,7 +11,10 @@ import (
 	bridgegrpc "github.com/volschin/eebus-bridge/internal/grpc"
 	"github.com/volschin/eebus-bridge/internal/usecases"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
 )
 
 type fakeDHWTemperatureReader struct {
@@ -22,9 +26,18 @@ func (f fakeDHWTemperatureReader) Temperature(string) (float64, error) {
 	return f.value, f.err
 }
 
+type fakeDeviceOperatingStateReader struct {
+	value string
+	err   error
+}
+
+func (f fakeDeviceOperatingStateReader) OperatingState(string) (string, error) {
+	return f.value, f.err
+}
+
 func TestSubscribeMeasurements(t *testing.T) {
 	bus := eebus.NewEventBus()
-	svc := bridgegrpc.NewMonitoringService(nil, nil, nil, nil, nil, nil, bus, eebus.NewDeviceRegistry())
+	svc := bridgegrpc.NewMonitoringService(nil, nil, nil, nil, nil, nil, nil, bus, eebus.NewDeviceRegistry())
 
 	srv := bridgegrpc.NewServer("127.0.0.1", 0, false)
 	pb.RegisterMonitoringServiceServer(srv.GRPCServer(), svc)
@@ -68,6 +81,7 @@ func TestGetMeasurementsIncludesTemperatureUseCases(t *testing.T) {
 		fakeDHWTemperatureReader{value: 7.75},
 		fakeDHWTemperatureReader{value: 42.5},
 		fakeDHWTemperatureReader{value: 37.25},
+		nil,
 		eebus.NewEventBus(),
 		eebus.NewDeviceRegistry(),
 	)
@@ -106,6 +120,7 @@ func TestSubscribeMeasurementsIncludesTemperaturePayloads(t *testing.T) {
 		fakeDHWTemperatureReader{value: 6.5},
 		fakeDHWTemperatureReader{value: 43},
 		fakeDHWTemperatureReader{value: 38},
+		nil,
 		bus,
 		eebus.NewDeviceRegistry(),
 	)
@@ -174,3 +189,91 @@ func TestSubscribeMeasurementsIncludesTemperaturePayloads(t *testing.T) {
 		}
 	}
 }
+
+func TestGetDeviceDiagnostics(t *testing.T) {
+	svc := bridgegrpc.NewMonitoringService(
+		nil, nil, nil, nil, nil, nil,
+		fakeDeviceOperatingStateReader{value: "normalOperation"},
+		eebus.NewEventBus(),
+		eebus.NewDeviceRegistry(),
+	)
+
+	result, err := svc.GetDeviceDiagnostics(context.Background(), &pb.DeviceRequest{Ski: "test-ski"})
+	if err != nil {
+		t.Fatalf("GetDeviceDiagnostics() error = %v", err)
+	}
+	if result.OperatingState != "normalOperation" || result.Timestamp == nil {
+		t.Fatalf("GetDeviceDiagnostics() = %+v", result)
+	}
+}
+
+func TestGetDeviceDiagnosticsReturnsNotFoundWhenUnavailable(t *testing.T) {
+	svc := bridgegrpc.NewMonitoringService(
+		nil, nil, nil, nil, nil, nil,
+		fakeDeviceOperatingStateReader{err: usecases.ErrDeviceOperatingStateUnavailable},
+		eebus.NewEventBus(),
+		eebus.NewDeviceRegistry(),
+	)
+
+	_, err := svc.GetDeviceDiagnostics(context.Background(), &pb.DeviceRequest{Ski: "test-ski"})
+	if status.Code(err) != codes.NotFound {
+		t.Fatalf("GetDeviceDiagnostics() code = %v, want NotFound", status.Code(err))
+	}
+}
+
+func TestSubscribeMeasurementsForwardsDeviceOperatingState(t *testing.T) {
+	bus := eebus.NewEventBus()
+	svc := bridgegrpc.NewMonitoringService(
+		nil, nil, nil, nil, nil, nil,
+		fakeDeviceOperatingStateReader{value: "futureVendorState"},
+		bus,
+		eebus.NewDeviceRegistry(),
+	)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	stream := newFakeMeasurementStream(ctx)
+	done := make(chan error, 1)
+	go func() {
+		done <- svc.SubscribeMeasurements(&pb.DeviceRequest{Ski: "test-ski"}, stream)
+	}()
+
+	time.Sleep(10 * time.Millisecond)
+	bus.Publish(eebus.Event{SKI: "test-ski", Type: "monitoring.device_operating_state_updated"})
+
+	select {
+	case event := <-stream.events:
+		if event.EventType != pb.MeasurementEventType_MEASUREMENT_EVENT_DEVICE_OPERATING_STATE_UPDATED ||
+			event.GetDeviceDiagnostics().GetOperatingState() != "futureVendorState" ||
+			event.GetDeviceDiagnostics().GetTimestamp() == nil {
+			t.Fatalf("event = %+v", event)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for device operating state event")
+	}
+
+	cancel()
+	if err := <-done; !errors.Is(err, context.Canceled) {
+		t.Fatalf("SubscribeMeasurements() error = %v, want context.Canceled", err)
+	}
+}
+
+type fakeMeasurementStream struct {
+	ctx    context.Context
+	events chan *pb.MeasurementEvent
+}
+
+func newFakeMeasurementStream(ctx context.Context) *fakeMeasurementStream {
+	return &fakeMeasurementStream{ctx: ctx, events: make(chan *pb.MeasurementEvent, 1)}
+}
+
+func (s *fakeMeasurementStream) Send(event *pb.MeasurementEvent) error {
+	s.events <- event
+	return nil
+}
+
+func (s *fakeMeasurementStream) SetHeader(metadata.MD) error  { return nil }
+func (s *fakeMeasurementStream) SendHeader(metadata.MD) error { return nil }
+func (s *fakeMeasurementStream) SetTrailer(metadata.MD)       {}
+func (s *fakeMeasurementStream) Context() context.Context     { return s.ctx }
+func (s *fakeMeasurementStream) SendMsg(any) error            { return nil }
+func (s *fakeMeasurementStream) RecvMsg(any) error            { return nil }

--- a/eebus-bridge/internal/usecases/devicediagnosis.go
+++ b/eebus-bridge/internal/usecases/devicediagnosis.go
@@ -1,0 +1,157 @@
+package usecases
+
+import (
+	"errors"
+	"log"
+	"time"
+
+	spineapi "github.com/enbility/spine-go/api"
+	"github.com/enbility/spine-go/model"
+	"github.com/volschin/eebus-bridge/internal/eebus"
+)
+
+var ErrDeviceOperatingStateUnavailable = errors.New("device operating state unavailable")
+
+var deviceOperatingStateReadTimeout = 5 * time.Second
+
+// DeviceOperatingState registers its own DeviceDiagnosis/client feature and
+// actively reads the remote DeviceDiagnosis/server feature because no existing
+// EEBUS use case negotiates or refreshes that feature.
+type DeviceOperatingState struct {
+	bus         *eebus.EventBus
+	registry    *eebus.DeviceRegistry
+	localEntity spineapi.EntityLocalInterface
+	debug       bool
+}
+
+func NewDeviceOperatingState(
+	bus *eebus.EventBus,
+	registry *eebus.DeviceRegistry,
+	debug bool,
+) *DeviceOperatingState {
+	return &DeviceOperatingState{bus: bus, registry: registry, debug: debug}
+}
+
+// Setup registers the local DeviceDiagnosis client before service startup and
+// subscribes to raw cache updates from the local device.
+func (d *DeviceOperatingState) Setup(localEntity spineapi.EntityLocalInterface) {
+	if localEntity == nil {
+		return
+	}
+	d.localEntity = localEntity
+	localEntity.GetOrAddFeature(model.FeatureTypeTypeDeviceDiagnosis, model.RoleTypeClient)
+	_ = localEntity.Device().Events().Subscribe(d)
+}
+
+// HandleEvent republishes valid DeviceDiagnosis cache updates as typed events.
+func (d *DeviceOperatingState) HandleEvent(payload spineapi.EventPayload) {
+	if payload.Entity == nil || payload.EventType != spineapi.EventTypeDataChange ||
+		payload.ChangeType != spineapi.ElementChangeUpdate {
+		return
+	}
+	if _, ok := payload.Data.(*model.DeviceDiagnosisStateDataType); !ok {
+		return
+	}
+	if d.registry == nil || d.bus == nil {
+		return
+	}
+	ski := eebus.NormalizeSKI(payload.Ski)
+	if _, err := d.OperatingState(ski); err == nil {
+		d.bus.Publish(eebus.Event{SKI: ski, Type: "monitoring.device_operating_state_updated"})
+	}
+}
+
+// OperatingState actively reads and returns the remote device operating state.
+func (d *DeviceOperatingState) OperatingState(ski string) (string, error) {
+	local := d.localDeviceDiagnosisFeature()
+	remote := d.remoteDeviceDiagnosisFeature(ski)
+	if local == nil || remote == nil {
+		return "", ErrDeviceOperatingStateUnavailable
+	}
+
+	counter, requestErr := local.RequestRemoteData(
+		model.FunctionTypeDeviceDiagnosisStateData,
+		nil,
+		nil,
+		remote,
+	)
+	if requestErr != nil {
+		if d.debug {
+			log.Printf("[DeviceDiagnosis] requesting operating state failed: %s", requestErr.String())
+		}
+		return operatingStateFromCache(remote)
+	}
+	if counter == nil {
+		return operatingStateFromCache(remote)
+	}
+
+	response := make(chan any, 1)
+	if err := local.AddResponseCallback(*counter, func(message spineapi.ResponseMessage) {
+		select {
+		case response <- message.Data:
+		default:
+		}
+	}); err != nil {
+		if d.debug {
+			log.Printf("[DeviceDiagnosis] registering operating-state response callback failed: %v", err)
+		}
+		return operatingStateFromCache(remote)
+	}
+
+	timer := time.NewTimer(deviceOperatingStateReadTimeout)
+	defer timer.Stop()
+	select {
+	case data := <-response:
+		if state, ok := deviceOperatingState(data); ok {
+			return state, nil
+		}
+		return operatingStateFromCache(remote)
+	case <-timer.C:
+		return operatingStateFromCache(remote)
+	}
+}
+
+func (d *DeviceOperatingState) localDeviceDiagnosisFeature() spineapi.FeatureLocalInterface {
+	if d.localEntity == nil {
+		return nil
+	}
+	return d.localEntity.FeatureOfTypeAndRole(model.FeatureTypeTypeDeviceDiagnosis, model.RoleTypeClient)
+}
+
+func (d *DeviceOperatingState) remoteDeviceDiagnosisFeature(ski string) spineapi.FeatureRemoteInterface {
+	if d.registry == nil {
+		return nil
+	}
+	var fallback spineapi.FeatureRemoteInterface
+	for _, info := range d.registry.Entities(ski) {
+		if info.Entity == nil {
+			continue
+		}
+		feature := info.Entity.FeatureOfTypeAndRole(model.FeatureTypeTypeDeviceDiagnosis, model.RoleTypeServer)
+		if feature == nil {
+			continue
+		}
+		if info.Type == string(model.EntityTypeTypeHeatPumpAppliance) {
+			return feature
+		}
+		if fallback == nil {
+			fallback = feature
+		}
+	}
+	return fallback
+}
+
+func operatingStateFromCache(feature spineapi.FeatureRemoteInterface) (string, error) {
+	if state, ok := deviceOperatingState(feature.DataCopy(model.FunctionTypeDeviceDiagnosisStateData)); ok {
+		return state, nil
+	}
+	return "", ErrDeviceOperatingStateUnavailable
+}
+
+func deviceOperatingState(data any) (string, bool) {
+	state, ok := data.(*model.DeviceDiagnosisStateDataType)
+	if !ok || state == nil || state.OperatingState == nil {
+		return "", false
+	}
+	return string(*state.OperatingState), true
+}

--- a/eebus-bridge/internal/usecases/devicediagnosis_test.go
+++ b/eebus-bridge/internal/usecases/devicediagnosis_test.go
@@ -1,0 +1,139 @@
+package usecases
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	spineapi "github.com/enbility/spine-go/api"
+	"github.com/enbility/spine-go/mocks"
+	"github.com/enbility/spine-go/model"
+	"github.com/stretchr/testify/mock"
+	"github.com/volschin/eebus-bridge/internal/eebus"
+)
+
+func TestDeviceOperatingStateReadsResponse(t *testing.T) {
+	reader, local, remote := deviceOperatingStateHarness(t)
+	local.On("AddResponseCallback", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+		callback := args.Get(1).(func(spineapi.ResponseMessage))
+		callback(spineapi.ResponseMessage{Data: diagnosisState("normalOperation")})
+	}).Return(nil)
+	remote.On("DataCopy", model.FunctionTypeDeviceDiagnosisStateData).Return(nil).Maybe()
+
+	state, err := reader.OperatingState("test-ski")
+	if err != nil {
+		t.Fatalf("OperatingState() error = %v", err)
+	}
+	if state != "normalOperation" {
+		t.Fatalf("OperatingState() = %q, want normalOperation", state)
+	}
+}
+
+func TestDeviceOperatingStateReadsCacheFallback(t *testing.T) {
+	reader, local, remote := deviceOperatingStateHarness(t)
+	local.On("AddResponseCallback", mock.Anything, mock.Anything).Return(nil)
+	remote.On("DataCopy", model.FunctionTypeDeviceDiagnosisStateData).Return(diagnosisState("standby"))
+	setDeviceOperatingStateReadTimeout(t, time.Millisecond)
+
+	state, err := reader.OperatingState("test-ski")
+	if err != nil {
+		t.Fatalf("OperatingState() error = %v", err)
+	}
+	if state != "standby" {
+		t.Fatalf("OperatingState() = %q, want standby", state)
+	}
+}
+
+func TestDeviceOperatingStateReturnsUnavailableOnTimeout(t *testing.T) {
+	reader, local, remote := deviceOperatingStateHarness(t)
+	local.On("AddResponseCallback", mock.Anything, mock.Anything).Return(nil)
+	remote.On("DataCopy", model.FunctionTypeDeviceDiagnosisStateData).Return(nil)
+	setDeviceOperatingStateReadTimeout(t, time.Millisecond)
+
+	_, err := reader.OperatingState("test-ski")
+	if !errors.Is(err, ErrDeviceOperatingStateUnavailable) {
+		t.Fatalf("OperatingState() error = %v, want ErrDeviceOperatingStateUnavailable", err)
+	}
+}
+
+func TestDeviceOperatingStatePassesThroughUnknownState(t *testing.T) {
+	reader, local, remote := deviceOperatingStateHarness(t)
+	local.On("AddResponseCallback", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+		callback := args.Get(1).(func(spineapi.ResponseMessage))
+		callback(spineapi.ResponseMessage{Data: diagnosisState("futureVendorState")})
+	}).Return(nil)
+	remote.On("DataCopy", model.FunctionTypeDeviceDiagnosisStateData).Return(nil).Maybe()
+
+	state, err := reader.OperatingState("test-ski")
+	if err != nil {
+		t.Fatalf("OperatingState() error = %v", err)
+	}
+	if state != "futureVendorState" {
+		t.Fatalf("OperatingState() = %q, want futureVendorState", state)
+	}
+}
+
+func TestDeviceOperatingStateHandleEventIgnoresUnrelatedUpdates(t *testing.T) {
+	reader := NewDeviceOperatingState(eebus.NewEventBus(), eebus.NewDeviceRegistry(), false)
+
+	reader.HandleEvent(spineapi.EventPayload{
+		Entity:     mocks.NewEntityRemoteInterface(t),
+		EventType:  spineapi.EventTypeDataChange,
+		ChangeType: spineapi.ElementChangeUpdate,
+		Data:       &model.MeasurementListDataType{},
+	})
+	reader.HandleEvent(spineapi.EventPayload{
+		Entity:     mocks.NewEntityRemoteInterface(t),
+		EventType:  spineapi.EventTypeDataChange,
+		ChangeType: spineapi.ElementChangeAdd,
+		Data:       diagnosisState("normalOperation"),
+	})
+}
+
+func deviceOperatingStateHarness(
+	t *testing.T,
+) (*DeviceOperatingState, *mocks.FeatureLocalInterface, *mocks.FeatureRemoteInterface) {
+	t.Helper()
+	remote := mocks.NewFeatureRemoteInterface(t)
+	remote.On("Type").Return(model.FeatureTypeTypeDeviceDiagnosis)
+	remote.On("Role").Return(model.RoleTypeServer)
+	remote.On("String").Return("remote device diagnosis").Maybe()
+
+	entity := mocks.NewEntityRemoteInterface(t)
+	entity.On("FeatureOfTypeAndRole", model.FeatureTypeTypeDeviceDiagnosis, model.RoleTypeServer).Return(remote)
+	entity.On("Address").Return(&model.EntityAddressType{})
+	entity.On("EntityType").Return(model.EntityTypeTypeHeatPumpAppliance)
+	entity.On("Features").Return([]spineapi.FeatureRemoteInterface{remote})
+
+	registry := eebus.NewDeviceRegistry()
+	registry.AddDevice("test-ski", eebus.DeviceInfo{SKI: "test-ski"})
+	registry.UpsertObservation("test-ski", nil, entity, "device_diagnosis")
+
+	local := mocks.NewFeatureLocalInterface(t)
+	local.On("String").Return("local device diagnosis").Maybe()
+	local.On(
+		"RequestRemoteData",
+		model.FunctionTypeDeviceDiagnosisStateData,
+		nil,
+		nil,
+		remote,
+	).Return(ptr(model.MsgCounterType(1)), (*model.ErrorType)(nil))
+	localEntity := mocks.NewEntityLocalInterface(t)
+	localEntity.On("FeatureOfTypeAndRole", model.FeatureTypeTypeDeviceDiagnosis, model.RoleTypeClient).Return(local)
+
+	reader := NewDeviceOperatingState(eebus.NewEventBus(), registry, false)
+	reader.localEntity = localEntity
+	return reader, local, remote
+}
+
+func diagnosisState(value string) *model.DeviceDiagnosisStateDataType {
+	state := model.DeviceDiagnosisOperatingStateType(value)
+	return &model.DeviceDiagnosisStateDataType{OperatingState: &state}
+}
+
+func setDeviceOperatingStateReadTimeout(t *testing.T, timeout time.Duration) {
+	t.Helper()
+	original := deviceOperatingStateReadTimeout
+	deviceOperatingStateReadTimeout = timeout
+	t.Cleanup(func() { deviceOperatingStateReadTimeout = original })
+}

--- a/eebus-bridge/proto/eebus/v1/monitoring_service.proto
+++ b/eebus-bridge/proto/eebus/v1/monitoring_service.proto
@@ -11,6 +11,7 @@ service MonitoringService {
   rpc GetPowerConsumption(DeviceRequest) returns (PowerMeasurement);
   rpc GetEnergyConsumed(DeviceRequest) returns (EnergyMeasurement);
   rpc GetMeasurements(DeviceRequest) returns (MeasurementList);
+  rpc GetDeviceDiagnostics(DeviceRequest) returns (DeviceDiagnosticsData);
   rpc SubscribeMeasurements(DeviceRequest) returns (stream MeasurementEvent);
 }
 
@@ -23,6 +24,11 @@ message MeasurementList {
   repeated MeasurementEntry measurements = 1;
 }
 
+message DeviceDiagnosticsData {
+  string operating_state = 1;
+  google.protobuf.Timestamp timestamp = 2;
+}
+
 message MeasurementEvent {
   string ski = 1;
   MeasurementEventType event_type = 2;
@@ -30,6 +36,7 @@ message MeasurementEvent {
     PowerMeasurement power = 3;
     EnergyMeasurement energy = 4;
     MeasurementEntry measurement = 5;
+    DeviceDiagnosticsData device_diagnostics = 6;
   }
 }
 
@@ -45,4 +52,5 @@ enum MeasurementEventType {
   MEASUREMENT_EVENT_OUTDOOR_TEMPERATURE_SUPPORT_UPDATED = 8;
   MEASUREMENT_EVENT_FLOW_TEMPERATURE_UPDATED = 9;
   MEASUREMENT_EVENT_RETURN_TEMPERATURE_UPDATED = 10;
+  MEASUREMENT_EVENT_DEVICE_OPERATING_STATE_UPDATED = 11;
 }


### PR DESCRIPTION
## Summary

- read the VR940's `DeviceDiagnosis.operatingState` by registering a bridge-local `DeviceDiagnosis` client feature (no existing EEBUS use case negotiates this feature type, unlike temperature/setpoint reads)
- add `GetDeviceDiagnostics` RPC + push event to `MonitoringService`, mirroring the flow/return temperature pattern
- expose as `sensor.eebus_device_operating_state`, diagnostic category, enabled by default, free-text passthrough (not a fixed enum) since only `normalOperation` has been observed live

## Evidence

Confirmed available via the extended SPINE capture analysis in
`docs/superpowers/specs/2026-07-13-vr940-extended-capture-findings.md`
(idle capture, 2026-07-13): `DeviceDiagnosisStateData` → `{"operatingState": "normalOperation"}`.
That same document also lists what the capture proved is *not* available on
this hardware (firmware/hw revision, pressure, boot count/uptime, cycle
count/runtime, current energy mode, eco mode, away/party mode) — none of
that is in scope here.

Design/implementation plan: `docs/superpowers/plans/2026-07-13-device-operating-state-plan.md`.

## Verification

- `go build ./...`, `go vet ./...`, `go test -race ./...`
- `ruff check custom_components/`, `mypy custom_components/eebus`, `PYTHONPATH=. pytest` (82 passed)
- Regenerated both Go and Python proto stubs, confirmed byte-stable (no drift)

## Hardware acceptance pending

This is a read-only, always-on (no experimental gate) addition with no write
path, but should still be smoke-tested against the live VR940 before merge to
confirm `sensor.eebus_device_operating_state` shows real data end-to-end.

🤖 Implementation delegated to Codex per this repo's standard workflow; verified independently (rebuilt, retested, and independently re-ran the proto regen to confirm stability before committing).