### PR TITLE
Type internal bus events

### DIFF
--- a/eebus-bridge/cmd/eebus-bridge/main.go
+++ b/eebus-bridge/cmd/eebus-bridge/main.go
@@ -239,10 +239,10 @@ func main() {
 		defer bus.Unsubscribe(ch)
 		for evt := range ch {
 			switch evt.Type {
-			case "device.register_ski":
+			case eebus.EventTypeDeviceRegisterSKI:
 				bridgeSvc.RegisterRemoteSKI(evt.SKI)
 				log.Printf("Registered remote SKI: %s", evt.SKI)
-			case "device.unregister_ski":
+			case eebus.EventTypeDeviceUnregisterSKI:
 				// eebus-go's UnregisterRemoteService only notifies via
 				// ServicePairingDetailUpdate, not ServiceAutoTrustRemoved, so the
 				// registry is cleared explicitly here rather than relying on a
@@ -250,7 +250,7 @@ func main() {
 				// handles the remote-initiated revocation case).
 				bridgeSvc.UnregisterRemoteSKI(evt.SKI)
 				registry.RemoveDevice(evt.SKI)
-				bus.Publish(eebus.Event{SKI: evt.SKI, Type: "device.trust_removed"})
+				bus.Publish(eebus.Event{SKI: evt.SKI, Type: eebus.EventTypeDeviceTrustRemoved})
 				log.Printf("Unregistered remote SKI: %s", evt.SKI)
 			}
 		}

--- a/eebus-bridge/internal/eebus/callbacks.go
+++ b/eebus-bridge/internal/eebus/callbacks.go
@@ -48,7 +48,7 @@ func (c *Callbacks) RemoteServiceConnected(_ api.ServiceInterface, identity ship
 
 	c.bus.Publish(Event{
 		SKI:  ski,
-		Type: "device.connected",
+		Type: EventTypeDeviceConnected,
 	})
 }
 
@@ -67,7 +67,7 @@ func (c *Callbacks) RemoteServiceDisconnected(_ api.ServiceInterface, identity s
 
 	c.bus.Publish(Event{
 		SKI:  ski,
-		Type: "device.disconnected",
+		Type: EventTypeDeviceDisconnected,
 	})
 }
 
@@ -82,7 +82,7 @@ func (c *Callbacks) VisibleRemoteMdnsServicesUpdated(_ api.ServiceInterface, ent
 	c.mu.Unlock()
 
 	c.bus.Publish(Event{
-		Type: "discovery.updated",
+		Type: EventTypeDiscoveryUpdated,
 	})
 }
 
@@ -104,7 +104,7 @@ func (c *Callbacks) ServicePairingDetailUpdate(identity shipapi.ServiceIdentity,
 
 	c.bus.Publish(Event{
 		SKI:  ski,
-		Type: "pairing.updated",
+		Type: EventTypePairingUpdated,
 	})
 }
 
@@ -139,7 +139,7 @@ func (c *Callbacks) ServiceAutoTrustRemoved(_ api.ServiceInterface, identity shi
 
 	c.bus.Publish(Event{
 		SKI:  ski,
-		Type: "device.trust_removed",
+		Type: EventTypeDeviceTrustRemoved,
 	})
 }
 

--- a/eebus-bridge/internal/eebus/callbacks_test.go
+++ b/eebus-bridge/internal/eebus/callbacks_test.go
@@ -23,7 +23,7 @@ func TestCallbacksDispatchConnect(t *testing.T) {
 		if evt.SKI != "TEST-SKI-123" {
 			t.Errorf("SKI = %q, want TEST-SKI-123", evt.SKI)
 		}
-		if evt.Type != "device.connected" {
+		if evt.Type != eebus.EventTypeDeviceConnected {
 			t.Errorf("Type = %q, want device.connected", evt.Type)
 		}
 	case <-time.After(time.Second):
@@ -54,7 +54,7 @@ func TestCallbacksDispatchDisconnect(t *testing.T) {
 
 	select {
 	case evt := <-ch:
-		if evt.Type != "device.disconnected" {
+		if evt.Type != eebus.EventTypeDeviceDisconnected {
 			t.Errorf("Type = %q, want device.disconnected", evt.Type)
 		}
 	case <-time.After(time.Second):
@@ -111,7 +111,7 @@ func TestCallbacksTrustRemovedClearsCachedEntitiesAndPublishes(t *testing.T) {
 
 	select {
 	case evt := <-ch:
-		if evt.Type != "device.trust_removed" {
+		if evt.Type != eebus.EventTypeDeviceTrustRemoved {
 			t.Errorf("Type = %q, want device.trust_removed", evt.Type)
 		}
 		if evt.SKI != "TEST-SKI-789" {
@@ -132,7 +132,7 @@ func TestCallbacksVisibleServicesUpdated(t *testing.T) {
 
 	select {
 	case evt := <-ch:
-		if evt.Type != "discovery.updated" {
+		if evt.Type != eebus.EventTypeDiscoveryUpdated {
 			t.Errorf("Type = %q, want discovery.updated", evt.Type)
 		}
 	case <-time.After(time.Second):

--- a/eebus-bridge/internal/eebus/eventbus.go
+++ b/eebus-bridge/internal/eebus/eventbus.go
@@ -2,13 +2,6 @@ package eebus
 
 import "sync"
 
-// Event represents an internal event from eebus-go callbacks.
-type Event struct {
-	SKI  string
-	Type string
-	Data map[string]any
-}
-
 // EventBus provides fan-out event distribution to multiple subscribers.
 type EventBus struct {
 	mu          sync.RWMutex

--- a/eebus-bridge/internal/eebus/events.go
+++ b/eebus-bridge/internal/eebus/events.go
@@ -1,0 +1,68 @@
+package eebus
+
+// EventType identifies an event published on the internal event bus.
+type EventType string
+
+const (
+	EventTypeDeviceConnected     EventType = "device.connected"
+	EventTypeDeviceDisconnected  EventType = "device.disconnected"
+	EventTypeDeviceTrustRemoved  EventType = "device.trust_removed"
+	EventTypeDeviceRegisterSKI   EventType = "device.register_ski"
+	EventTypeDeviceUnregisterSKI EventType = "device.unregister_ski"
+	EventTypeDiscoveryUpdated    EventType = "discovery.updated"
+	EventTypePairingUpdated      EventType = "pairing.updated"
+
+	EventTypeMonitoringPowerUpdated                EventType = "monitoring.power_updated"
+	EventTypeMonitoringPowerPerPhaseUpdated        EventType = "monitoring.power_per_phase_updated"
+	EventTypeMonitoringEnergyConsumedUpdated       EventType = "monitoring.energy_consumed_updated"
+	EventTypeMonitoringEnergyProducedUpdated       EventType = "monitoring.energy_produced_updated"
+	EventTypeMonitoringCurrentsPerPhaseUpdated     EventType = "monitoring.currents_per_phase_updated"
+	EventTypeMonitoringVoltagePerPhaseUpdated      EventType = "monitoring.voltage_per_phase_updated"
+	EventTypeMonitoringFrequencyUpdated            EventType = "monitoring.frequency_updated"
+	EventTypeMonitoringUseCaseSupportUpdated       EventType = "monitoring.use_case_support_updated"
+	EventTypeMonitoringFlowTemperatureUpdated      EventType = "monitoring.flow_temperature_updated"
+	EventTypeMonitoringReturnTemperatureUpdated    EventType = "monitoring.return_temperature_updated"
+	EventTypeMonitoringDeviceOperatingStateUpdated EventType = "monitoring.device_operating_state_updated"
+
+	EventTypeLPCLimitUpdated            EventType = "lpc.limit_updated"
+	EventTypeLPCFailsafePowerUpdated    EventType = "lpc.failsafe_power_updated"
+	EventTypeLPCFailsafeDurationUpdated EventType = "lpc.failsafe_duration_updated"
+	EventTypeLPCUseCaseSupportUpdated   EventType = "lpc.use_case_support_updated"
+	EventTypeLPCHeartbeatUpdated        EventType = "lpc.heartbeat_updated"
+
+	EventTypeDHWTemperatureUpdated                   EventType = "dhw.temperature_updated"
+	EventTypeDHWMonitoringSupportUpdated             EventType = "dhw.monitoring_support_updated"
+	EventTypeDHWSetpointUpdated                      EventType = "dhw.setpoint_updated"
+	EventTypeDHWUseCaseSupportUpdated                EventType = "dhw.use_case_support_updated"
+	EventTypeDHWSystemFunctionUpdated                EventType = "dhwsysfn.updated"
+	EventTypeDHWSystemFunctionSupportUpdated         EventType = "dhwsysfn.use_case_support_updated"
+	EventTypeRoomTemperatureUpdated                  EventType = "room.temperature_updated"
+	EventTypeRoomMonitoringSupportUpdated            EventType = "room.monitoring_support_updated"
+	EventTypeOutdoorTemperatureUpdated               EventType = "outdoor.temperature_updated"
+	EventTypeOutdoorMonitoringSupportUpdated         EventType = "outdoor.monitoring_support_updated"
+	EventTypeRoomHeatingSetpointUpdated              EventType = "roomheating.setpoint_updated"
+	EventTypeRoomHeatingUseCaseSupportUpdated        EventType = "roomheating.use_case_support_updated"
+	EventTypeRoomHeatingSystemFunctionUpdated        EventType = "roomheatingsysfn.updated"
+	EventTypeRoomHeatingSystemFunctionSupportUpdated EventType = "roomheatingsysfn.use_case_support_updated"
+
+	EventTypeOHPCFUseCaseSupportUpdated         EventType = "ohpcf.use_case_support_updated"
+	EventTypeOHPCFConsumptionStateUpdated       EventType = "ohpcf.consumption_state_updated"
+	EventTypeOHPCFConsumptionStoppableUpdated   EventType = "ohpcf.consumption_stoppable_updated"
+	EventTypeOHPCFConsumptionPausableUpdated    EventType = "ohpcf.consumption_pausable_updated"
+	EventTypeOHPCFConsumptionStartTimeUpdated   EventType = "ohpcf.consumption_start_time_updated"
+	EventTypeOHPCFRequestedPowerEstimateUpdated EventType = "ohpcf.requested_power_estimate_updated"
+	EventTypeOHPCFRequestedPowerMaxUpdated      EventType = "ohpcf.requested_power_max_updated"
+	EventTypeOHPCFMinimalRunDurationUpdated     EventType = "ohpcf.minimal_run_duration_updated"
+	EventTypeOHPCFMinimalPauseDurationUpdated   EventType = "ohpcf.minimal_pause_duration_updated"
+
+	EventTypeMGCPConsumerUpdated EventType = "mgcp.consumer_updated"
+	EventTypeVAPDConsumerUpdated EventType = "vapd.consumer_updated"
+	EventTypeVABDConsumerUpdated EventType = "vabd.consumer_updated"
+)
+
+// Event represents an internal event from eebus-go callbacks.
+type Event struct {
+	SKI  string
+	Type EventType
+	Data map[string]any
+}

--- a/eebus-bridge/internal/grpc/device_service.go
+++ b/eebus-bridge/internal/grpc/device_service.go
@@ -49,7 +49,7 @@ func (s *DeviceService) RegisterRemoteSKI(_ context.Context, req *pb.RegisterSKI
 	if !validSKI(ski) {
 		return nil, status.Errorf(codes.InvalidArgument, "ski must be 40 hex characters, got %q", req.Ski)
 	}
-	s.bus.Publish(eebus.Event{SKI: ski, Type: "device.register_ski"})
+	s.bus.Publish(eebus.Event{SKI: ski, Type: eebus.EventTypeDeviceRegisterSKI})
 	return &pb.Empty{}, nil
 }
 
@@ -62,7 +62,7 @@ func (s *DeviceService) UnregisterRemoteSKI(_ context.Context, req *pb.RegisterS
 	if !validSKI(ski) {
 		return nil, status.Errorf(codes.InvalidArgument, "ski must be 40 hex characters, got %q", req.Ski)
 	}
-	s.bus.Publish(eebus.Event{SKI: ski, Type: "device.unregister_ski"})
+	s.bus.Publish(eebus.Event{SKI: ski, Type: eebus.EventTypeDeviceUnregisterSKI})
 	return &pb.Empty{}, nil
 }
 
@@ -94,11 +94,11 @@ func (s *DeviceService) SubscribeDeviceEvents(_ *pb.Empty, stream pb.DeviceServi
 			}
 			var eventType pb.DeviceEventType
 			switch evt.Type {
-			case "device.connected":
+			case eebus.EventTypeDeviceConnected:
 				eventType = pb.DeviceEventType_DEVICE_EVENT_CONNECTED
-			case "device.disconnected":
+			case eebus.EventTypeDeviceDisconnected:
 				eventType = pb.DeviceEventType_DEVICE_EVENT_DISCONNECTED
-			case "device.trust_removed":
+			case eebus.EventTypeDeviceTrustRemoved:
 				eventType = pb.DeviceEventType_DEVICE_EVENT_TRUST_REMOVED
 			default:
 				continue

--- a/eebus-bridge/internal/grpc/device_service_test.go
+++ b/eebus-bridge/internal/grpc/device_service_test.go
@@ -118,7 +118,7 @@ func TestUnregisterRemoteSKIPublishesEvent(t *testing.T) {
 
 	select {
 	case evt := <-ch:
-		if evt.Type != "device.unregister_ski" || evt.SKI != testValidSKI {
+		if evt.Type != eebus.EventTypeDeviceUnregisterSKI || evt.SKI != testValidSKI {
 			t.Errorf("event = %+v, want type=device.unregister_ski ski=%s", evt, testValidSKI)
 		}
 	case <-time.After(time.Second):
@@ -150,7 +150,7 @@ func TestSubscribeDeviceEventsTrustRemoved(t *testing.T) {
 	}
 	time.Sleep(100 * time.Millisecond)
 
-	bus.Publish(eebus.Event{SKI: testValidSKI, Type: "device.trust_removed"})
+	bus.Publish(eebus.Event{SKI: testValidSKI, Type: eebus.EventTypeDeviceTrustRemoved})
 
 	evt, err := stream.Recv()
 	if err != nil {

--- a/eebus-bridge/internal/grpc/dhw_service.go
+++ b/eebus-bridge/internal/grpc/dhw_service.go
@@ -135,9 +135,9 @@ func (s *DHWService) SubscribeDHWEvents(req *pb.DeviceRequest, stream pb.DHWServ
 			}
 			var eventType pb.DHWEventType
 			switch evt.Type {
-			case "dhw.use_case_support_updated":
+			case eebus.EventTypeDHWUseCaseSupportUpdated:
 				eventType = pb.DHWEventType_DHW_EVENT_SUPPORT_UPDATED
-			case "dhw.setpoint_updated":
+			case eebus.EventTypeDHWSetpointUpdated:
 				eventType = pb.DHWEventType_DHW_EVENT_SETPOINT_UPDATED
 			default:
 				continue
@@ -178,9 +178,9 @@ func (s *DHWService) SubscribeDHWSystemFunctionEvents(
 			}
 			var eventType pb.DHWSystemFunctionEventType
 			switch evt.Type {
-			case "dhwsysfn.use_case_support_updated":
+			case eebus.EventTypeDHWSystemFunctionSupportUpdated:
 				eventType = pb.DHWSystemFunctionEventType_DHW_SYSTEM_FUNCTION_EVENT_SUPPORT_UPDATED
-			case "dhwsysfn.updated":
+			case eebus.EventTypeDHWSystemFunctionUpdated:
 				eventType = pb.DHWSystemFunctionEventType_DHW_SYSTEM_FUNCTION_EVENT_STATE_UPDATED
 			default:
 				continue

--- a/eebus-bridge/internal/grpc/hvac_service.go
+++ b/eebus-bridge/internal/grpc/hvac_service.go
@@ -139,13 +139,13 @@ func (s *HVACService) SubscribeRoomHeatingEvents(
 			}
 			var eventType pb.RoomHeatingEventType
 			switch evt.Type {
-			case "roomheating.use_case_support_updated", "roomheatingsysfn.use_case_support_updated":
+			case eebus.EventTypeRoomHeatingUseCaseSupportUpdated, eebus.EventTypeRoomHeatingSystemFunctionSupportUpdated:
 				eventType = pb.RoomHeatingEventType_ROOM_HEATING_EVENT_SUPPORT_UPDATED
-			case "room.temperature_updated":
+			case eebus.EventTypeRoomTemperatureUpdated:
 				eventType = pb.RoomHeatingEventType_ROOM_HEATING_EVENT_CURRENT_TEMPERATURE_UPDATED
-			case "roomheating.setpoint_updated":
+			case eebus.EventTypeRoomHeatingSetpointUpdated:
 				eventType = pb.RoomHeatingEventType_ROOM_HEATING_EVENT_SETPOINT_UPDATED
-			case "roomheatingsysfn.updated":
+			case eebus.EventTypeRoomHeatingSystemFunctionUpdated:
 				eventType = pb.RoomHeatingEventType_ROOM_HEATING_EVENT_SYSTEM_FUNCTION_UPDATED
 			default:
 				continue

--- a/eebus-bridge/internal/grpc/lpc_service.go
+++ b/eebus-bridge/internal/grpc/lpc_service.go
@@ -190,11 +190,11 @@ func (s *LPCService) SubscribeLPCEvents(req *pb.DeviceRequest, stream pb.LPCServ
 			}
 			var eventType pb.LPCEventType
 			switch evt.Type {
-			case "lpc.limit_updated":
+			case eebus.EventTypeLPCLimitUpdated:
 				eventType = pb.LPCEventType_LPC_EVENT_LIMIT_UPDATED
-			case "lpc.failsafe_power_updated", "lpc.failsafe_duration_updated":
+			case eebus.EventTypeLPCFailsafePowerUpdated, eebus.EventTypeLPCFailsafeDurationUpdated:
 				eventType = pb.LPCEventType_LPC_EVENT_FAILSAFE_UPDATED
-			case "lpc.heartbeat_updated":
+			case eebus.EventTypeLPCHeartbeatUpdated:
 				eventType = pb.LPCEventType_LPC_EVENT_HEARTBEAT_TIMEOUT
 			default:
 				continue

--- a/eebus-bridge/internal/grpc/lpc_service_test.go
+++ b/eebus-bridge/internal/grpc/lpc_service_test.go
@@ -39,7 +39,7 @@ func TestSubscribeLPCEvents(t *testing.T) {
 
 	// Give the server-side handler goroutine time to subscribe before publishing.
 	time.Sleep(50 * time.Millisecond)
-	bus.Publish(eebus.Event{SKI: "test-ski", Type: "lpc.limit_updated"})
+	bus.Publish(eebus.Event{SKI: "test-ski", Type: eebus.EventTypeLPCLimitUpdated})
 
 	evt, err := stream.Recv()
 	if err != nil {
@@ -76,7 +76,7 @@ func TestSubscribeLPCEventsHeartbeat(t *testing.T) {
 	}
 
 	time.Sleep(50 * time.Millisecond)
-	bus.Publish(eebus.Event{SKI: "test-ski", Type: "lpc.heartbeat_updated"})
+	bus.Publish(eebus.Event{SKI: "test-ski", Type: eebus.EventTypeLPCHeartbeatUpdated})
 
 	evt, err := stream.Recv()
 	if err != nil {

--- a/eebus-bridge/internal/grpc/monitoring_service.go
+++ b/eebus-bridge/internal/grpc/monitoring_service.go
@@ -245,27 +245,27 @@ func (s *MonitoringService) SubscribeMeasurements(req *pb.DeviceRequest, stream 
 			}
 			var eventType pb.MeasurementEventType
 			switch evt.Type {
-			case "monitoring.power_updated":
+			case eebus.EventTypeMonitoringPowerUpdated:
 				eventType = pb.MeasurementEventType_MEASUREMENT_EVENT_POWER_UPDATED
-			case "monitoring.energy_consumed_updated":
+			case eebus.EventTypeMonitoringEnergyConsumedUpdated:
 				eventType = pb.MeasurementEventType_MEASUREMENT_EVENT_ENERGY_UPDATED
-			case "dhw.temperature_updated":
+			case eebus.EventTypeDHWTemperatureUpdated:
 				eventType = pb.MeasurementEventType_MEASUREMENT_EVENT_DHW_TEMPERATURE_UPDATED
-			case "dhw.monitoring_support_updated":
+			case eebus.EventTypeDHWMonitoringSupportUpdated:
 				eventType = pb.MeasurementEventType_MEASUREMENT_EVENT_DHW_TEMPERATURE_SUPPORT_UPDATED
-			case "room.temperature_updated":
+			case eebus.EventTypeRoomTemperatureUpdated:
 				eventType = pb.MeasurementEventType_MEASUREMENT_EVENT_ROOM_TEMPERATURE_UPDATED
-			case "room.monitoring_support_updated":
+			case eebus.EventTypeRoomMonitoringSupportUpdated:
 				eventType = pb.MeasurementEventType_MEASUREMENT_EVENT_ROOM_TEMPERATURE_SUPPORT_UPDATED
-			case "outdoor.temperature_updated":
+			case eebus.EventTypeOutdoorTemperatureUpdated:
 				eventType = pb.MeasurementEventType_MEASUREMENT_EVENT_OUTDOOR_TEMPERATURE_UPDATED
-			case "outdoor.monitoring_support_updated":
+			case eebus.EventTypeOutdoorMonitoringSupportUpdated:
 				eventType = pb.MeasurementEventType_MEASUREMENT_EVENT_OUTDOOR_TEMPERATURE_SUPPORT_UPDATED
-			case "monitoring.flow_temperature_updated":
+			case eebus.EventTypeMonitoringFlowTemperatureUpdated:
 				eventType = pb.MeasurementEventType_MEASUREMENT_EVENT_FLOW_TEMPERATURE_UPDATED
-			case "monitoring.return_temperature_updated":
+			case eebus.EventTypeMonitoringReturnTemperatureUpdated:
 				eventType = pb.MeasurementEventType_MEASUREMENT_EVENT_RETURN_TEMPERATURE_UPDATED
-			case "monitoring.device_operating_state_updated":
+			case eebus.EventTypeMonitoringDeviceOperatingStateUpdated:
 				eventType = pb.MeasurementEventType_MEASUREMENT_EVENT_DEVICE_OPERATING_STATE_UPDATED
 			default:
 				continue

--- a/eebus-bridge/internal/grpc/monitoring_service_test.go
+++ b/eebus-bridge/internal/grpc/monitoring_service_test.go
@@ -64,7 +64,7 @@ func TestSubscribeMeasurements(t *testing.T) {
 
 	// Give the server-side handler goroutine time to subscribe before publishing.
 	time.Sleep(50 * time.Millisecond)
-	bus.Publish(eebus.Event{SKI: "test-ski", Type: "monitoring.power_updated"})
+	bus.Publish(eebus.Event{SKI: "test-ski", Type: eebus.EventTypeMonitoringPowerUpdated})
 
 	evt, err := stream.Recv()
 	if err != nil {
@@ -151,16 +151,16 @@ func TestSubscribeMeasurementsIncludesTemperaturePayloads(t *testing.T) {
 
 	time.Sleep(50 * time.Millisecond)
 	tests := []struct {
-		bridgeEvent string
+		bridgeEvent eebus.EventType
 		eventType   pb.MeasurementEventType
 		typ         string
 		value       float64
 	}{
-		{"dhw.temperature_updated", pb.MeasurementEventType_MEASUREMENT_EVENT_DHW_TEMPERATURE_UPDATED, "dhw_temperature", 49},
-		{"room.temperature_updated", pb.MeasurementEventType_MEASUREMENT_EVENT_ROOM_TEMPERATURE_UPDATED, "room_temperature", 20.5},
-		{"outdoor.temperature_updated", pb.MeasurementEventType_MEASUREMENT_EVENT_OUTDOOR_TEMPERATURE_UPDATED, "outdoor_temperature", 6.5},
-		{"monitoring.flow_temperature_updated", pb.MeasurementEventType_MEASUREMENT_EVENT_FLOW_TEMPERATURE_UPDATED, "flow_temperature", 43},
-		{"monitoring.return_temperature_updated", pb.MeasurementEventType_MEASUREMENT_EVENT_RETURN_TEMPERATURE_UPDATED, "return_temperature", 38},
+		{eebus.EventTypeDHWTemperatureUpdated, pb.MeasurementEventType_MEASUREMENT_EVENT_DHW_TEMPERATURE_UPDATED, "dhw_temperature", 49},
+		{eebus.EventTypeRoomTemperatureUpdated, pb.MeasurementEventType_MEASUREMENT_EVENT_ROOM_TEMPERATURE_UPDATED, "room_temperature", 20.5},
+		{eebus.EventTypeOutdoorTemperatureUpdated, pb.MeasurementEventType_MEASUREMENT_EVENT_OUTDOOR_TEMPERATURE_UPDATED, "outdoor_temperature", 6.5},
+		{eebus.EventTypeMonitoringFlowTemperatureUpdated, pb.MeasurementEventType_MEASUREMENT_EVENT_FLOW_TEMPERATURE_UPDATED, "flow_temperature", 43},
+		{eebus.EventTypeMonitoringReturnTemperatureUpdated, pb.MeasurementEventType_MEASUREMENT_EVENT_RETURN_TEMPERATURE_UPDATED, "return_temperature", 38},
 	}
 	for _, tt := range tests {
 		bus.Publish(eebus.Event{SKI: "test-ski", Type: tt.bridgeEvent})
@@ -176,11 +176,11 @@ func TestSubscribeMeasurementsIncludesTemperaturePayloads(t *testing.T) {
 	}
 
 	supportTests := []struct {
-		bridgeEvent string
+		bridgeEvent eebus.EventType
 		eventType   pb.MeasurementEventType
 	}{
-		{"room.monitoring_support_updated", pb.MeasurementEventType_MEASUREMENT_EVENT_ROOM_TEMPERATURE_SUPPORT_UPDATED},
-		{"outdoor.monitoring_support_updated", pb.MeasurementEventType_MEASUREMENT_EVENT_OUTDOOR_TEMPERATURE_SUPPORT_UPDATED},
+		{eebus.EventTypeRoomMonitoringSupportUpdated, pb.MeasurementEventType_MEASUREMENT_EVENT_ROOM_TEMPERATURE_SUPPORT_UPDATED},
+		{eebus.EventTypeOutdoorMonitoringSupportUpdated, pb.MeasurementEventType_MEASUREMENT_EVENT_OUTDOOR_TEMPERATURE_SUPPORT_UPDATED},
 	}
 	for _, tt := range supportTests {
 		bus.Publish(eebus.Event{SKI: "test-ski", Type: tt.bridgeEvent})
@@ -255,7 +255,7 @@ func TestSubscribeMeasurementsForwardsDeviceOperatingState(t *testing.T) {
 	}
 
 	time.Sleep(50 * time.Millisecond)
-	bus.Publish(eebus.Event{SKI: "test-ski", Type: "monitoring.device_operating_state_updated"})
+	bus.Publish(eebus.Event{SKI: "test-ski", Type: eebus.EventTypeMonitoringDeviceOperatingStateUpdated})
 
 	event, err := stream.Recv()
 	if err != nil {

--- a/eebus-bridge/internal/grpc/ohpcf_service.go
+++ b/eebus-bridge/internal/grpc/ohpcf_service.go
@@ -93,17 +93,17 @@ func (s *OHPCFService) SubscribeOHPCFEvents(req *pb.DeviceRequest, stream pb.OHP
 			}
 			var eventType pb.OHPCFEventType
 			switch evt.Type {
-			case "ohpcf.use_case_support_updated":
+			case eebus.EventTypeOHPCFUseCaseSupportUpdated:
 				eventType = pb.OHPCFEventType_OHPCF_EVENT_SUPPORT_UPDATED
-			case "ohpcf.consumption_state_updated":
+			case eebus.EventTypeOHPCFConsumptionStateUpdated:
 				eventType = pb.OHPCFEventType_OHPCF_EVENT_STATE_UPDATED
-			case "ohpcf.consumption_stoppable_updated",
-				"ohpcf.consumption_pausable_updated",
-				"ohpcf.consumption_start_time_updated",
-				"ohpcf.requested_power_estimate_updated",
-				"ohpcf.requested_power_max_updated",
-				"ohpcf.minimal_run_duration_updated",
-				"ohpcf.minimal_pause_duration_updated":
+			case eebus.EventTypeOHPCFConsumptionStoppableUpdated,
+				eebus.EventTypeOHPCFConsumptionPausableUpdated,
+				eebus.EventTypeOHPCFConsumptionStartTimeUpdated,
+				eebus.EventTypeOHPCFRequestedPowerEstimateUpdated,
+				eebus.EventTypeOHPCFRequestedPowerMaxUpdated,
+				eebus.EventTypeOHPCFMinimalRunDurationUpdated,
+				eebus.EventTypeOHPCFMinimalPauseDurationUpdated:
 				eventType = pb.OHPCFEventType_OHPCF_EVENT_DATA_UPDATED
 			default:
 				continue

--- a/eebus-bridge/internal/usecases/devicediagnosis.go
+++ b/eebus-bridge/internal/usecases/devicediagnosis.go
@@ -58,7 +58,7 @@ func (d *DeviceOperatingState) HandleEvent(payload spineapi.EventPayload) {
 		return
 	}
 	ski := eebus.NormalizeSKI(payload.Ski)
-	d.bus.Publish(eebus.Event{SKI: ski, Type: "monitoring.device_operating_state_updated"})
+	d.bus.Publish(eebus.Event{SKI: ski, Type: eebus.EventTypeMonitoringDeviceOperatingStateUpdated})
 }
 
 // OperatingState actively reads and returns the remote device operating state.

--- a/eebus-bridge/internal/usecases/devicediagnosis_test.go
+++ b/eebus-bridge/internal/usecases/devicediagnosis_test.go
@@ -91,7 +91,7 @@ func TestDeviceOperatingStateHandleEventPublishesFromPayload(t *testing.T) {
 
 	select {
 	case evt := <-ch:
-		if evt.Type != "monitoring.device_operating_state_updated" || evt.SKI != "TEST-SKI" {
+		if evt.Type != eebus.EventTypeMonitoringDeviceOperatingStateUpdated || evt.SKI != "TEST-SKI" {
 			t.Fatalf("event = %+v", evt)
 		}
 	default:

--- a/eebus-bridge/internal/usecases/dhw.go
+++ b/eebus-bridge/internal/usecases/dhw.go
@@ -115,7 +115,7 @@ func (d *DHWTemperature) HandleEvent(payload spineapi.EventPayload) {
 		d.request(payload.Entity, model.FunctionTypeSetpointListData)
 	case *model.SetpointListDataType:
 		if _, err := d.State(payload.Entity); err == nil && d.bus != nil {
-			d.bus.Publish(eebus.Event{SKI: payload.Ski, Type: "dhw.setpoint_updated"})
+			d.bus.Publish(eebus.Event{SKI: payload.Ski, Type: eebus.EventTypeDHWSetpointUpdated})
 		}
 	}
 }
@@ -130,7 +130,7 @@ func (d *DHWTemperature) handleUseCaseEvent(
 		d.registry.UpsertObservation(ski, device, entity, "dhw_temperature")
 	}
 	if d.bus != nil {
-		d.bus.Publish(eebus.Event{SKI: ski, Type: "dhw.use_case_support_updated"})
+		d.bus.Publish(eebus.Event{SKI: ski, Type: eebus.EventTypeDHWUseCaseSupportUpdated})
 	}
 }
 

--- a/eebus-bridge/internal/usecases/dhwmonitoring_test.go
+++ b/eebus-bridge/internal/usecases/dhwmonitoring_test.go
@@ -20,7 +20,7 @@ func TestDHWMonitoringWrapperPublishesTemperatureUpdate(t *testing.T) {
 
 	select {
 	case event := <-ch:
-		if event.SKI != "test-ski" || event.Type != "dhw.temperature_updated" {
+		if event.SKI != "test-ski" || event.Type != eebus.EventTypeDHWTemperatureUpdated {
 			t.Fatalf("event = %+v", event)
 		}
 	case <-time.After(time.Second):

--- a/eebus-bridge/internal/usecases/dhwsysfn.go
+++ b/eebus-bridge/internal/usecases/dhwsysfn.go
@@ -123,11 +123,11 @@ func (d *DHWSystemFunction) HandleEvent(payload spineapi.EventPayload) {
 		*model.HvacSystemFunctionOperationModeRelationListDataType,
 		*model.HvacOverrunDescriptionListDataType:
 		if _, err := d.State(payload.Entity); err == nil && d.bus != nil {
-			d.bus.Publish(eebus.Event{SKI: payload.Ski, Type: "dhwsysfn.use_case_support_updated"})
+			d.bus.Publish(eebus.Event{SKI: payload.Ski, Type: eebus.EventTypeDHWSystemFunctionSupportUpdated})
 		}
 	case *model.HvacSystemFunctionListDataType, *model.HvacOverrunListDataType:
 		if _, err := d.State(payload.Entity); err == nil && d.bus != nil {
-			d.bus.Publish(eebus.Event{SKI: payload.Ski, Type: "dhwsysfn.updated"})
+			d.bus.Publish(eebus.Event{SKI: payload.Ski, Type: eebus.EventTypeDHWSystemFunctionUpdated})
 		}
 	}
 }
@@ -142,7 +142,7 @@ func (d *DHWSystemFunction) handleUseCaseEvent(
 		d.registry.UpsertObservation(ski, device, entity, "dhw_system_function")
 	}
 	if d.bus != nil {
-		d.bus.Publish(eebus.Event{SKI: ski, Type: "dhwsysfn.use_case_support_updated"})
+		d.bus.Publish(eebus.Event{SKI: ski, Type: eebus.EventTypeDHWSystemFunctionSupportUpdated})
 	}
 }
 

--- a/eebus-bridge/internal/usecases/hydraulictemp.go
+++ b/eebus-bridge/internal/usecases/hydraulictemp.go
@@ -52,10 +52,10 @@ func (h *HydraulicTemperatures) HandleEvent(payload spineapi.EventPayload) {
 	}
 	ski := eebus.NormalizeSKI(payload.Ski)
 	if _, err := h.FlowTemperature(ski); err == nil {
-		h.bus.Publish(eebus.Event{SKI: ski, Type: "monitoring.flow_temperature_updated"})
+		h.bus.Publish(eebus.Event{SKI: ski, Type: eebus.EventTypeMonitoringFlowTemperatureUpdated})
 	}
 	if _, err := h.ReturnTemperature(ski); err == nil {
-		h.bus.Publish(eebus.Event{SKI: ski, Type: "monitoring.return_temperature_updated"})
+		h.bus.Publish(eebus.Event{SKI: ski, Type: eebus.EventTypeMonitoringReturnTemperatureUpdated})
 	}
 }
 

--- a/eebus-bridge/internal/usecases/lpc.go
+++ b/eebus-bridge/internal/usecases/lpc.go
@@ -67,20 +67,20 @@ func (w *LPCWrapper) HandleEvent(ski string, device spineapi.DeviceRemoteInterfa
 		enrichDeviceClassification(w.registry, w.localEntity, ski, device, entity)
 	}
 
-	var eventType string
+	var eventType eebus.EventType
 	switch event {
 	case eglpc.DataUpdateLimit:
-		eventType = "lpc.limit_updated"
+		eventType = eebus.EventTypeLPCLimitUpdated
 	case eglpc.DataUpdateFailsafeConsumptionActivePowerLimit:
-		eventType = "lpc.failsafe_power_updated"
+		eventType = eebus.EventTypeLPCFailsafePowerUpdated
 	case eglpc.DataUpdateFailsafeDurationMinimum:
-		eventType = "lpc.failsafe_duration_updated"
+		eventType = eebus.EventTypeLPCFailsafeDurationUpdated
 	case eglpc.UseCaseSupportUpdate:
-		eventType = "lpc.use_case_support_updated"
+		eventType = eebus.EventTypeLPCUseCaseSupportUpdated
 	case eglpc.DataUpdateHeartbeat:
 		// Per eebus-go: signals the remote entering or leaving failsafe state.
 		// No payload is attached; HA reconciles via GetHeartbeatStatus on refresh.
-		eventType = "lpc.heartbeat_updated"
+		eventType = eebus.EventTypeLPCHeartbeatUpdated
 	default:
 		return
 	}

--- a/eebus-bridge/internal/usecases/lpc_test.go
+++ b/eebus-bridge/internal/usecases/lpc_test.go
@@ -24,7 +24,7 @@ func TestLPCEventRouting(t *testing.T) {
 		if evt.SKI != "test-ski" {
 			t.Errorf("SKI = %q, want test-ski", evt.SKI)
 		}
-		if evt.Type != "lpc.limit_updated" {
+		if evt.Type != eebus.EventTypeLPCLimitUpdated {
 			t.Errorf("Type = %q, want lpc.limit_updated", evt.Type)
 		}
 	case <-time.After(time.Second):
@@ -42,7 +42,7 @@ func TestLPCFailsafePowerEventRouting(t *testing.T) {
 
 	select {
 	case evt := <-ch:
-		if evt.Type != "lpc.failsafe_power_updated" {
+		if evt.Type != eebus.EventTypeLPCFailsafePowerUpdated {
 			t.Errorf("Type = %q, want lpc.failsafe_power_updated", evt.Type)
 		}
 	case <-time.After(time.Second):
@@ -60,7 +60,7 @@ func TestLPCFailsafeDurationEventRouting(t *testing.T) {
 
 	select {
 	case evt := <-ch:
-		if evt.Type != "lpc.failsafe_duration_updated" {
+		if evt.Type != eebus.EventTypeLPCFailsafeDurationUpdated {
 			t.Errorf("Type = %q, want lpc.failsafe_duration_updated", evt.Type)
 		}
 	case <-time.After(time.Second):
@@ -78,7 +78,7 @@ func TestLPCHeartbeatEventRouting(t *testing.T) {
 
 	select {
 	case evt := <-ch:
-		if evt.Type != "lpc.heartbeat_updated" {
+		if evt.Type != eebus.EventTypeLPCHeartbeatUpdated {
 			t.Errorf("Type = %q, want lpc.heartbeat_updated", evt.Type)
 		}
 	case <-time.After(time.Second):

--- a/eebus-bridge/internal/usecases/mgcp.go
+++ b/eebus-bridge/internal/usecases/mgcp.go
@@ -239,7 +239,7 @@ func (p *MGCPProvider) handleEvent(ski string, _ spineapi.DeviceRemoteInterface,
 	if event == mgcpUseCaseSupportUpdate {
 		log.Printf("[MGCP] consumer support update from ski=%s", ski)
 		if p.bus != nil {
-			p.bus.Publish(eebus.Event{SKI: ski, Type: "mgcp.consumer_updated"})
+			p.bus.Publish(eebus.Event{SKI: ski, Type: eebus.EventTypeMGCPConsumerUpdated})
 		}
 	}
 }

--- a/eebus-bridge/internal/usecases/monitoring.go
+++ b/eebus-bridge/internal/usecases/monitoring.go
@@ -79,24 +79,24 @@ func (w *MonitoringWrapper) HandleEvent(ski string, device spineapi.DeviceRemote
 		enrichDeviceClassification(w.registry, w.localEntity, ski, device, entity)
 	}
 
-	var eventType string
+	var eventType eebus.EventType
 	switch event {
 	case mampc.DataUpdatePower:
-		eventType = "monitoring.power_updated"
+		eventType = eebus.EventTypeMonitoringPowerUpdated
 	case mampc.DataUpdatePowerPerPhase:
-		eventType = "monitoring.power_per_phase_updated"
+		eventType = eebus.EventTypeMonitoringPowerPerPhaseUpdated
 	case mampc.DataUpdateEnergyConsumed:
-		eventType = "monitoring.energy_consumed_updated"
+		eventType = eebus.EventTypeMonitoringEnergyConsumedUpdated
 	case mampc.DataUpdateEnergyProduced:
-		eventType = "monitoring.energy_produced_updated"
+		eventType = eebus.EventTypeMonitoringEnergyProducedUpdated
 	case mampc.DataUpdateCurrentsPerPhase:
-		eventType = "monitoring.currents_per_phase_updated"
+		eventType = eebus.EventTypeMonitoringCurrentsPerPhaseUpdated
 	case mampc.DataUpdateVoltagePerPhase:
-		eventType = "monitoring.voltage_per_phase_updated"
+		eventType = eebus.EventTypeMonitoringVoltagePerPhaseUpdated
 	case mampc.DataUpdateFrequency:
-		eventType = "monitoring.frequency_updated"
+		eventType = eebus.EventTypeMonitoringFrequencyUpdated
 	case mampc.UseCaseSupportUpdate:
-		eventType = "monitoring.use_case_support_updated"
+		eventType = eebus.EventTypeMonitoringUseCaseSupportUpdated
 	default:
 		return
 	}

--- a/eebus-bridge/internal/usecases/monitoring_test.go
+++ b/eebus-bridge/internal/usecases/monitoring_test.go
@@ -20,7 +20,7 @@ func TestMonitoringEventRouting(t *testing.T) {
 
 	select {
 	case evt := <-ch:
-		if evt.Type != "monitoring.power_updated" {
+		if evt.Type != eebus.EventTypeMonitoringPowerUpdated {
 			t.Errorf("Type = %q, want monitoring.power_updated", evt.Type)
 		}
 	case <-time.After(time.Second):
@@ -38,7 +38,7 @@ func TestMonitoringEnergyConsumedEventRouting(t *testing.T) {
 
 	select {
 	case evt := <-ch:
-		if evt.Type != "monitoring.energy_consumed_updated" {
+		if evt.Type != eebus.EventTypeMonitoringEnergyConsumedUpdated {
 			t.Errorf("Type = %q, want monitoring.energy_consumed_updated", evt.Type)
 		}
 	case <-time.After(time.Second):
@@ -56,7 +56,7 @@ func TestMonitoringFrequencyEventRouting(t *testing.T) {
 
 	select {
 	case evt := <-ch:
-		if evt.Type != "monitoring.frequency_updated" {
+		if evt.Type != eebus.EventTypeMonitoringFrequencyUpdated {
 			t.Errorf("Type = %q, want monitoring.frequency_updated", evt.Type)
 		}
 	case <-time.After(time.Second):

--- a/eebus-bridge/internal/usecases/ohpcf.go
+++ b/eebus-bridge/internal/usecases/ohpcf.go
@@ -81,26 +81,26 @@ func (w *OHPCFWrapper) HandleEvent(ski string, device spineapi.DeviceRemoteInter
 		enrichDeviceClassification(w.registry, w.localEntity, ski, device, entity)
 	}
 
-	var eventType string
+	var eventType eebus.EventType
 	switch event {
 	case cemohpcf.UseCaseSupportUpdate:
-		eventType = "ohpcf.use_case_support_updated"
+		eventType = eebus.EventTypeOHPCFUseCaseSupportUpdated
 	case cemohpcf.DataUpdateConsumptionState:
-		eventType = "ohpcf.consumption_state_updated"
+		eventType = eebus.EventTypeOHPCFConsumptionStateUpdated
 	case cemohpcf.DataUpdateConsumptionIsStoppable:
-		eventType = "ohpcf.consumption_stoppable_updated"
+		eventType = eebus.EventTypeOHPCFConsumptionStoppableUpdated
 	case cemohpcf.DataUpdateConsumptionIsPausable:
-		eventType = "ohpcf.consumption_pausable_updated"
+		eventType = eebus.EventTypeOHPCFConsumptionPausableUpdated
 	case cemohpcf.DataUpdateConsumptionStartTime:
-		eventType = "ohpcf.consumption_start_time_updated"
+		eventType = eebus.EventTypeOHPCFConsumptionStartTimeUpdated
 	case cemohpcf.DataUpdateRequestedPowerEstimate:
-		eventType = "ohpcf.requested_power_estimate_updated"
+		eventType = eebus.EventTypeOHPCFRequestedPowerEstimateUpdated
 	case cemohpcf.DataUpdateRequestedPowerMax:
-		eventType = "ohpcf.requested_power_max_updated"
+		eventType = eebus.EventTypeOHPCFRequestedPowerMaxUpdated
 	case cemohpcf.DataUpdateMinimalRunDuration:
-		eventType = "ohpcf.minimal_run_duration_updated"
+		eventType = eebus.EventTypeOHPCFMinimalRunDurationUpdated
 	case cemohpcf.DataUpdateMinimalPauseDuration:
-		eventType = "ohpcf.minimal_pause_duration_updated"
+		eventType = eebus.EventTypeOHPCFMinimalPauseDurationUpdated
 	default:
 		return
 	}

--- a/eebus-bridge/internal/usecases/ohpcf_test.go
+++ b/eebus-bridge/internal/usecases/ohpcf_test.go
@@ -24,7 +24,7 @@ func TestOHPCFEventRouting(t *testing.T) {
 
 	select {
 	case evt := <-ch:
-		if evt.Type != "ohpcf.consumption_state_updated" {
+		if evt.Type != eebus.EventTypeOHPCFConsumptionStateUpdated {
 			t.Errorf("Type = %q, want ohpcf.consumption_state_updated", evt.Type)
 		}
 		if evt.SKI != "ohpcf-ski" {

--- a/eebus-bridge/internal/usecases/outdoormonitoring_test.go
+++ b/eebus-bridge/internal/usecases/outdoormonitoring_test.go
@@ -14,10 +14,10 @@ func TestOutdoorMonitoringWrapperPublishesEvents(t *testing.T) {
 	tests := []struct {
 		name string
 		in   eebusapi.EventType
-		want string
+		want eebus.EventType
 	}{
-		{name: "temperature", in: mamot.DataUpdateTemperature, want: "outdoor.temperature_updated"},
-		{name: "support", in: mamot.UseCaseSupportUpdate, want: "outdoor.monitoring_support_updated"},
+		{name: "temperature", in: mamot.DataUpdateTemperature, want: eebus.EventTypeOutdoorTemperatureUpdated},
+		{name: "support", in: mamot.UseCaseSupportUpdate, want: eebus.EventTypeOutdoorMonitoringSupportUpdated},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/eebus-bridge/internal/usecases/roomheatingsysfn.go
+++ b/eebus-bridge/internal/usecases/roomheatingsysfn.go
@@ -108,11 +108,11 @@ func (r *RoomHeatingSystemFunction) HandleEvent(payload spineapi.EventPayload) {
 		*model.HvacOperationModeDescriptionListDataType,
 		*model.HvacSystemFunctionOperationModeRelationListDataType:
 		if _, err := r.State(payload.Entity); err == nil && r.bus != nil {
-			r.bus.Publish(eebus.Event{SKI: payload.Ski, Type: "roomheatingsysfn.use_case_support_updated"})
+			r.bus.Publish(eebus.Event{SKI: payload.Ski, Type: eebus.EventTypeRoomHeatingSystemFunctionSupportUpdated})
 		}
 	case *model.HvacSystemFunctionListDataType:
 		if _, err := r.State(payload.Entity); err == nil && r.bus != nil {
-			r.bus.Publish(eebus.Event{SKI: payload.Ski, Type: "roomheatingsysfn.updated"})
+			r.bus.Publish(eebus.Event{SKI: payload.Ski, Type: eebus.EventTypeRoomHeatingSystemFunctionUpdated})
 		}
 	}
 }
@@ -127,7 +127,7 @@ func (r *RoomHeatingSystemFunction) handleUseCaseEvent(
 		r.registry.UpsertObservation(ski, device, entity, "room_heating_system_function")
 	}
 	if r.bus != nil {
-		r.bus.Publish(eebus.Event{SKI: ski, Type: "roomheatingsysfn.use_case_support_updated"})
+		r.bus.Publish(eebus.Event{SKI: ski, Type: eebus.EventTypeRoomHeatingSystemFunctionSupportUpdated})
 	}
 }
 

--- a/eebus-bridge/internal/usecases/roomheatingtemp.go
+++ b/eebus-bridge/internal/usecases/roomheatingtemp.go
@@ -111,7 +111,7 @@ func (r *RoomHeatingTemperature) HandleEvent(payload spineapi.EventPayload) {
 		r.request(payload.Entity, model.FunctionTypeSetpointListData)
 	case *model.SetpointListDataType:
 		if _, err := r.State(payload.Entity); err == nil && r.bus != nil {
-			r.bus.Publish(eebus.Event{SKI: payload.Ski, Type: "roomheating.setpoint_updated"})
+			r.bus.Publish(eebus.Event{SKI: payload.Ski, Type: eebus.EventTypeRoomHeatingSetpointUpdated})
 		}
 	}
 }
@@ -126,7 +126,7 @@ func (r *RoomHeatingTemperature) handleUseCaseEvent(
 		r.registry.UpsertObservation(ski, device, entity, "room_heating_temperature")
 	}
 	if r.bus != nil {
-		r.bus.Publish(eebus.Event{SKI: ski, Type: "roomheating.use_case_support_updated"})
+		r.bus.Publish(eebus.Event{SKI: ski, Type: eebus.EventTypeRoomHeatingUseCaseSupportUpdated})
 	}
 }
 

--- a/eebus-bridge/internal/usecases/roommonitoring_test.go
+++ b/eebus-bridge/internal/usecases/roommonitoring_test.go
@@ -14,10 +14,10 @@ func TestRoomMonitoringWrapperPublishesEvents(t *testing.T) {
 	tests := []struct {
 		name string
 		in   eebusapi.EventType
-		want string
+		want eebus.EventType
 	}{
-		{name: "temperature", in: mamrt.DataUpdateTemperature, want: "room.temperature_updated"},
-		{name: "support", in: mamrt.UseCaseSupportUpdate, want: "room.monitoring_support_updated"},
+		{name: "temperature", in: mamrt.DataUpdateTemperature, want: eebus.EventTypeRoomTemperatureUpdated},
+		{name: "support", in: mamrt.UseCaseSupportUpdate, want: eebus.EventTypeRoomMonitoringSupportUpdated},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/eebus-bridge/internal/usecases/temperaturemonitoring.go
+++ b/eebus-bridge/internal/usecases/temperaturemonitoring.go
@@ -42,8 +42,8 @@ type TemperatureMonitoringWrapper struct {
 	newUseCase        func(spineapi.EntityLocalInterface, eebusapi.EntityEventCallback) temperatureUseCase
 	dataEvent         eebusapi.EventType
 	supportEvent      eebusapi.EventType
-	publishData       string
-	publishSupport    string
+	publishData       eebus.EventType
+	publishSupport    eebus.EventType
 	errNotInitialized error
 }
 
@@ -62,8 +62,8 @@ func NewDHWMonitoringWrapper(
 		},
 		dataEvent:         mamdt.DataUpdateTemperature,
 		supportEvent:      mamdt.UseCaseSupportUpdate,
-		publishData:       "dhw.temperature_updated",
-		publishSupport:    "dhw.monitoring_support_updated",
+		publishData:       eebus.EventTypeDHWTemperatureUpdated,
+		publishSupport:    eebus.EventTypeDHWMonitoringSupportUpdated,
 		errNotInitialized: errDHWMonitoringNotInitialized,
 	}
 }
@@ -83,8 +83,8 @@ func NewRoomMonitoringWrapper(
 		},
 		dataEvent:         mamrt.DataUpdateTemperature,
 		supportEvent:      mamrt.UseCaseSupportUpdate,
-		publishData:       "room.temperature_updated",
-		publishSupport:    "room.monitoring_support_updated",
+		publishData:       eebus.EventTypeRoomTemperatureUpdated,
+		publishSupport:    eebus.EventTypeRoomMonitoringSupportUpdated,
 		errNotInitialized: errRoomMonitoringNotInitialized,
 	}
 }
@@ -104,8 +104,8 @@ func NewOutdoorMonitoringWrapper(
 		},
 		dataEvent:         mamot.DataUpdateTemperature,
 		supportEvent:      mamot.UseCaseSupportUpdate,
-		publishData:       "outdoor.temperature_updated",
-		publishSupport:    "outdoor.monitoring_support_updated",
+		publishData:       eebus.EventTypeOutdoorTemperatureUpdated,
+		publishSupport:    eebus.EventTypeOutdoorMonitoringSupportUpdated,
 		errNotInitialized: errOutdoorMonitoringNotInitialized,
 	}
 }
@@ -132,7 +132,7 @@ func (w *TemperatureMonitoringWrapper) HandleEvent(
 		w.registry.UpsertObservation(ski, device, entity, w.registryTag)
 	}
 
-	var eventType string
+	var eventType eebus.EventType
 	switch event {
 	case w.dataEvent:
 		eventType = w.publishData

--- a/eebus-bridge/internal/usecases/vabd.go
+++ b/eebus-bridge/internal/usecases/vabd.go
@@ -248,7 +248,7 @@ func (p *VABDProvider) handleEvent(ski string, _ spineapi.DeviceRemoteInterface,
 	if event == vabdUseCaseSupportUpdate {
 		log.Printf("[VABD] consumer support update from ski=%s", ski)
 		if p.bus != nil {
-			p.bus.Publish(eebus.Event{SKI: ski, Type: "vabd.consumer_updated"})
+			p.bus.Publish(eebus.Event{SKI: ski, Type: eebus.EventTypeVABDConsumerUpdated})
 		}
 	}
 }

--- a/eebus-bridge/internal/usecases/vapd.go
+++ b/eebus-bridge/internal/usecases/vapd.go
@@ -245,7 +245,7 @@ func (p *VAPDProvider) handleEvent(ski string, _ spineapi.DeviceRemoteInterface,
 	if event == vapdUseCaseSupportUpdate {
 		log.Printf("[VAPD] consumer support update from ski=%s", ski)
 		if p.bus != nil {
-			p.bus.Publish(eebus.Event{SKI: ski, Type: "vapd.consumer_updated"})
+			p.bus.Publish(eebus.Event{SKI: ski, Type: eebus.EventTypeVAPDConsumerUpdated})
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- introduce a typed EventType vocabulary for all internal bus events
- replace publisher and subscriber string literals with shared constants
- update event-routing tests and typed test tables to use the same constants

## Tests

- go vet ./...
- go test -race ./...
