### PR TITLE
RF-02: strict device identity isolation

### DIFF
--- a/custom_components/eebus/coordinator.py
+++ b/custom_components/eebus/coordinator.py
@@ -317,26 +317,24 @@ class EebusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             monitoring_stub = proto_stubs.monitoring_service_stub(channel)
             lpc_stub = proto_stubs.lpc_service_stub(channel)
             request = proto_stubs.DeviceRequest(ski=self.ski)
-            fallback_request = proto_stubs.DeviceRequest(ski="")
-            flags = {"saw_not_found": False, "used_fallback": False}
+            flags = {"saw_not_found": False}
 
             # The reads are independent; run them concurrently so poll latency
             # is the slowest single read instead of the sum of all round-trips.
             power, measurements, energy, limit, failsafe, hb = await asyncio.gather(
                 self._poll_read(
-                    "power", monitoring_stub.GetPowerConsumption, request, fallback_request, flags
+                    "power", monitoring_stub.GetPowerConsumption, request, flags
                 ),
                 self._poll_read(
-                    "scoped energy", monitoring_stub.GetMeasurements, request, fallback_request, flags
+                    "scoped energy", monitoring_stub.GetMeasurements, request, flags
                 ),
                 self._poll_read(
-                    "total energy", monitoring_stub.GetEnergyConsumed, request, fallback_request, flags
+                    "total energy", monitoring_stub.GetEnergyConsumed, request, flags
                 ),
                 self._poll_read(
                     "consumption limit",
                     lpc_stub.GetConsumptionLimit,
                     request,
-                    fallback_request,
                     flags,
                     unsupported_attr="_lpc_supported",
                 ),
@@ -344,7 +342,6 @@ class EebusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     "failsafe",
                     lpc_stub.GetFailsafeLimit,
                     request,
-                    fallback_request,
                     flags,
                     unsupported_attr="_failsafe_supported",
                 ),
@@ -352,7 +349,6 @@ class EebusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     "heartbeat",
                     lpc_stub.GetHeartbeatStatus,
                     request,
-                    fallback_request,
                     flags,
                     unsupported_attr="_heartbeat_supported",
                 ),
@@ -402,16 +398,13 @@ class EebusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 data["heartbeat_status"] = None
 
             saw_not_found = flags["saw_not_found"]
-            used_fallback = flags["used_fallback"]
             data["heartbeat_supported"] = self._heartbeat_supported
             data["lpc_supported"] = self._lpc_supported
             data["failsafe_supported"] = self._failsafe_supported
-            data["read_fallback_used"] = used_fallback
 
-            # Remaining reads are independent too; the device-info read needs
-            # used_fallback from the first batch, so this is a second gather.
-            # OHPCF/DHW/room-heating stay unavailable when the bridge side is
-            # off; device diagnostics is best-effort.
+            # Remaining reads are independent too. OHPCF/DHW/room-heating stay
+            # unavailable when the bridge side is off; device diagnostics is
+            # best-effort.
             (
                 data["device_info"],
                 data["compressor_flexibility"],
@@ -420,9 +413,7 @@ class EebusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 room_heating,
                 data["device_operating_state"],
             ) = await asyncio.gather(
-                self._async_fetch_device_info(
-                    device_stub, proto_stubs, allow_fallback=used_fallback
-                ),
+                self._async_fetch_device_info(device_stub, proto_stubs),
                 self._async_read_compressor_flexibility(channel, proto_stubs, request),
                 self._async_read_dhw_setpoint(channel, proto_stubs, request),
                 self._async_read_dhw_system_function(channel, proto_stubs, request),
@@ -453,13 +444,12 @@ class EebusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 self._not_found_streak = 0
 
             _LOGGER.debug(
-                "EEBUS poll summary for SKI %s: power=%s energy_total=%s energy_heating=%s energy_dhw=%s fallback=%s",
+                "EEBUS poll summary for SKI %s: power=%s energy_total=%s energy_heating=%s energy_dhw=%s",
                 self.ski,
                 data["power_watts"],
                 data["energy_consumed_kwh"],
                 data["energy_consumed_heating_kwh"],
                 data["energy_consumed_dhw_kwh"],
-                used_fallback,
             )
 
             if self._was_unavailable:
@@ -489,38 +479,20 @@ class EebusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         label: str,
         call: Any,
         request: Any,
-        fallback_request: Any,
         flags: dict[str, bool],
         unsupported_attr: str | None = None,
     ) -> Any:
-        """Call a read RPC, retrying once with the fallback SKI on NOT_FOUND.
+        """Call a device-scoped read RPC once.
 
-        Returns the response, or None on failure. Records NOT_FOUND and
-        fallback use in ``flags``; when ``unsupported_attr`` is given, clears
-        that support flag on UNIMPLEMENTED.
+        Returns the response, or None on failure. Records NOT_FOUND in
+        ``flags``; when ``unsupported_attr`` is given, clears that support flag
+        on UNIMPLEMENTED.
         """
         try:
             response = await call(request, timeout=RPC_TIMEOUT)
         except grpc.aio.AioRpcError as err:
             if _is_not_found(err):
                 flags["saw_not_found"] = True
-                try:
-                    response = await call(fallback_request, timeout=RPC_TIMEOUT)
-                except grpc.aio.AioRpcError as retry_err:
-                    _LOGGER.debug(
-                        "EEBUS %s read failed for SKI %s and fallback: %s",
-                        label,
-                        self.ski,
-                        _rpc_error_text(retry_err),
-                    )
-                    if unsupported_attr is not None and _is_unimplemented(retry_err):
-                        setattr(self, unsupported_attr, False)
-                    return None
-                flags["used_fallback"] = True
-                _LOGGER.debug(
-                    "EEBUS %s read for SKI %s used fallback entity", label, self.ski
-                )
-                return response
             _LOGGER.debug(
                 "EEBUS %s read failed for SKI %s: %s",
                 label,
@@ -537,7 +509,7 @@ class EebusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         return response
 
     async def _async_fetch_device_info(
-        self, device_stub: Any, proto_stubs: Any, allow_fallback: bool
+        self, device_stub: Any, proto_stubs: Any
     ) -> dict[str, str] | None:
         """Read manufacturer/model metadata for the configured device.
 
@@ -566,8 +538,6 @@ class EebusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             return None
 
         match = next((d for d in devices if d.ski == self.ski), None)
-        if match is None and allow_fallback and len(devices) == 1:
-            match = devices[0]
         if match is None:
             return None
 
@@ -1359,10 +1329,7 @@ class EebusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
     def _event_matches(self, event_ski: str) -> bool:
         """Return True when an event applies to the configured device."""
-        if not event_ski or _normalize_ski(event_ski) == _normalize_ski(self.ski):
-            return True
-        # Reads fell back to the first available entity; its events are ours.
-        return bool(self.data and self.data.get("read_fallback_used"))
+        return _normalize_ski(event_ski) == _normalize_ski(self.ski)
 
     def _push_data(self, updates: dict[str, Any]) -> None:
         """Merge stream updates into coordinator data and notify listeners."""

--- a/custom_components/eebus/tests/test_coordinator.py
+++ b/custom_components/eebus/tests/test_coordinator.py
@@ -179,10 +179,8 @@ async def test_read_device_diagnostics_unavailable_returns_none():
 
 
 def test_measurement_event_other_ski_ignored():
-    """Events for a different SKI are ignored unless fallback reads are active."""
-    coordinator, pushed = _make_coordinator(
-        data={"power_watts": 100.0, "read_fallback_used": False}
-    )
+    """Events for a different SKI are always ignored."""
+    coordinator, pushed = _make_coordinator(data={"power_watts": 100.0})
     event = monitoring_service_pb2.MeasurementEvent(
         ski="other-ski",
         event_type=monitoring_service_pb2.MEASUREMENT_EVENT_POWER_UPDATED,
@@ -195,7 +193,7 @@ def test_measurement_event_other_ski_ignored():
 def test_measurement_event_matches_canonicalized_ski():
     """Canonical bridge events match a differently formatted configured SKI."""
     coordinator, pushed = _make_coordinator(
-        ski="ab:cd-ef", data={"power_watts": 100.0, "read_fallback_used": False}
+        ski="ab:cd-ef", data={"power_watts": 100.0}
     )
     event = monitoring_service_pb2.MeasurementEvent(
         ski="ABCDEF",
@@ -208,18 +206,16 @@ def test_measurement_event_matches_canonicalized_ski():
     assert pushed["power_watts"] == 1234.5
 
 
-def test_measurement_event_fallback_ski_accepted():
-    """When reads fell back to first entity, its events are accepted."""
-    coordinator, pushed = _make_coordinator(
-        data={"power_watts": 100.0, "read_fallback_used": True}
-    )
+def test_measurement_event_empty_ski_ignored():
+    """An empty event SKI is never treated as a wildcard."""
+    coordinator, pushed = _make_coordinator(data={"power_watts": 100.0})
     event = monitoring_service_pb2.MeasurementEvent(
-        ski="other-ski",
+        ski="",
         event_type=monitoring_service_pb2.MEASUREMENT_EVENT_POWER_UPDATED,
         power={"watts": 7.0},
     )
     coordinator._handle_measurement_event(event)
-    assert pushed["power_watts"] == 7.0
+    assert not pushed
 
 
 def test_measurement_event_before_first_poll_ignored():
@@ -308,9 +304,7 @@ def test_fetch_device_info_uses_matching_ski():
             device_type="HeatPumpAppliance",
         ),
     )
