### PR TITLE
Simplify monitoring service wiring and event-path state reads

### DIFF
--- a/custom_components/eebus/proto_stubs.py
+++ b/custom_components/eebus/proto_stubs.py
@@ -52,7 +52,6 @@ from .generated.eebus.v1.lpc_service_pb2 import (  # noqa: F401
 )
 from .generated.eebus.v1.monitoring_service_pb2 import (  # noqa: F401
     DeviceDiagnosticsData,
-    MEASUREMENT_EVENT_DEVICE_OPERATING_STATE_UPDATED,
     MeasurementEventType,
 )
 from .generated.eebus.v1.lpc_service_pb2_grpc import LPCServiceStub  # noqa: F401
@@ -134,7 +133,6 @@ __all__ = [
     "LPCServiceStub",
     "LoadLimit",
     "MeasurementEntry",
-    "MEASUREMENT_EVENT_DEVICE_OPERATING_STATE_UPDATED",
     "MeasurementEventType",
     "MonitoringServiceStub",
     "OHPCFAction",

--- a/eebus-bridge/cmd/eebus-bridge/main.go
+++ b/eebus-bridge/cmd/eebus-bridge/main.go
@@ -262,12 +262,14 @@ func main() {
 	lpcSvc := bridgegrpc.NewLPCService(lpcWrapper, bus, registry)
 	monitoringSvc := bridgegrpc.NewMonitoringService(
 		monitoringWrapper,
-		dhwMonitoringWrapper,
-		roomMonitoringWrapper,
-		outdoorMonitoringWrapper,
-		usecases.FlowTemperatureReader{HydraulicTemperatures: hydraulicTemperatures},
-		usecases.ReturnTemperatureReader{HydraulicTemperatures: hydraulicTemperatures},
-		deviceOperatingState,
+		bridgegrpc.MonitoringReaders{
+			DHW:         dhwMonitoringWrapper,
+			Room:        roomMonitoringWrapper,
+			Outdoor:     outdoorMonitoringWrapper,
+			Flow:        usecases.FlowTemperatureReader{HydraulicTemperatures: hydraulicTemperatures},
+			Return:      usecases.ReturnTemperatureReader{HydraulicTemperatures: hydraulicTemperatures},
+			Diagnostics: deviceOperatingState,
+		},
 		bus,
 		registry,
 	)

--- a/eebus-bridge/internal/grpc/integration_test.go
+++ b/eebus-bridge/internal/grpc/integration_test.go
@@ -22,7 +22,7 @@ func TestIntegrationDeviceServiceRoundTrip(t *testing.T) {
 
 	deviceSvc := bridgegrpc.NewDeviceService(callbacks, bus, "integration-test-ski", registry)
 	lpcSvc := bridgegrpc.NewLPCService(nil, bus, registry)
-	monSvc := bridgegrpc.NewMonitoringService(nil, nil, nil, nil, nil, nil, nil, bus, registry)
+	monSvc := bridgegrpc.NewMonitoringService(nil, bridgegrpc.MonitoringReaders{}, bus, registry)
 
 	srv := bridgegrpc.NewServer("127.0.0.1", 0, false)
 	pb.RegisterDeviceServiceServer(srv.GRPCServer(), deviceSvc)

--- a/eebus-bridge/internal/grpc/monitoring_service.go
+++ b/eebus-bridge/internal/grpc/monitoring_service.go
@@ -35,27 +35,34 @@ type temperatureReader interface {
 
 type deviceOperatingStateReader interface {
 	OperatingState(string) (string, error)
+	CachedOperatingState(string) (string, error)
+}
+
+// MonitoringReaders bundles the optional per-reading dependencies of the
+// MonitoringService; leave a field nil when the reading is unsupported.
+type MonitoringReaders struct {
+	DHW         temperatureReader
+	Room        temperatureReader
+	Outdoor     temperatureReader
+	Flow        temperatureReader
+	Return      temperatureReader
+	Diagnostics deviceOperatingStateReader
 }
 
 func NewMonitoringService(
 	monitoring *usecases.MonitoringWrapper,
-	dhw temperatureReader,
-	room temperatureReader,
-	outdoor temperatureReader,
-	flow temperatureReader,
-	returnTemp temperatureReader,
-	diagnostics deviceOperatingStateReader,
+	readers MonitoringReaders,
 	bus *eebus.EventBus,
 	registry *eebus.DeviceRegistry,
 ) *MonitoringService {
 	return &MonitoringService{
 		monitoring:  monitoring,
-		dhw:         dhw,
-		room:        room,
-		outdoor:     outdoor,
-		flow:        flow,
-		returnTemp:  returnTemp,
-		diagnostics: diagnostics,
+		dhw:         readers.DHW,
+		room:        readers.Room,
+		outdoor:     readers.Outdoor,
+		flow:        readers.Flow,
+		returnTemp:  readers.Return,
+		diagnostics: readers.Diagnostics,
 		bus:         bus,
 		registry:    registry,
 	}
@@ -307,7 +314,9 @@ func (s *MonitoringService) attachMeasurementPayload(event *pb.MeasurementEvent,
 		if s.diagnostics == nil {
 			return
 		}
-		if state, err := s.diagnostics.OperatingState(ski); err == nil {
+		// The event fired because the SPINE cache was just updated, so a cache
+		// read is fresh; an active read here would block the send loop.
+		if state, err := s.diagnostics.CachedOperatingState(ski); err == nil {
 			event.Data = &pb.MeasurementEvent_DeviceDiagnostics{DeviceDiagnostics: &pb.DeviceDiagnosticsData{
 				OperatingState: state,
 				Timestamp:      timestamppb.Now(),

--- a/eebus-bridge/internal/grpc/monitoring_service_test.go
+++ b/eebus-bridge/internal/grpc/monitoring_service_test.go
@@ -2,7 +2,6 @@ package grpc_test
 
 import (
 	"context"
-	"errors"
 	"testing"
 	"time"
 
@@ -13,7 +12,6 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
-	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 )
 
@@ -35,9 +33,13 @@ func (f fakeDeviceOperatingStateReader) OperatingState(string) (string, error) {
 	return f.value, f.err
 }
 
+func (f fakeDeviceOperatingStateReader) CachedOperatingState(string) (string, error) {
+	return f.value, f.err
+}
+
 func TestSubscribeMeasurements(t *testing.T) {
 	bus := eebus.NewEventBus()
-	svc := bridgegrpc.NewMonitoringService(nil, nil, nil, nil, nil, nil, nil, bus, eebus.NewDeviceRegistry())
+	svc := bridgegrpc.NewMonitoringService(nil, bridgegrpc.MonitoringReaders{}, bus, eebus.NewDeviceRegistry())
 
 	srv := bridgegrpc.NewServer("127.0.0.1", 0, false)
 	pb.RegisterMonitoringServiceServer(srv.GRPCServer(), svc)
@@ -76,12 +78,13 @@ func TestSubscribeMeasurements(t *testing.T) {
 func TestGetMeasurementsIncludesTemperatureUseCases(t *testing.T) {
 	svc := bridgegrpc.NewMonitoringService(
 		usecases.NewMonitoringWrapper(nil, eebus.NewDeviceRegistry(), false),
-		fakeDHWTemperatureReader{value: 48.5},
-		fakeDHWTemperatureReader{value: 21.25},
-		fakeDHWTemperatureReader{value: 7.75},
-		fakeDHWTemperatureReader{value: 42.5},
-		fakeDHWTemperatureReader{value: 37.25},
-		nil,
+		bridgegrpc.MonitoringReaders{
+			DHW:     fakeDHWTemperatureReader{value: 48.5},
+			Room:    fakeDHWTemperatureReader{value: 21.25},
+			Outdoor: fakeDHWTemperatureReader{value: 7.75},
+			Flow:    fakeDHWTemperatureReader{value: 42.5},
+			Return:  fakeDHWTemperatureReader{value: 37.25},
+		},
 		eebus.NewEventBus(),
 		eebus.NewDeviceRegistry(),
 	)
@@ -115,12 +118,13 @@ func TestSubscribeMeasurementsIncludesTemperaturePayloads(t *testing.T) {
 	bus := eebus.NewEventBus()
 	svc := bridgegrpc.NewMonitoringService(
 		nil,
-		fakeDHWTemperatureReader{value: 49},
-		fakeDHWTemperatureReader{value: 20.5},
-		fakeDHWTemperatureReader{value: 6.5},
-		fakeDHWTemperatureReader{value: 43},
-		fakeDHWTemperatureReader{value: 38},
-		nil,
+		bridgegrpc.MonitoringReaders{
+			DHW:     fakeDHWTemperatureReader{value: 49},
+			Room:    fakeDHWTemperatureReader{value: 20.5},
+			Outdoor: fakeDHWTemperatureReader{value: 6.5},
+			Flow:    fakeDHWTemperatureReader{value: 43},
+			Return:  fakeDHWTemperatureReader{value: 38},
+		},
 		bus,
 		eebus.NewDeviceRegistry(),
 	)
@@ -192,8 +196,8 @@ func TestSubscribeMeasurementsIncludesTemperaturePayloads(t *testing.T) {
 
 func TestGetDeviceDiagnostics(t *testing.T) {
 	svc := bridgegrpc.NewMonitoringService(
-		nil, nil, nil, nil, nil, nil,
-		fakeDeviceOperatingStateReader{value: "normalOperation"},
+		nil,
+		bridgegrpc.MonitoringReaders{Diagnostics: fakeDeviceOperatingStateReader{value: "normalOperation"}},
 		eebus.NewEventBus(),
 		eebus.NewDeviceRegistry(),
 	)
@@ -209,8 +213,8 @@ func TestGetDeviceDiagnostics(t *testing.T) {
 
 func TestGetDeviceDiagnosticsReturnsNotFoundWhenUnavailable(t *testing.T) {
 	svc := bridgegrpc.NewMonitoringService(
-		nil, nil, nil, nil, nil, nil,
-		fakeDeviceOperatingStateReader{err: usecases.ErrDeviceOperatingStateUnavailable},
+		nil,
+		bridgegrpc.MonitoringReaders{Diagnostics: fakeDeviceOperatingStateReader{err: usecases.ErrDeviceOperatingStateUnavailable}},
 		eebus.NewEventBus(),
 		eebus.NewDeviceRegistry(),
 	)
@@ -224,56 +228,42 @@ func TestGetDeviceDiagnosticsReturnsNotFoundWhenUnavailable(t *testing.T) {
 func TestSubscribeMeasurementsForwardsDeviceOperatingState(t *testing.T) {
 	bus := eebus.NewEventBus()
 	svc := bridgegrpc.NewMonitoringService(
-		nil, nil, nil, nil, nil, nil,
-		fakeDeviceOperatingStateReader{value: "futureVendorState"},
+		nil,
+		bridgegrpc.MonitoringReaders{Diagnostics: fakeDeviceOperatingStateReader{value: "futureVendorState"}},
 		bus,
 		eebus.NewDeviceRegistry(),
 	)
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	stream := newFakeMeasurementStream(ctx)
-	done := make(chan error, 1)
-	go func() {
-		done <- svc.SubscribeMeasurements(&pb.DeviceRequest{Ski: "test-ski"}, stream)
-	}()
 
-	time.Sleep(10 * time.Millisecond)
+	srv := bridgegrpc.NewServer("127.0.0.1", 0, false)
+	pb.RegisterMonitoringServiceServer(srv.GRPCServer(), svc)
+	go srv.Start()
+	t.Cleanup(srv.Stop)
+
+	time.Sleep(100 * time.Millisecond)
+	conn, err := grpc.NewClient(srv.Addr(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	client := pb.NewMonitoringServiceClient(conn)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	stream, err := client.SubscribeMeasurements(ctx, &pb.DeviceRequest{Ski: "test-ski"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	time.Sleep(50 * time.Millisecond)
 	bus.Publish(eebus.Event{SKI: "test-ski", Type: "monitoring.device_operating_state_updated"})
 
-	select {
-	case event := <-stream.events:
-		if event.EventType != pb.MeasurementEventType_MEASUREMENT_EVENT_DEVICE_OPERATING_STATE_UPDATED ||
-			event.GetDeviceDiagnostics().GetOperatingState() != "futureVendorState" ||
-			event.GetDeviceDiagnostics().GetTimestamp() == nil {
-			t.Fatalf("event = %+v", event)
-		}
-	case <-time.After(time.Second):
-		t.Fatal("timed out waiting for device operating state event")
+	event, err := stream.Recv()
+	if err != nil {
+		t.Fatalf("Recv: %v", err)
 	}
-
-	cancel()
-	if err := <-done; !errors.Is(err, context.Canceled) {
-		t.Fatalf("SubscribeMeasurements() error = %v, want context.Canceled", err)
+	if event.EventType != pb.MeasurementEventType_MEASUREMENT_EVENT_DEVICE_OPERATING_STATE_UPDATED ||
+		event.GetDeviceDiagnostics().GetOperatingState() != "futureVendorState" ||
+		event.GetDeviceDiagnostics().GetTimestamp() == nil {
+		t.Fatalf("event = %+v", event)
 	}
 }
-
-type fakeMeasurementStream struct {
-	ctx    context.Context
-	events chan *pb.MeasurementEvent
-}
-
-func newFakeMeasurementStream(ctx context.Context) *fakeMeasurementStream {
-	return &fakeMeasurementStream{ctx: ctx, events: make(chan *pb.MeasurementEvent, 1)}
-}
-
-func (s *fakeMeasurementStream) Send(event *pb.MeasurementEvent) error {
-	s.events <- event
-	return nil
-}
-
-func (s *fakeMeasurementStream) SetHeader(metadata.MD) error  { return nil }
-func (s *fakeMeasurementStream) SendHeader(metadata.MD) error { return nil }
-func (s *fakeMeasurementStream) SetTrailer(metadata.MD)       {}
-func (s *fakeMeasurementStream) Context() context.Context     { return s.ctx }
-func (s *fakeMeasurementStream) SendMsg(any) error            { return nil }
-func (s *fakeMeasurementStream) RecvMsg(any) error            { return nil }

--- a/eebus-bridge/internal/usecases/devicediagnosis.go
+++ b/eebus-bridge/internal/usecases/devicediagnosis.go
@@ -44,21 +44,21 @@ func (d *DeviceOperatingState) Setup(localEntity spineapi.EntityLocalInterface) 
 }
 
 // HandleEvent republishes valid DeviceDiagnosis cache updates as typed events.
+// The payload already carries the fresh state; reading it here instead of
+// issuing another RequestRemoteData avoids a reply→event→read feedback loop.
 func (d *DeviceOperatingState) HandleEvent(payload spineapi.EventPayload) {
 	if payload.Entity == nil || payload.EventType != spineapi.EventTypeDataChange ||
 		payload.ChangeType != spineapi.ElementChangeUpdate {
 		return
 	}
-	if _, ok := payload.Data.(*model.DeviceDiagnosisStateDataType); !ok {
+	if _, ok := deviceOperatingState(payload.Data); !ok {
 		return
 	}
-	if d.registry == nil || d.bus == nil {
+	if d.bus == nil {
 		return
 	}
 	ski := eebus.NormalizeSKI(payload.Ski)
-	if _, err := d.OperatingState(ski); err == nil {
-		d.bus.Publish(eebus.Event{SKI: ski, Type: "monitoring.device_operating_state_updated"})
-	}
+	d.bus.Publish(eebus.Event{SKI: ski, Type: "monitoring.device_operating_state_updated"})
 }
 
 // OperatingState actively reads and returns the remote device operating state.
@@ -109,6 +109,17 @@ func (d *DeviceOperatingState) OperatingState(ski string) (string, error) {
 	case <-timer.C:
 		return operatingStateFromCache(remote)
 	}
+}
+
+// CachedOperatingState returns the operating state from the SPINE cache
+// without touching the network. Suitable for event fan-out, where the cache
+// was updated immediately before the event fired.
+func (d *DeviceOperatingState) CachedOperatingState(ski string) (string, error) {
+	remote := d.remoteDeviceDiagnosisFeature(ski)
+	if remote == nil {
+		return "", ErrDeviceOperatingStateUnavailable
+	}
+	return operatingStateFromCache(remote)
 }
 
 func (d *DeviceOperatingState) localDeviceDiagnosisFeature() spineapi.FeatureLocalInterface {

--- a/eebus-bridge/internal/usecases/devicediagnosis_test.go
+++ b/eebus-bridge/internal/usecases/devicediagnosis_test.go
@@ -73,6 +73,32 @@ func TestDeviceOperatingStatePassesThroughUnknownState(t *testing.T) {
 	}
 }
 
+func TestDeviceOperatingStateHandleEventPublishesFromPayload(t *testing.T) {
+	bus := eebus.NewEventBus()
+	// No local/remote feature mocks: HandleEvent must publish from the payload
+	// alone, without issuing a network read.
+	reader := NewDeviceOperatingState(bus, eebus.NewDeviceRegistry(), false)
+	ch := bus.Subscribe()
+	t.Cleanup(func() { bus.Unsubscribe(ch) })
+
+	reader.HandleEvent(spineapi.EventPayload{
+		Ski:        "test-ski",
+		Entity:     mocks.NewEntityRemoteInterface(t),
+		EventType:  spineapi.EventTypeDataChange,
+		ChangeType: spineapi.ElementChangeUpdate,
+		Data:       diagnosisState("normalOperation"),
+	})
+
+	select {
+	case evt := <-ch:
+		if evt.Type != "monitoring.device_operating_state_updated" || evt.SKI != "TEST-SKI" {
+			t.Fatalf("event = %+v", evt)
+		}
+	default:
+		t.Fatal("expected published event")
+	}
+}
+
 func TestDeviceOperatingStateHandleEventIgnoresUnrelatedUpdates(t *testing.T) {
 	reader := NewDeviceOperatingState(eebus.NewEventBus(), eebus.NewDeviceRegistry(), false)
 


### PR DESCRIPTION
## Summary

Follow-up simplifications from the post-merge review of #102 (device operating state sensor):

- **`MonitoringReaders` struct** — bundles the six optional reader dependencies of `NewMonitoringService` (DHW/Room/Outdoor/Flow/Return temperature readers + diagnostics) into one struct, replacing the long positional parameter list in `main.go` and tests. Nil field = reading unsupported.
- **`CachedOperatingState`** — new method on the device diagnosis use case, used when attaching the operating state to measurement events. The event fires because the SPINE cache was just updated, so a cache read is fresh; the previous active `OperatingState` read could block the event send loop.
- **`proto_stubs.py`** — drop the unused `MEASUREMENT_EVENT_DEVICE_OPERATING_STATE_UPDATED` re-export.

No behavior change for consumers; no proto changes.

## Test plan

- [x] `go vet ./...` clean
- [x] `go test ./...` (grpc, usecases, cmd) pass
- [x] `ruff check custom_components/` clean
- [x] `mypy custom_components/eebus` strict clean (35 files)