-    info = asyncio.run(
-        coordinator._async_fetch_device_info(stub, proto_stubs, allow_fallback=False)
-    )
+    info = asyncio.run(coordinator._async_fetch_device_info(stub, proto_stubs))
     assert info == {
         "manufacturer": "Bosch",
         "model": "Compress 5800i",
@@ -319,29 +313,78 @@ def test_fetch_device_info_uses_matching_ski():
     }
 
 
-def test_fetch_device_info_fallback_single_device():
-    """When reads fell back to the only device, its info is used despite SKI mismatch."""
+def test_fetch_device_info_single_mismatched_device_returns_none():
+    """A sole mismatched device is not used as metadata fallback."""
     coordinator, _ = _make_coordinator(ski="configured-ski")
     stub = _device_stub_returning(
         device_service_pb2.PairedDevice(ski="actual-ski", brand="Bosch")
     )
-    info = asyncio.run(
-        coordinator._async_fetch_device_info(stub, proto_stubs, allow_fallback=True)
-    )
-    assert info == {"manufacturer": "Bosch"}
+    info = asyncio.run(coordinator._async_fetch_device_info(stub, proto_stubs))
+    assert info is None
 
 
 def test_fetch_device_info_no_match_returns_none():
-    """No SKI match and no fallback yields None (no mislabeling)."""
+    """No SKI match yields None (no cross-device mislabeling)."""
     coordinator, _ = _make_coordinator(ski="configured-ski")
     stub = _device_stub_returning(
         device_service_pb2.PairedDevice(ski="a", brand="Bosch"),
         device_service_pb2.PairedDevice(ski="b", brand="Vaillant"),
     )
-    info = asyncio.run(
-        coordinator._async_fetch_device_info(stub, proto_stubs, allow_fallback=True)
-    )
+    info = asyncio.run(coordinator._async_fetch_device_info(stub, proto_stubs))
     assert info is None
+
+
+async def test_two_coordinators_isolate_device_info_and_events():
+    """Each config entry surfaces only metadata and events for its own SKI."""
+    coordinator_a, pushed_a = _make_coordinator(
+        ski="ski-a", data={"power_watts": 100.0}
+    )
+    coordinator_b, pushed_b = _make_coordinator(
+        ski="ski-b", data={"power_watts": 200.0}
+    )
+    stub = _device_stub_returning(
+        device_service_pb2.PairedDevice(ski="ski-b", brand="Brand B"),
+        device_service_pb2.PairedDevice(ski="ski-a", brand="Brand A"),
+    )
+
+    info_a, info_b = await asyncio.gather(
+        coordinator_a._async_fetch_device_info(stub, proto_stubs),
+        coordinator_b._async_fetch_device_info(stub, proto_stubs),
+    )
+    assert info_a == {"manufacturer": "Brand A"}
+    assert info_b == {"manufacturer": "Brand B"}
+
+    event_b = monitoring_service_pb2.MeasurementEvent(
+        ski="ski-b",
+        event_type=monitoring_service_pb2.MEASUREMENT_EVENT_POWER_UPDATED,
+        power={"watts": 250.0},
+    )
+    coordinator_a._handle_measurement_event(event_b)
+    coordinator_b._handle_measurement_event(event_b)
+
+    assert not pushed_a
+    assert pushed_b["power_watts"] == 250.0
+
+
+async def test_poll_read_not_found_does_not_retry_with_empty_ski():
+    """A failed device-scoped read is attempted exactly once."""
+    coordinator, _ = _make_coordinator(ski="ski-a")
+    call = AsyncMock(
+        side_effect=AioRpcError(
+            grpc.StatusCode.NOT_FOUND,
+            Metadata(),
+            Metadata(),
+            details="not found",
+        )
+    )
+    request = proto_stubs.DeviceRequest(ski="ski-a")
+    flags = {"saw_not_found": False}
+
+    result = await coordinator._poll_read("power", call, request, flags)
+
+    assert result is None
+    assert flags["saw_not_found"] is True
+    call.assert_awaited_once_with(request, timeout=10)
 
 
 def test_device_event_triggers_refresh():

--- a/eebus-bridge/internal/eebus/callbacks_test.go
+++ b/eebus-bridge/internal/eebus/callbacks_test.go
@@ -20,8 +20,8 @@ func TestCallbacksDispatchConnect(t *testing.T) {
 	select {
 	case evt := <-ch:
 		// SKI is normalized (uppercased, whitespace stripped) before dispatch.
-		if evt.SKI != "TEST-SKI-123" {
-			t.Errorf("SKI = %q, want TEST-SKI-123", evt.SKI)
+		if evt.SKI != "TESTSKI123" {
+			t.Errorf("SKI = %q, want TESTSKI123", evt.SKI)
 		}
 		if evt.Type != eebus.EventTypeDeviceConnected {
 			t.Errorf("Type = %q, want device.connected", evt.Type)
@@ -114,8 +114,8 @@ func TestCallbacksTrustRemovedClearsCachedEntitiesAndPublishes(t *testing.T) {
 		if evt.Type != eebus.EventTypeDeviceTrustRemoved {
 			t.Errorf("Type = %q, want device.trust_removed", evt.Type)
 		}
-		if evt.SKI != "TEST-SKI-789" {
-			t.Errorf("SKI = %q, want TEST-SKI-789", evt.SKI)
+		if evt.SKI != "TESTSKI789" {
+			t.Errorf("SKI = %q, want TESTSKI789", evt.SKI)
 		}
 	case <-time.After(time.Second):
 		t.Fatal("timeout waiting for trust_removed event")
@@ -137,6 +137,9 @@ func TestCallbacksVisibleServicesUpdated(t *testing.T) {
 		}
 	case <-time.After(time.Second):
 		t.Fatal("timeout")
+	}
+	if got := bus.DroppedUnresolvedEvents(); got != 0 {
+		t.Errorf("DroppedUnresolvedEvents() = %d, want 0", got)
 	}
 
 	if got := cb.DiscoveredServices(); len(got) != 1 || got[0].Ski != "abc" {

--- a/eebus-bridge/internal/eebus/eventbus.go
+++ b/eebus-bridge/internal/eebus/eventbus.go
@@ -1,11 +1,15 @@
 package eebus
 
-import "sync"
+import (
+	"sync"
+	"sync/atomic"
+)
 
 // EventBus provides fan-out event distribution to multiple subscribers.
 type EventBus struct {
-	mu          sync.RWMutex
-	subscribers map[chan Event]struct{}
+	mu                      sync.RWMutex
+	subscribers             map[chan Event]struct{}
+	droppedUnresolvedEvents atomic.Uint64
 }
 
 func NewEventBus() *EventBus {
@@ -37,13 +41,17 @@ func (b *EventBus) Unsubscribe(ch chan Event) {
 // Publish sends an event to all subscribers. Non-blocking: drops events
 // for subscribers whose buffer is full.
 //
-// evt.SKI is normalized here so every subscriber sees a canonical SKI
-// regardless of what the publishing call site passed in — callers used to
-// normalize inconsistently (or not at all), forcing every stream filter to
-// re-normalize both sides of the comparison.
+// evt.SKI is normalized here so every subscriber sees a canonical SKI.
+// Device-scoped events without a resolvable device identity are dropped at
+// this boundary, never broadcast as wildcards, and included in
+// DroppedUnresolvedEvents. EventTypeDiscoveryUpdated is exempt: it reports on
+// the whole visible-services list, not a single device, so it has no SKI to
+// resolve in the first place.
 func (b *EventBus) Publish(evt Event) {
-	if evt.SKI != "" {
-		evt.SKI = NormalizeSKI(evt.SKI)
+	evt.SKI = NormalizeSKI(evt.SKI)
+	if evt.SKI == "" && evt.Type != EventTypeDiscoveryUpdated {
+		b.droppedUnresolvedEvents.Add(1)
+		return
 	}
 	b.mu.RLock()
 	defer b.mu.RUnlock()
@@ -54,4 +62,10 @@ func (b *EventBus) Publish(evt Event) {
 			// subscriber too slow, drop event
 		}
 	}
+}
+
+// DroppedUnresolvedEvents returns the number of publish attempts rejected
+// because no canonical device SKI was supplied.
+func (b *EventBus) DroppedUnresolvedEvents() uint64 {
+	return b.droppedUnresolvedEvents.Load()
 }

--- a/eebus-bridge/internal/eebus/eventbus_test.go
+++ b/eebus-bridge/internal/eebus/eventbus_test.go
@@ -22,8 +22,8 @@ func TestEventBusSubscribeAndPublish(t *testing.T) {
 
 	select {
 	case received := <-ch:
-		if received.SKI != "TEST-SKI" {
-			t.Errorf("SKI = %q, want TEST-SKI (Publish normalizes)", received.SKI)
+		if received.SKI != "TESTSKI" {
+			t.Errorf("SKI = %q, want TESTSKI (Publish normalizes)", received.SKI)
 		}
 		if received.Type != "test-event" {
 			t.Errorf("Type = %q, want test-event", received.Type)
@@ -42,11 +42,28 @@ func TestEventBusPublishNormalizesSKI(t *testing.T) {
 
 	select {
 	case evt := <-ch:
-		if evt.SKI != "TEST:SKI123" {
-			t.Errorf("SKI = %q, want TEST:SKI123", evt.SKI)
+		if evt.SKI != "TESTSKI123" {
+			t.Errorf("SKI = %q, want TESTSKI123", evt.SKI)
 		}
 	case <-time.After(time.Second):
 		t.Fatal("timeout waiting for event")
+	}
+}
+
+func TestEventBusDropsAndCountsEmptySKI(t *testing.T) {
+	bus := eebus.NewEventBus()
+	ch := bus.Subscribe()
+	defer bus.Unsubscribe(ch)
+
+	bus.Publish(eebus.Event{Type: "device-event"})
+
+	if got := bus.DroppedUnresolvedEvents(); got != 1 {
+		t.Fatalf("DroppedUnresolvedEvents() = %d, want 1", got)
+	}
+	select {
+	case evt := <-ch:
+		t.Fatalf("received unresolved event %+v", evt)
+	case <-time.After(50 * time.Millisecond):
 	}
 }
 

--- a/eebus-bridge/internal/eebus/registry.go
+++ b/eebus-bridge/internal/eebus/registry.go
@@ -2,6 +2,7 @@ package eebus
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -28,6 +29,18 @@ type DeviceInfo struct {
 	RemoteDevice   spineapi.DeviceRemoteInterface
 	RemoteEntities []spineapi.EntityRemoteInterface
 	Entities       []EntityInfo
+}
+
+// EntityResolution describes a device-scoped entity lookup. DeviceCount is the
+// number of distinct normalized device SKIs that matched an unscoped lookup.
+// More than one match is ambiguous and deliberately has no selected Entity.
+type EntityResolution struct {
+	Entity      spineapi.EntityRemoteInterface
+	DeviceCount int
+}
+
+func (r EntityResolution) Ambiguous() bool {
+	return r.Entity == nil && r.DeviceCount > 1
 }
 
 type DeviceRegistry struct {
@@ -64,13 +77,13 @@ func (r *DeviceRegistry) MonitoringStale(threshold time.Duration) bool {
 	return time.Since(last) > threshold
 }
 
-// NormalizeSKI canonicalizes a SKI for use as a registry key: uppercase, no
-// surrounding or embedded whitespace. Remote peers (e.g. Bosch/Connect-Key) may
-// report the same SKI with differing case or spacing; normalizing prevents the
-// same device being stored under multiple keys, which later causes resolveEntity
-// lookups to fail with NOT_FOUND.
+// NormalizeSKI canonicalizes a SKI for use as a registry key: uppercase, with
+// whitespace and common display separators removed. Remote peers and clients
+// may report the same SKI with differing case or formatting; normalizing
+// prevents one physical device from being stored under multiple keys.
 func NormalizeSKI(ski string) string {
-	return strings.ToUpper(strings.ReplaceAll(strings.TrimSpace(ski), " ", ""))
+	replacer := strings.NewReplacer(" ", "", "\t", "", "\n", "", "\r", "", ":", "", "-", "")
+	return strings.ToUpper(replacer.Replace(strings.TrimSpace(ski)))
 }
 
 func (r *DeviceRegistry) AddDevice(ski string, info DeviceInfo) {
@@ -205,6 +218,9 @@ func (r *DeviceRegistry) ListDevices() []DeviceInfo {
 	for _, info := range r.devices {
 		result = append(result, info)
 	}
+	sort.Slice(result, func(i, j int) bool {
+		return NormalizeSKI(result[i].SKI) < NormalizeSKI(result[j].SKI)
+	})
 	return result
 }
 
@@ -219,17 +235,26 @@ func (r *DeviceRegistry) FirstEntity(ski string) spineapi.EntityRemoteInterface 
 	return info.RemoteEntities[0]
 }
 
-// FirstAvailableEntity returns the first entity from any known device.
-// Used as a fallback when a client-selected SKI has no mapped entity yet.
-func (r *DeviceRegistry) FirstAvailableEntity() spineapi.EntityRemoteInterface {
+// FirstAvailableEntity resolves an entity only when exactly one known device
+// currently has entities. Multiple devices are reported as ambiguous instead
+// of depending on randomized map iteration order.
+func (r *DeviceRegistry) FirstAvailableEntity() EntityResolution {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
+	var entity spineapi.EntityRemoteInterface
+	deviceCount := 0
 	for _, info := range r.devices {
 		if len(info.RemoteEntities) > 0 {
-			return info.RemoteEntities[0]
+			deviceCount++
+			if entity == nil {
+				entity = info.RemoteEntities[0]
+			}
 		}
 	}
-	return nil
+	if deviceCount != 1 {
+		entity = nil
+	}
+	return EntityResolution{Entity: entity, DeviceCount: deviceCount}
 }
 
 func (r *DeviceRegistry) Entities(ski string) []EntityInfo {

--- a/eebus-bridge/internal/eebus/registry_test.go
+++ b/eebus-bridge/internal/eebus/registry_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	spineapi "github.com/enbility/spine-go/api"
+	"github.com/enbility/spine-go/mocks"
 	"github.com/volschin/eebus-bridge/internal/eebus"
 )
 
@@ -103,6 +104,8 @@ func TestNormalizeSKI(t *testing.T) {
 	cases := map[string]string{
 		"abcdef":       "ABCDEF",
 		"  ab cd ef  ": "ABCDEF",
+		"ab:cd-ef":     "ABCDEF",
+		"ab\tcd\nef":   "ABCDEF",
 		"AbCdEf":       "ABCDEF",
 		"":             "",
 	}
@@ -139,12 +142,43 @@ func TestRegistrySKINormalizationConsistency(t *testing.T) {
 
 func TestRegistryListDevices(t *testing.T) {
 	reg := eebus.NewDeviceRegistry()
-	reg.AddDevice("ski-1", eebus.DeviceInfo{Brand: "A"})
-	reg.AddDevice("ski-2", eebus.DeviceInfo{Brand: "B"})
+	reg.AddDevice("cc:03", eebus.DeviceInfo{Brand: "C"})
+	reg.AddDevice("AA-01", eebus.DeviceInfo{Brand: "A"})
+	reg.AddDevice(" bb 02 ", eebus.DeviceInfo{Brand: "B"})
 
 	devices := reg.ListDevices()
-	if len(devices) != 2 {
-		t.Errorf("len(devices) = %d, want 2", len(devices))
+	if len(devices) != 3 {
+		t.Fatalf("len(devices) = %d, want 3", len(devices))
+	}
+	for index, want := range []string{"AA01", "BB02", "CC03"} {
+		if devices[index].SKI != want {
+			t.Errorf("devices[%d].SKI = %q, want %q", index, devices[index].SKI, want)
+		}
+	}
+}
+
+func TestRegistryFirstAvailableEntityRequiresOneDevice(t *testing.T) {
+	reg := eebus.NewDeviceRegistry()
+	entityA := mocks.NewEntityRemoteInterface(t)
+	entityB := mocks.NewEntityRemoteInterface(t)
+
+	reg.AddDevice("ab:cd-ef", eebus.DeviceInfo{RemoteEntities: []spineapi.EntityRemoteInterface{entityA}})
+	reg.AddDevice(" AB-CD-EF ", eebus.DeviceInfo{RemoteEntities: []spineapi.EntityRemoteInterface{entityA}})
+	resolution := reg.FirstAvailableEntity()
+	if resolution.Ambiguous() || resolution.DeviceCount != 1 || resolution.Entity != entityA {
+		t.Fatalf("format variants resolved as %+v, want one physical device", resolution)
+	}
+
+	reg.AddDevice("DDEEFF", eebus.DeviceInfo{RemoteEntities: []spineapi.EntityRemoteInterface{entityB}})
+	resolution = reg.FirstAvailableEntity()
+	if !resolution.Ambiguous() || resolution.DeviceCount != 2 {
+		t.Fatalf("two devices resolved as %+v, want ambiguity", resolution)
+	}
+	if reg.FirstEntity("ab cd ef") != entityA || reg.FirstEntity("dd:ee:ff") != entityB {
+		t.Error("explicit registry lookup did not preserve device identity")
+	}
+	if reg.FirstEntity("unknown") != nil {
+		t.Error("unknown explicit registry lookup returned an entity")
 	}
 }
 

--- a/eebus-bridge/internal/grpc/device_service.go
+++ b/eebus-bridge/internal/grpc/device_service.go
@@ -2,6 +2,7 @@ package grpc
 
 import (
 	"context"
+	"sort"
 
 	pb "github.com/volschin/eebus-bridge/gen/proto/eebus/v1"
 	"github.com/volschin/eebus-bridge/internal/eebus"
@@ -35,6 +36,9 @@ func (s *DeviceService) GetStatus(_ context.Context, _ *pb.Empty) (*pb.ServiceSt
 
 func (s *DeviceService) ListDiscoveredDevices(_ context.Context, _ *pb.Empty) (*pb.ListDevicesResponse, error) {
 	svcs := s.callbacks.DiscoveredServices()
+	sort.SliceStable(svcs, func(i, j int) bool {
+		return eebus.NormalizeSKI(svcs[i].Ski) < eebus.NormalizeSKI(svcs[j].Ski)
+	})
 	devices := make([]*pb.DiscoveredDevice, 0, len(svcs))
 	for _, svc := range svcs {
 		devices = append(devices, &pb.DiscoveredDevice{

--- a/eebus-bridge/internal/grpc/device_service_test.go
+++ b/eebus-bridge/internal/grpc/device_service_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	shipapi "github.com/enbility/ship-go/api"
 	pb "github.com/volschin/eebus-bridge/gen/proto/eebus/v1"
 	"github.com/volschin/eebus-bridge/internal/eebus"
 	bridgegrpc "github.com/volschin/eebus-bridge/internal/grpc"
@@ -50,6 +51,41 @@ func TestGetStatus(t *testing.T) {
 	}
 	if !resp.Running {
 		t.Error("Running = false, want true")
+	}
+}
+
+func TestListDevicesResponsesAreSortedByNormalizedSKI(t *testing.T) {
+	bus := eebus.NewEventBus()
+	callbacks := eebus.NewCallbacks(bus, false)
+	callbacks.VisibleRemoteMdnsServicesUpdated(nil, []shipapi.RemoteMdnsService{
+		{Ski: "cc:03"},
+		{Ski: "AA-01"},
+		{Ski: " bb 02 "},
+	})
+	registry := eebus.NewDeviceRegistry()
+	registry.AddDevice("cc:03", eebus.DeviceInfo{})
+	registry.AddDevice("AA-01", eebus.DeviceInfo{})
+	registry.AddDevice(" bb 02 ", eebus.DeviceInfo{})
+	svc := bridgegrpc.NewDeviceService(callbacks, bus, "local", registry)
+
+	discovered, err := svc.ListDiscoveredDevices(context.Background(), &pb.Empty{})
+	if err != nil {
+		t.Fatalf("ListDiscoveredDevices: %v", err)
+	}
+	for index, want := range []string{"AA-01", " bb 02 ", "cc:03"} {
+		if discovered.Devices[index].Ski != want {
+			t.Errorf("discovered[%d].ski = %q, want %q", index, discovered.Devices[index].Ski, want)
+		}
+	}
+
+	paired, err := svc.ListPairedDevices(context.Background(), &pb.Empty{})
+	if err != nil {
+		t.Fatalf("ListPairedDevices: %v", err)
+	}
+	for index, want := range []string{"AA01", "BB02", "CC03"} {
+		if paired.Devices[index].Ski != want {
+			t.Errorf("paired[%d].ski = %q, want %q", index, paired.Devices[index].Ski, want)
+		}
 	}
 }
 

--- a/eebus-bridge/internal/grpc/dhw_service.go
+++ b/eebus-bridge/internal/grpc/dhw_service.go
@@ -12,13 +12,13 @@ import (
 )
 
 type dhwController interface {
-	CompatibleEntity(string) spineapi.EntityRemoteInterface
+	CompatibleEntity(string) eebus.EntityResolution
 	State(spineapi.EntityRemoteInterface) (usecases.DHWSetpoint, error)
 	Write(context.Context, spineapi.EntityRemoteInterface, float64) error
 }
 
 type dhwSysFnController interface {
-	CompatibleEntity(string) spineapi.EntityRemoteInterface
+	CompatibleEntity(string) eebus.EntityResolution
 	State(spineapi.EntityRemoteInterface) (usecases.DHWSystemFunctionState, error)
 	WriteBoost(context.Context, spineapi.EntityRemoteInterface, bool) error
 	WriteOperationMode(context.Context, spineapi.EntityRemoteInterface, string) error
@@ -144,8 +144,8 @@ func (s *DHWService) SubscribeDHWEvents(req *pb.DeviceRequest, stream pb.DHWServ
 				continue
 			}
 			event := &pb.DHWEvent{Ski: evt.SKI, EventType: eventType}
-			if entity := s.dhw.CompatibleEntity(evt.SKI); entity != nil {
-				if state, err := s.dhw.State(entity); err == nil {
+			if resolution := s.dhw.CompatibleEntity(evt.SKI); resolution.Entity != nil {
+				if state, err := s.dhw.State(resolution.Entity); err == nil {
 					event.Setpoint = convertDHWSetpoint(state)
 				}
 			}
@@ -189,8 +189,8 @@ func (s *DHWService) SubscribeDHWSystemFunctionEvents(
 			}
 			event := &pb.DHWSystemFunctionEvent{Ski: evt.SKI, EventType: eventType}
 			if s.dhwSysFn != nil {
-				if entity := s.dhwSysFn.CompatibleEntity(evt.SKI); entity != nil {
-					if state, err := s.dhwSysFn.State(entity); err == nil {
+				if resolution := s.dhwSysFn.CompatibleEntity(evt.SKI); resolution.Entity != nil {
+					if state, err := s.dhwSysFn.State(resolution.Entity); err == nil {
 						event.State = convertDHWSystemFunctionState(state)
 					}
 				}
@@ -208,22 +208,28 @@ func (s *DHWService) resolveEntity(ski string) (spineapi.EntityRemoteInterface, 
 	if s.dhw == nil {
 		return nil, status.Error(codes.Unavailable, "DHW temperature use case not initialized")
 	}
-	entity := s.dhw.CompatibleEntity(ski)
-	if entity == nil {
+	resolution := s.dhw.CompatibleEntity(ski)
+	if resolution.Ambiguous() {
+		return nil, ambiguousDeviceSelection(resolution.DeviceCount)
+	}
+	if resolution.Entity == nil {
 		return nil, status.Errorf(codes.NotFound, "no compatible DHWCircuit found for ski %s", ski)
 	}
-	return entity, nil
+	return resolution.Entity, nil
 }
 
 func (s *DHWService) resolveSysFnEntity(ski string) (spineapi.EntityRemoteInterface, error) {
 	if s.dhwSysFn == nil {
 		return nil, status.Error(codes.Unavailable, "DHW system function use case not initialized")
 	}
-	entity := s.dhwSysFn.CompatibleEntity(ski)
-	if entity == nil {
+	resolution := s.dhwSysFn.CompatibleEntity(ski)
+	if resolution.Ambiguous() {
+		return nil, ambiguousDeviceSelection(resolution.DeviceCount)
+	}
+	if resolution.Entity == nil {
 		return nil, status.Errorf(codes.NotFound, "no compatible DHWCircuit found for ski %s", ski)
 	}
-	return entity, nil
+	return resolution.Entity, nil
 }
 
 func convertDHWSetpoint(state usecases.DHWSetpoint) *pb.DHWSetpoint {

--- a/eebus-bridge/internal/grpc/dhw_service_test.go
+++ b/eebus-bridge/internal/grpc/dhw_service_test.go
@@ -22,8 +22,8 @@ type fakeDHWController struct {
 	writtenValue float64
 }
 
-func (f *fakeDHWController) CompatibleEntity(string) spineapi.EntityRemoteInterface {
-	return f.entity
+func (f *fakeDHWController) CompatibleEntity(string) eebus.EntityResolution {
+	return eebus.EntityResolution{Entity: f.entity, DeviceCount: 1}
 }
 
 func (f *fakeDHWController) State(spineapi.EntityRemoteInterface) (usecases.DHWSetpoint, error) {
@@ -45,8 +45,8 @@ type fakeDHWSysFnController struct {
 	writtenMode  string
 }
 
-func (f *fakeDHWSysFnController) CompatibleEntity(string) spineapi.EntityRemoteInterface {
-	return f.entity
+func (f *fakeDHWSysFnController) CompatibleEntity(string) eebus.EntityResolution {
+	return eebus.EntityResolution{Entity: f.entity, DeviceCount: 1}
 }
 
 func (f *fakeDHWSysFnController) State(spineapi.EntityRemoteInterface) (usecases.DHWSystemFunctionState, error) {

--- a/eebus-bridge/internal/grpc/entity_resolution_test.go
+++ b/eebus-bridge/internal/grpc/entity_resolution_test.go
@@ -1,0 +1,63 @@
+package grpc
+
+import (
+	"errors"
+	"testing"
+
+	spineapi "github.com/enbility/spine-go/api"
+	"github.com/enbility/spine-go/mocks"
+	"github.com/volschin/eebus-bridge/internal/eebus"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestRegistryFallbackRejectsAmbiguousEmptySKI(t *testing.T) {
+	registry := eebus.NewDeviceRegistry()
+	entityA := mocks.NewEntityRemoteInterface(t)
+	entityB := mocks.NewEntityRemoteInterface(t)
+	registry.AddDevice("aa:bb-cc", eebus.DeviceInfo{
+		RemoteEntities: []spineapi.EntityRemoteInterface{entityA},
+	})
+	registry.AddDevice("dd:ee-ff", eebus.DeviceInfo{
+		RemoteEntities: []spineapi.EntityRemoteInterface{entityB},
+	})
+	service := NewLPCService(nil, eebus.NewEventBus(), registry)
+
+	if _, err := service.resolveEntity(""); status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("empty SKI error = %v, want FailedPrecondition", err)
+	}
+	for _, test := range []struct {
+		ski  string
+		want spineapi.EntityRemoteInterface
+	}{
+		{ski: " AA-BB-CC ", want: entityA},
+		{ski: "DDEEFF", want: entityB},
+	} {
+		got, err := service.resolveEntity(test.ski)
+		if err != nil {
+			t.Fatalf("resolveEntity(%q): %v", test.ski, err)
+		}
+		if got != test.want {
+			t.Errorf("resolveEntity(%q) selected the wrong device", test.ski)
+		}
+	}
+	if _, err := service.resolveEntity("unknown"); status.Code(err) != codes.NotFound {
+		t.Fatalf("unknown explicit SKI error = %v, want NotFound", err)
+	}
+}
+
+func TestReadMetricDoesNotFallbackAfterUnknownExplicitSKI(t *testing.T) {
+	wantErr := status.Error(codes.NotFound, "unknown device")
+	called := false
+	_, err := readMetric("power", resolvedEntity{ski: "UNKNOWN", err: wantErr}, func(spineapi.EntityRemoteInterface) (float64, error) {
+		called = true
+		return 123, nil
+	})
+
+	if called {
+		t.Error("read function was called after explicit SKI resolution failed")
+	}
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("readMetric error = %v, want original NotFound", err)
+	}
+}

--- a/eebus-bridge/internal/grpc/hvac_service.go
+++ b/eebus-bridge/internal/grpc/hvac_service.go
@@ -12,13 +12,13 @@ import (
 )
 
 type roomHeatingTempController interface {
-	CompatibleEntity(string) spineapi.EntityRemoteInterface
+	CompatibleEntity(string) eebus.EntityResolution
 	State(spineapi.EntityRemoteInterface) (usecases.RoomHeatingSetpoint, error)
 	Write(context.Context, spineapi.EntityRemoteInterface, float64) error
 }
 
 type roomHeatingSysFnController interface {
-	CompatibleEntity(string) spineapi.EntityRemoteInterface
+	CompatibleEntity(string) eebus.EntityResolution
 	State(spineapi.EntityRemoteInterface) (usecases.RoomHeatingSystemFunctionState, error)
 	WriteOperationMode(context.Context, spineapi.EntityRemoteInterface, string) error
 }
@@ -54,17 +54,25 @@ func (s *HVACService) GetRoomHeating(_ context.Context, req *pb.DeviceRequest) (
 		}
 	}
 	if s.temp != nil {
-		if entity := s.temp.CompatibleEntity(req.Ski); entity != nil {
+		resolution := s.temp.CompatibleEntity(req.Ski)
+		if resolution.Ambiguous() {
+			return nil, ambiguousDeviceSelection(resolution.DeviceCount)
+		}
+		if resolution.Entity != nil {
 			resolved = true
-			if setpoint, err := s.temp.State(entity); err == nil {
+			if setpoint, err := s.temp.State(resolution.Entity); err == nil {
 				state.Setpoint = convertRoomHeatingSetpoint(setpoint)
 			}
 		}
 	}
 	if s.sysfn != nil {
-		if entity := s.sysfn.CompatibleEntity(req.Ski); entity != nil {
+		resolution := s.sysfn.CompatibleEntity(req.Ski)
+		if resolution.Ambiguous() {
+			return nil, ambiguousDeviceSelection(resolution.DeviceCount)
+		}
+		if resolution.Entity != nil {
 			resolved = true
-			if sysfn, err := s.sysfn.State(entity); err == nil {
+			if sysfn, err := s.sysfn.State(resolution.Entity); err == nil {
 				state.SystemFunction = convertRoomHeatingSystemFunction(sysfn)
 			}
 		}
@@ -85,11 +93,14 @@ func (s *HVACService) SetRoomHeatingTemperature(
 	if s.temp == nil {
 		return nil, status.Error(codes.Unavailable, "room heating temperature use case not initialized")
 	}
-	entity := s.temp.CompatibleEntity(req.Ski)
-	if entity == nil {
+	resolution := s.temp.CompatibleEntity(req.Ski)
+	if resolution.Ambiguous() {
+		return nil, ambiguousDeviceSelection(resolution.DeviceCount)
+	}
+	if resolution.Entity == nil {
 		return nil, status.Errorf(codes.NotFound, "no compatible HVACRoom found for ski %s", req.Ski)
 	}
-	if err := s.temp.Write(ctx, entity, req.ValueCelsius); err != nil {
+	if err := s.temp.Write(ctx, resolution.Entity, req.ValueCelsius); err != nil {
 		return nil, mapRoomHeatingError("writing room heating setpoint", err)
 	}
 	return &pb.Empty{}, nil
@@ -105,11 +116,14 @@ func (s *HVACService) SetRoomHeatingMode(
 	if s.sysfn == nil {
 		return nil, status.Error(codes.Unavailable, "room heating system function use case not initialized")
 	}
-	entity := s.sysfn.CompatibleEntity(req.Ski)
-	if entity == nil {
+	resolution := s.sysfn.CompatibleEntity(req.Ski)
+	if resolution.Ambiguous() {
+		return nil, ambiguousDeviceSelection(resolution.DeviceCount)
+	}
+	if resolution.Entity == nil {
 		return nil, status.Errorf(codes.NotFound, "no compatible HVACRoom found for ski %s", req.Ski)
 	}
-	if err := s.sysfn.WriteOperationMode(ctx, entity, req.Mode); err != nil {
+	if err := s.sysfn.WriteOperationMode(ctx, resolution.Entity, req.Mode); err != nil {
 		return nil, mapRoomHeatingError("writing room heating mode", err)
 	}
 	return &pb.Empty{}, nil

--- a/eebus-bridge/internal/grpc/hvac_service_test.go
+++ b/eebus-bridge/internal/grpc/hvac_service_test.go
@@ -7,22 +7,76 @@ import (
 	spineapi "github.com/enbility/spine-go/api"
 	"github.com/enbility/spine-go/mocks"
 	pb "github.com/volschin/eebus-bridge/gen/proto/eebus/v1"
+	"github.com/volschin/eebus-bridge/internal/eebus"
 	"github.com/volschin/eebus-bridge/internal/usecases"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
 
 type fakeRoomHeatingTemp struct {
-	entity spineapi.EntityRemoteInterface
-	state  usecases.RoomHeatingSetpoint
-	err    error
+	entity   spineapi.EntityRemoteInterface
+	entities map[string]spineapi.EntityRemoteInterface
+	state    usecases.RoomHeatingSetpoint
+	states   map[spineapi.EntityRemoteInterface]usecases.RoomHeatingSetpoint
+	err      error
 }
 
-func (f *fakeRoomHeatingTemp) CompatibleEntity(string) spineapi.EntityRemoteInterface {
-	return f.entity
+func (f *fakeRoomHeatingTemp) CompatibleEntity(ski string) eebus.EntityResolution {
+	if f.entities == nil {
+		return eebus.EntityResolution{Entity: f.entity, DeviceCount: 1}
+	}
+	if eebus.NormalizeSKI(ski) == "" {
+		return eebus.EntityResolution{DeviceCount: len(f.entities)}
+	}
+	entity := f.entities[eebus.NormalizeSKI(ski)]
+	if entity == nil {
+		return eebus.EntityResolution{}
+	}
+	return eebus.EntityResolution{Entity: entity, DeviceCount: 1}
 }
-func (f *fakeRoomHeatingTemp) State(spineapi.EntityRemoteInterface) (usecases.RoomHeatingSetpoint, error) {
+func (f *fakeRoomHeatingTemp) State(entity spineapi.EntityRemoteInterface) (usecases.RoomHeatingSetpoint, error) {
+	if f.states != nil {
+		return f.states[entity], f.err
+	}
 	return f.state, f.err
+}
+
+func TestHVACServiceIsolatesCompatibleDevices(t *testing.T) {
+	deviceA := mocks.NewEntityRemoteInterface(t)
+	deviceB := mocks.NewEntityRemoteInterface(t)
+	temp := &fakeRoomHeatingTemp{
+		entities: map[string]spineapi.EntityRemoteInterface{
+			"AABBCC": deviceA,
+			"DDEEFF": deviceB,
+		},
+		states: map[spineapi.EntityRemoteInterface]usecases.RoomHeatingSetpoint{
+			deviceA: {Value: 19},
+			deviceB: {Value: 23},
+		},
+	}
+	svc := NewHVACService(temp, nil, nil, nil)
+
+	if _, err := svc.GetRoomHeating(context.Background(), &pb.DeviceRequest{}); status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("empty SKI error = %v, want FailedPrecondition", err)
+	}
+	for _, test := range []struct {
+		ski  string
+		want float64
+	}{
+		{ski: "aa:bb-cc", want: 19},
+		{ski: "DDEEFF", want: 23},
+	} {
+		state, err := svc.GetRoomHeating(context.Background(), &pb.DeviceRequest{Ski: test.ski})
+		if err != nil {
+			t.Fatalf("GetRoomHeating(%q): %v", test.ski, err)
+		}
+		if state.Setpoint == nil || state.Setpoint.ValueCelsius != test.want {
+			t.Errorf("GetRoomHeating(%q) = %+v, want setpoint %v", test.ski, state, test.want)
+		}
+	}
+	if _, err := svc.GetRoomHeating(context.Background(), &pb.DeviceRequest{Ski: "unknown"}); status.Code(err) != codes.NotFound {
+		t.Fatalf("unknown explicit SKI error = %v, want NotFound", err)
+	}
 }
 func (f *fakeRoomHeatingTemp) Write(context.Context, spineapi.EntityRemoteInterface, float64) error {
 	return f.err

--- a/eebus-bridge/internal/grpc/integration_test.go
+++ b/eebus-bridge/internal/grpc/integration_test.go
@@ -83,8 +83,8 @@ func TestIntegrationDeviceServiceRoundTrip(t *testing.T) {
 		t.Fatalf("stream.Recv: %v", err)
 	}
 	// SKI is normalized (uppercased, whitespace stripped) before dispatch.
-	if evt.Ski != "REMOTE-SKI-TEST" {
-		t.Errorf("event SKI = %q, want REMOTE-SKI-TEST", evt.Ski)
+	if evt.Ski != "REMOTESKITEST" {
+		t.Errorf("event SKI = %q, want REMOTESKITEST", evt.Ski)
 	}
 	if evt.EventType != pb.DeviceEventType_DEVICE_EVENT_CONNECTED {
 		t.Errorf("event type = %v", evt.EventType)

--- a/eebus-bridge/internal/grpc/lpc_service.go
+++ b/eebus-bridge/internal/grpc/lpc_service.go
@@ -255,8 +255,12 @@ func (s *LPCService) resolveEntity(ski string) (spineapi.EntityRemoteInterface, 
 	// registry returns whichever was observed first (often the monitoring meter),
 	// which eebus-go rejects on write with ErrNoCompatibleEntity (issue #47).
 	if s.lpc != nil {
-		if entity := s.lpc.CompatibleEntity(ski); entity != nil {
-			return entity, nil
+		resolution := s.lpc.CompatibleEntity(ski)
+		if resolution.Ambiguous() {
+			return nil, ambiguousDeviceSelection(resolution.DeviceCount)
+		}
+		if resolution.Entity != nil {
+			return resolution.Entity, nil
 		}
 	}
 	if s.registry == nil {
@@ -264,7 +268,11 @@ func (s *LPCService) resolveEntity(ski string) (spineapi.EntityRemoteInterface, 
 	}
 	entity := s.registry.FirstEntity(ski)
 	if entity == nil && ski == "" {
-		entity = s.registry.FirstAvailableEntity()
+		resolution := s.registry.FirstAvailableEntity()
+		if resolution.Ambiguous() {
+			return nil, ambiguousDeviceSelection(resolution.DeviceCount)
+		}
+		entity = resolution.Entity
 	}
 	if entity == nil {
 		return nil, status.Errorf(codes.NotFound, "no remote entity found for ski %s", ski)

--- a/eebus-bridge/internal/grpc/monitoring_service.go
+++ b/eebus-bridge/internal/grpc/monitoring_service.go
@@ -142,6 +142,9 @@ func (s *MonitoringService) GetMeasurements(_ context.Context, req *pb.DeviceReq
 	now := timestamppb.Now()
 	measurements := make([]*pb.MeasurementEntry, 0, 12)
 	resolved := s.resolveForRead(req.Ski)
+	if status.Code(resolved.err) == codes.FailedPrecondition {
+		return nil, resolved.err
+	}
 
 	if value, err := readMetric("power", resolved, s.monitoring.Power); err == nil {
 		appendMeasurement(&measurements, now, "power_consumption", value, "W")
@@ -178,33 +181,33 @@ func (s *MonitoringService) GetMeasurements(_ context.Context, req *pb.DeviceReq
 	}
 
 	if s.dhw != nil {
-		if value, err := s.dhw.Temperature(req.Ski); err == nil {
+		if value, err := s.dhw.Temperature(resolved.ski); err == nil {
 			appendMeasurement(&measurements, now, "dhw_temperature", value, "degC")
 		}
 	}
 	if s.room != nil {
-		if value, err := s.room.Temperature(req.Ski); err == nil {
+		if value, err := s.room.Temperature(resolved.ski); err == nil {
 			appendMeasurement(&measurements, now, "room_temperature", value, "degC")
 		}
 	}
 	if s.outdoor != nil {
-		if value, err := s.outdoor.Temperature(req.Ski); err == nil {
+		if value, err := s.outdoor.Temperature(resolved.ski); err == nil {
 			appendMeasurement(&measurements, now, "outdoor_temperature", value, "degC")
 		}
 	}
 	if s.flow != nil {
-		if value, err := s.flow.Temperature(req.Ski); err == nil {
+		if value, err := s.flow.Temperature(resolved.ski); err == nil {
 			appendMeasurement(&measurements, now, "flow_temperature", value, "degC")
 		}
 	}
 	if s.returnTemp != nil {
-		if value, err := s.returnTemp.Temperature(req.Ski); err == nil {
+		if value, err := s.returnTemp.Temperature(resolved.ski); err == nil {
 			appendMeasurement(&measurements, now, "return_temperature", value, "degC")
 		}
 	}
 
 	if s.monitoring != nil {
-		values, err := s.monitoring.GenericMeasurements(req.Ski)
+		values, err := s.monitoring.GenericMeasurements(resolved.ski)
 		if err != nil {
 			values = nil
 		}
@@ -348,11 +351,15 @@ func (s *MonitoringService) attachTemperaturePayload(
 
 func (s *MonitoringService) resolveEntity(ski string) (spineapi.EntityRemoteInterface, error) {
 	if s.monitoring != nil {
-		if entity := s.monitoring.CompatibleEntity(ski); entity != nil {
+		resolution := s.monitoring.CompatibleEntity(ski)
+		if resolution.Ambiguous() {
+			return nil, ambiguousDeviceSelection(resolution.DeviceCount)
+		}
+		if resolution.Entity != nil {
 			if s.registry != nil {
 				s.registry.RecordMonitoringSuccess()
 			}
-			return entity, nil
+			return resolution.Entity, nil
 		}
 	}
 	if s.registry == nil {
@@ -363,8 +370,12 @@ func (s *MonitoringService) resolveEntity(ski string) (spineapi.EntityRemoteInte
 		log.Printf("[DEBUG] Monitoring.resolveEntity no entity for requested SKI: requested_ski=%s", ski)
 	}
 	if entity == nil && ski == "" {
-		entity = s.registry.FirstAvailableEntity()
-		if entity != nil {
+		resolution := s.registry.FirstAvailableEntity()
+		if resolution.Ambiguous() {
+			return nil, ambiguousDeviceSelection(resolution.DeviceCount)
+		}
+		entity = resolution.Entity
+		if resolution.Entity != nil {
 			log.Printf("[DEBUG] Monitoring.resolveEntity selected fallback entity for empty SKI request")
 		}
 	}
@@ -373,6 +384,14 @@ func (s *MonitoringService) resolveEntity(ski string) (spineapi.EntityRemoteInte
 		return nil, status.Errorf(codes.NotFound, "no remote entity found for ski %s", ski)
 	}
 	return entity, nil
+}
+
+func ambiguousDeviceSelection(deviceCount int) error {
+	return status.Errorf(
+		codes.FailedPrecondition,
+		"ambiguous device selection: %d compatible devices found for empty ski, specify ski",
+		deviceCount,
+	)
 }
 
 // resolvedEntity carries the outcome of resolveEntity so multi-metric callers
@@ -385,42 +404,25 @@ type resolvedEntity struct {
 
 func (s *MonitoringService) resolveForRead(ski string) resolvedEntity {
 	entity, err := s.resolveEntity(ski)
-	return resolvedEntity{ski: ski, entity: entity, err: err}
+	resolvedSKI := eebus.NormalizeSKI(ski)
+	if resolvedSKI == "" && entity != nil && entity.Device() != nil {
+		resolvedSKI = eebus.NormalizeSKI(entity.Device().Ski())
+	}
+	return resolvedEntity{ski: resolvedSKI, entity: entity, err: err}
 }
 
 // readMetric reads one measurement through the monitoring use case. Reads are
 // best-effort: GetMeasurements only appends a result when the read succeeds,
 // so a device that does not advertise a given measurement simply omits it.
-// When the SKI did not resolve, the read is retried once with a nil entity
-// (guarded against panics inside eebus-go), matching the behaviour of the
-// former per-metric readers.
+// Resolution failures are returned unchanged so an unknown explicit SKI can
+// never fall through to eebus-go's implicit first-entity behavior.
 func readMetric[T any](label string, r resolvedEntity, read func(spineapi.EntityRemoteInterface) (T, error)) (T, error) {
 	var zero T
 	if r.err == nil {
 		return read(r.entity)
 	}
-	if status.Code(r.err) != codes.NotFound {
-		log.Printf("[DEBUG] Monitoring.readMetric %s resolveEntity failed without fallback: requested_ski=%s err=%v", label, r.ski, r.err)
-		return zero, r.err
-	}
-	log.Printf("[DEBUG] Monitoring.readMetric %s attempting nil-entity fallback: requested_ski=%s", label, r.ski)
-	value, fallbackErr := safeRead(label, func() (T, error) { return read(nil) })
-	if fallbackErr != nil {
-		log.Printf("[DEBUG] Monitoring.readMetric %s nil-entity fallback failed: requested_ski=%s err=%v", label, r.ski, fallbackErr)
-		return zero, r.err
-	}
-	log.Printf("[DEBUG] Monitoring.readMetric %s nil-entity fallback succeeded: requested_ski=%s", label, r.ski)
-	return value, nil
-}
-
-// safeRead guards a nil-entity read against panics inside eebus-go.
-func safeRead[T any](label string, read func() (T, error)) (value T, err error) {
-	defer func() {
-		if recovered := recover(); recovered != nil {
-			err = fmt.Errorf("panic during nil-entity %s read: %v", label, recovered)
-		}
-	}()
-	return read()
+	log.Printf("[DEBUG] Monitoring.readMetric %s resolveEntity failed: requested_ski=%s err=%v", label, r.ski, r.err)
+	return zero, r.err
 }
 
 func appendMeasurement(measurements *[]*pb.MeasurementEntry, now *timestamppb.Timestamp, measurementType string, value float64, unit string) {

--- a/eebus-bridge/internal/grpc/ohpcf_service.go
+++ b/eebus-bridge/internal/grpc/ohpcf_service.go
@@ -178,8 +178,12 @@ func convertCompressorState(st ucapi.CompressorPowerConsumptionStateType) pb.Com
 // the wrong one.
 func (s *OHPCFService) resolveEntity(ski string) (spineapi.EntityRemoteInterface, error) {
 	if s.ohpcf != nil {
-		if entity := s.ohpcf.CompatibleEntity(ski); entity != nil {
-			return entity, nil
+		resolution := s.ohpcf.CompatibleEntity(ski)
+		if resolution.Ambiguous() {
+			return nil, ambiguousDeviceSelection(resolution.DeviceCount)
+		}
+		if resolution.Entity != nil {
+			return resolution.Entity, nil
 		}
 	}
 	if s.registry == nil {
@@ -187,7 +191,11 @@ func (s *OHPCFService) resolveEntity(ski string) (spineapi.EntityRemoteInterface
 	}
 	entity := s.registry.FirstEntity(ski)
 	if entity == nil && ski == "" {
-		entity = s.registry.FirstAvailableEntity()
+		resolution := s.registry.FirstAvailableEntity()
+		if resolution.Ambiguous() {
+			return nil, ambiguousDeviceSelection(resolution.DeviceCount)
+		}
+		entity = resolution.Entity
 	}
 	if entity == nil {
 		return nil, status.Errorf(codes.NotFound, "no compatible OHPCF entity found for ski %s", ski)

--- a/eebus-bridge/internal/usecases/devicediagnosis_test.go
+++ b/eebus-bridge/internal/usecases/devicediagnosis_test.go
@@ -91,7 +91,7 @@ func TestDeviceOperatingStateHandleEventPublishesFromPayload(t *testing.T) {
 
 	select {
 	case evt := <-ch:
-		if evt.Type != eebus.EventTypeMonitoringDeviceOperatingStateUpdated || evt.SKI != "TEST-SKI" {
+		if evt.Type != eebus.EventTypeMonitoringDeviceOperatingStateUpdated || evt.SKI != "TESTSKI" {
 			t.Fatalf("event = %+v", evt)
 		}
 	default:

--- a/eebus-bridge/internal/usecases/dhw.go
+++ b/eebus-bridge/internal/usecases/dhw.go
@@ -181,7 +181,7 @@ func (d *DHWTemperature) request(entity spineapi.EntityRemoteInterface, function
 }
 
 // CompatibleEntity returns the negotiated DHWCircuit for a device SKI.
-func (d *DHWTemperature) CompatibleEntity(ski string) spineapi.EntityRemoteInterface {
+func (d *DHWTemperature) CompatibleEntity(ski string) eebus.EntityResolution {
 	return compatibleEntity(d.RemoteEntitiesScenarios(), ski)
 }
 

--- a/eebus-bridge/internal/usecases/dhwmonitoring_test.go
+++ b/eebus-bridge/internal/usecases/dhwmonitoring_test.go
@@ -20,7 +20,7 @@ func TestDHWMonitoringWrapperPublishesTemperatureUpdate(t *testing.T) {
 
 	select {
 	case event := <-ch:
-		if event.SKI != "TEST-SKI" || event.Type != eebus.EventTypeDHWTemperatureUpdated {
+		if event.SKI != "TESTSKI" || event.Type != eebus.EventTypeDHWTemperatureUpdated {
 			t.Fatalf("event = %+v", event)
 		}
 	case <-time.After(time.Second):

--- a/eebus-bridge/internal/usecases/dhwsysfn.go
+++ b/eebus-bridge/internal/usecases/dhwsysfn.go
@@ -195,7 +195,7 @@ func (d *DHWSystemFunction) request(entity spineapi.EntityRemoteInterface, funct
 }
 
 // CompatibleEntity returns the negotiated DHWCircuit for a device SKI.
-func (d *DHWSystemFunction) CompatibleEntity(ski string) spineapi.EntityRemoteInterface {
+func (d *DHWSystemFunction) CompatibleEntity(ski string) eebus.EntityResolution {
 	return compatibleEntity(d.RemoteEntitiesScenarios(), ski)
 }
 

--- a/eebus-bridge/internal/usecases/entity.go
+++ b/eebus-bridge/internal/usecases/entity.go
@@ -10,21 +10,40 @@ import (
 // compatibleEntity resolves the remote entity for a device SKI from a use
 // case's negotiated scenario list instead of the flat device registry:
 // multi-entity gateways expose several entities per device and only the
-// scenario list is use-case aware (issue #47). An empty ski matches the
-// first compatible entity of any device. SKIs are compared normalized so
-// case and spacing differences reported by the remote do not cause a
-// spurious mismatch. Returns nil when no compatible entity has been
-// negotiated yet.
-func compatibleEntity(scenarios []eebusapi.RemoteEntityScenarios, ski string) spineapi.EntityRemoteInterface {
+// scenario list is use-case aware (issue #47). An empty ski resolves only when
+// exactly one distinct normalized device SKI is compatible. SKIs are compared
+// normalized so formatting differences do not create false mismatches or
+// ambiguity.
+func compatibleEntity(scenarios []eebusapi.RemoteEntityScenarios, ski string) eebus.EntityResolution {
 	want := eebus.NormalizeSKI(ski)
+	if want != "" {
+		for _, remote := range scenarios {
+			entity := remote.Entity
+			if entity == nil || entity.Device() == nil {
+				continue
+			}
+			if eebus.NormalizeSKI(entity.Device().Ski()) == want {
+				return eebus.EntityResolution{Entity: entity, DeviceCount: 1}
+			}
+		}
+		return eebus.EntityResolution{}
+	}
+
+	entitiesBySKI := make(map[string]spineapi.EntityRemoteInterface)
 	for _, remote := range scenarios {
 		entity := remote.Entity
 		if entity == nil || entity.Device() == nil {
 			continue
 		}
-		if want == "" || eebus.NormalizeSKI(entity.Device().Ski()) == want {
-			return entity
+		normalizedSKI := eebus.NormalizeSKI(entity.Device().Ski())
+		if _, seen := entitiesBySKI[normalizedSKI]; !seen {
+			entitiesBySKI[normalizedSKI] = entity
 		}
 	}
-	return nil
+	if len(entitiesBySKI) == 1 {
+		for _, entity := range entitiesBySKI {
+			return eebus.EntityResolution{Entity: entity, DeviceCount: 1}
+		}
+	}
+	return eebus.EntityResolution{DeviceCount: len(entitiesBySKI)}
 }

--- a/eebus-bridge/internal/usecases/entity_test.go
+++ b/eebus-bridge/internal/usecases/entity_test.go
@@ -23,7 +23,7 @@ func TestCompatibleEntitySKIMatching(t *testing.T) {
 		want      string
 		match     bool
 	}{
-		{"empty want matches any", "abcd1234", "", true},
+		{"empty want matches one device", "abcd1234", "", true},
 		{"exact match", "abcd1234", "abcd1234", true},
 		{"case insensitive", "ABCD1234", "abcd1234", true},
 		{"whitespace insensitive", "ab cd 12 34", "abcd1234", true},
@@ -35,9 +35,9 @@ func TestCompatibleEntitySKIMatching(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			scenarios := []eebusapi.RemoteEntityScenarios{scenarioWithSKI(t, tt.entitySKI)}
 			got := compatibleEntity(scenarios, tt.want)
-			if (got != nil) != tt.match {
+			if (got.Entity != nil) != tt.match {
 				t.Errorf("compatibleEntity(ski=%q, want=%q) matched=%v, want %v",
-					tt.entitySKI, tt.want, got != nil, tt.match)
+					tt.entitySKI, tt.want, got.Entity != nil, tt.match)
 			}
 		})
 	}
@@ -48,16 +48,46 @@ func TestCompatibleEntitySkipsNilEntries(t *testing.T) {
 		{Entity: nil},
 		scenarioWithSKI(t, "abcd1234"),
 	}
-	if got := compatibleEntity(scenarios, "abcd1234"); got == nil {
+	if got := compatibleEntity(scenarios, "abcd1234"); got.Entity == nil {
 		t.Error("compatibleEntity skipped past nil entry but did not find match")
 	}
 }
 
-// CompatibleEntity must not panic and must return nil before Setup (uc == nil),
+func TestCompatibleEntityEmptySKIDetectsAmbiguity(t *testing.T) {
+	deviceA := scenarioWithSKI(t, "aa:bb-cc")
+	deviceB := scenarioWithSKI(t, "DDEEFF")
+	scenarios := []eebusapi.RemoteEntityScenarios{deviceA, deviceB}
+
+	resolution := compatibleEntity(scenarios, "")
+	if !resolution.Ambiguous() || resolution.DeviceCount != 2 {
+		t.Fatalf("compatibleEntity(empty) = %+v, want ambiguity across 2 devices", resolution)
+	}
+	if got := compatibleEntity(scenarios, " AA BB CC "); got.Entity != deviceA.Entity {
+		t.Error("explicit device A SKI did not resolve device A entity")
+	}
+	if got := compatibleEntity(scenarios, "dd:ee:ff"); got.Entity != deviceB.Entity {
+		t.Error("explicit device B SKI did not resolve device B entity")
+	}
+	if got := compatibleEntity(scenarios, "unknown"); got.Entity != nil || got.Ambiguous() {
+		t.Errorf("unknown explicit SKI = %+v, want unambiguous no-match", got)
+	}
+}
+
+func TestCompatibleEntityCountsNormalizedSKIOnce(t *testing.T) {
+	first := scenarioWithSKI(t, "ab:cd-ef")
+	second := scenarioWithSKI(t, " AB-CD-EF ")
+	resolution := compatibleEntity([]eebusapi.RemoteEntityScenarios{first, second}, "")
+
+	if resolution.Ambiguous() || resolution.DeviceCount != 1 || resolution.Entity != first.Entity {
+		t.Errorf("compatibleEntity(format variants) = %+v, want first entity for one normalized device", resolution)
+	}
+}
+
+// CompatibleEntity must not panic and must return no entity before Setup (uc == nil),
 // so resolveEntity falls back to the registry instead of crashing.
 func TestCompatibleEntityNilUseCase(t *testing.T) {
 	w := NewLPCWrapper(nil, nil, false)
-	if got := w.CompatibleEntity("abcd1234"); got != nil {
-		t.Errorf("CompatibleEntity on un-set-up wrapper = %v, want nil", got)
+	if got := w.CompatibleEntity("abcd1234"); got.Entity != nil || got.Ambiguous() {
+		t.Errorf("CompatibleEntity on un-set-up wrapper = %+v, want no match", got)
 	}
 }

--- a/eebus-bridge/internal/usecases/lpc.go
+++ b/eebus-bridge/internal/usecases/lpc.go
@@ -96,11 +96,10 @@ func (w *LPCWrapper) HandleEvent(ski string, device spineapi.DeviceRemoteInterfa
 // ("no compatible entity"). RemoteEntitiesScenarios lists only entities that
 // advertise the LPC use case, so resolving from it picks the correct one (issue #47).
 //
-// An empty ski matches the first LPC-capable entity of any device. Returns nil when
-// the use case is not set up or no compatible entity has been negotiated yet.
-func (w *LPCWrapper) CompatibleEntity(ski string) spineapi.EntityRemoteInterface {
+// An empty ski resolves only when exactly one device is LPC-capable.
+func (w *LPCWrapper) CompatibleEntity(ski string) eebus.EntityResolution {
 	if w.uc == nil {
-		return nil
+		return eebus.EntityResolution{}
 	}
 	return compatibleEntity(w.uc.RemoteEntitiesScenarios(), ski)
 }

--- a/eebus-bridge/internal/usecases/lpc_test.go
+++ b/eebus-bridge/internal/usecases/lpc_test.go
@@ -21,8 +21,8 @@ func TestLPCEventRouting(t *testing.T) {
 
 	select {
 	case evt := <-ch:
-		if evt.SKI != "TEST-SKI" {
-			t.Errorf("SKI = %q, want TEST-SKI", evt.SKI)
+		if evt.SKI != "TESTSKI" {
+			t.Errorf("SKI = %q, want TESTSKI", evt.SKI)
 		}
 		if evt.Type != eebus.EventTypeLPCLimitUpdated {
 			t.Errorf("Type = %q, want lpc.limit_updated", evt.Type)

--- a/eebus-bridge/internal/usecases/monitoring.go
+++ b/eebus-bridge/internal/usecases/monitoring.go
@@ -159,9 +159,9 @@ func (w *MonitoringWrapper) Frequency(entity spineapi.EntityRemoteInterface) (fl
 	return w.uc.Frequency(entity)
 }
 
-func (w *MonitoringWrapper) CompatibleEntity(ski string) spineapi.EntityRemoteInterface {
+func (w *MonitoringWrapper) CompatibleEntity(ski string) eebus.EntityResolution {
 	if w.uc == nil {
-		return nil
+		return eebus.EntityResolution{}
 	}
 	return compatibleEntity(w.uc.RemoteEntitiesScenarios(), ski)
 }

--- a/eebus-bridge/internal/usecases/ohpcf.go
+++ b/eebus-bridge/internal/usecases/ohpcf.go
@@ -123,11 +123,10 @@ func (w *OHPCFWrapper) OptionalPowerConsumptionAvailable(entity spineapi.EntityR
 // such as the Vaillant VR940 registers several entities under one device SKI;
 // RemoteEntitiesScenarios lists only entities that advertise OHPCF, so resolving
 // from it picks the Compressor rather than e.g. the monitoring meter (issue #47).
-// An empty ski matches the first OHPCF-capable entity of any device. Returns nil
-// when the use case is not set up or no compatible entity has been negotiated yet.
-func (w *OHPCFWrapper) CompatibleEntity(ski string) spineapi.EntityRemoteInterface {
+// An empty ski resolves only when exactly one device is OHPCF-capable.
+func (w *OHPCFWrapper) CompatibleEntity(ski string) eebus.EntityResolution {
 	if w.uc == nil {
-		return nil
+		return eebus.EntityResolution{}
 	}
 	return compatibleEntity(w.uc.RemoteEntitiesScenarios(), ski)
 }

--- a/eebus-bridge/internal/usecases/ohpcf_test.go
+++ b/eebus-bridge/internal/usecases/ohpcf_test.go
@@ -27,8 +27,8 @@ func TestOHPCFEventRouting(t *testing.T) {
 		if evt.Type != eebus.EventTypeOHPCFConsumptionStateUpdated {
 			t.Errorf("Type = %q, want ohpcf.consumption_state_updated", evt.Type)
 		}
-		if evt.SKI != "OHPCF-SKI" {
-			t.Errorf("SKI = %q, want OHPCF-SKI", evt.SKI)
+		if evt.SKI != "OHPCFSKI" {
+			t.Errorf("SKI = %q, want OHPCFSKI", evt.SKI)
 		}
 	case <-time.After(time.Second):
 		t.Fatal("timeout waiting for ohpcf event")

--- a/eebus-bridge/internal/usecases/outdoormonitoring_test.go
+++ b/eebus-bridge/internal/usecases/outdoormonitoring_test.go
@@ -29,7 +29,7 @@ func TestOutdoorMonitoringWrapperPublishesEvents(t *testing.T) {
 			wrapper.HandleEvent("test-ski", nil, nil, tt.in)
 			select {
 			case event := <-ch:
-				if event.SKI != "TEST-SKI" || event.Type != tt.want {
+				if event.SKI != "TESTSKI" || event.Type != tt.want {
 					t.Fatalf("event = %+v", event)
 				}
 			case <-time.After(time.Second):

--- a/eebus-bridge/internal/usecases/roomheatingsysfn.go
+++ b/eebus-bridge/internal/usecases/roomheatingsysfn.go
@@ -178,7 +178,7 @@ func (r *RoomHeatingSystemFunction) request(entity spineapi.EntityRemoteInterfac
 }
 
 // CompatibleEntity returns the negotiated HVACRoom for a device SKI.
-func (r *RoomHeatingSystemFunction) CompatibleEntity(ski string) spineapi.EntityRemoteInterface {
+func (r *RoomHeatingSystemFunction) CompatibleEntity(ski string) eebus.EntityResolution {
 	return compatibleEntity(r.RemoteEntitiesScenarios(), ski)
 }
 

--- a/eebus-bridge/internal/usecases/roomheatingtemp.go
+++ b/eebus-bridge/internal/usecases/roomheatingtemp.go
@@ -177,7 +177,7 @@ func (r *RoomHeatingTemperature) request(entity spineapi.EntityRemoteInterface, 
 }
 
 // CompatibleEntity returns the negotiated HVACRoom for a device SKI.
-func (r *RoomHeatingTemperature) CompatibleEntity(ski string) spineapi.EntityRemoteInterface {
+func (r *RoomHeatingTemperature) CompatibleEntity(ski string) eebus.EntityResolution {
 	return compatibleEntity(r.RemoteEntitiesScenarios(), ski)
 }
 

--- a/eebus-bridge/internal/usecases/roommonitoring_test.go
+++ b/eebus-bridge/internal/usecases/roommonitoring_test.go
@@ -29,7 +29,7 @@ func TestRoomMonitoringWrapperPublishesEvents(t *testing.T) {
 			wrapper.HandleEvent("test-ski", nil, nil, tt.in)
 			select {
 			case event := <-ch:
-				if event.SKI != "TEST-SKI" || event.Type != tt.want {
+				if event.SKI != "TESTSKI" || event.Type != tt.want {
 					t.Fatalf("event = %+v", event)
 				}
 			case <-time.After(time.Second):

--- a/eebus-bridge/internal/usecases/temperaturemonitoring.go
+++ b/eebus-bridge/internal/usecases/temperaturemonitoring.go
@@ -151,16 +151,16 @@ func (w *TemperatureMonitoringWrapper) Temperature(ski string) (float64, error) 
 	if w.uc == nil {
 		return 0, w.errNotInitialized
 	}
-	entity := w.CompatibleEntity(ski)
-	if entity == nil {
+	resolution := w.CompatibleEntity(ski)
+	if resolution.Entity == nil {
 		return 0, eebusapi.ErrDataNotAvailable
 	}
-	return w.uc.Temperature(entity, model.UnitOfMeasurementTypedegC)
+	return w.uc.Temperature(resolution.Entity, model.UnitOfMeasurementTypedegC)
 }
 
-func (w *TemperatureMonitoringWrapper) CompatibleEntity(ski string) spineapi.EntityRemoteInterface {
+func (w *TemperatureMonitoringWrapper) CompatibleEntity(ski string) eebus.EntityResolution {
 	if w.uc == nil {
-		return nil
+		return eebus.EntityResolution{}
 	}
 	return compatibleEntity(w.uc.RemoteEntitiesScenarios(), ski)
 }


### PR DESCRIPTION
## Summary
- Empty-SKI resolvers (`compatibleEntity`, `CompatibleEntity`, `FirstAvailableEntity`) now return an `EntityResolution` (entity + distinct-device count); an empty SKI resolves only when exactly one compatible device exists, otherwise every gRPC resolver (monitoring, LPC, OHPCF, DHW, HVAC) returns `FAILED_PRECONDITION` instead of silently picking a device. Unknown explicit SKIs still `NOT_FOUND`.
- `NormalizeSKI` now also strips colons/hyphens (mixed-case/whitespace/separator variants of the same physical SKI collapse to one registry entry).
- `ListDevices`/`ListDiscoveredDevices`/`ListPairedDevices` are deterministically sorted by normalized SKI.
- `EventBus.Publish` drops device-scoped events with no resolvable SKI (counted via `DroppedUnresolvedEvents`) instead of broadcasting them as wildcards; `discovery.updated` stays exempt since it's inherently device-agnostic, not tied to one SKI.
- HA coordinator: removed the `ski=""` retry fallback in `_poll_read`, the `allow_fallback` plumbing in `_async_fetch_device_info`, and the wildcard/`read_fallback_used` branches in `_event_matches` (now requires an exact configured-SKI match).

Implements RF-02 from `docs/refactoring-optimization-spec.md`.

## Test plan
- [x] `go vet ./...` and `go test -race ./...` (from `eebus-bridge/`)
- [x] `ruff check custom_components/`
- [x] `mypy custom_components/eebus`
- [x] `PYTHONPATH=. pytest` (95 passed)
- [x] New Go tests: two-device ambiguity → FAILED_PRECONDITION, explicit-SKI resolution stays scoped, unknown SKI stays NOT_FOUND, deterministic device-list ordering, SKI-alias normalization, discovery.updated event delivery preserved
- [ ] CI