### PR TITLE
RF-03: pairing commands off the event bus

### DIFF
--- a/eebus-bridge/cmd/eebus-bridge/main.go
+++ b/eebus-bridge/cmd/eebus-bridge/main.go
@@ -202,28 +202,6 @@ func main() {
 	}
 	log.Printf("Registered EEBUS use cases: %s", strings.Join(registeredUseCases, ", "))
 
-	go func() {
-		ch := bus.Subscribe()
-		defer bus.Unsubscribe(ch)
-		for evt := range ch {
-			switch evt.Type {
-			case eebus.EventTypeDeviceRegisterSKI:
-				bridgeSvc.RegisterRemoteSKI(evt.SKI)
-				log.Printf("Registered remote SKI: %s", evt.SKI)
-			case eebus.EventTypeDeviceUnregisterSKI:
-				// eebus-go's UnregisterRemoteService only notifies via
-				// ServicePairingDetailUpdate, not ServiceAutoTrustRemoved, so the
-				// registry is cleared explicitly here rather than relying on a
-				// callback (cf. ServiceAutoTrustRemoved in callbacks.go, which
-				// handles the remote-initiated revocation case).
-				bridgeSvc.UnregisterRemoteSKI(evt.SKI)
-				registry.RemoveDevice(evt.SKI)
-				bus.Publish(eebus.Event{SKI: evt.SKI, Type: eebus.EventTypeDeviceTrustRemoved})
-				log.Printf("Unregistered remote SKI: %s", evt.SKI)
-			}
-		}
-	}()
-
 	grpcSrv, err := bridgegrpc.NewServerWithSecurity(
 		cfg.GRPC.Bind,
 		cfg.GRPC.Port,
@@ -234,7 +212,8 @@ func main() {
 		log.Fatalf("configuring gRPC server security: %v", err)
 	}
 
-	deviceSvc := bridgegrpc.NewDeviceService(bridgeSvc.Callbacks(), bus, ski, registry)
+	trustController := eebus.NewTrustController(bridgeSvc, registry, bus)
+	deviceSvc := bridgegrpc.NewDeviceService(bridgeSvc.Callbacks(), bus, ski, registry, trustController)
 	lpcSvc := bridgegrpc.NewLPCService(lpcWrapper, bus, registry)
 	monitoringSvc := bridgegrpc.NewMonitoringService(
 		monitoringWrapper,

--- a/eebus-bridge/internal/eebus/events.go
+++ b/eebus-bridge/internal/eebus/events.go
@@ -4,13 +4,11 @@ package eebus
 type EventType string
 
 const (
-	EventTypeDeviceConnected     EventType = "device.connected"
-	EventTypeDeviceDisconnected  EventType = "device.disconnected"
-	EventTypeDeviceTrustRemoved  EventType = "device.trust_removed"
-	EventTypeDeviceRegisterSKI   EventType = "device.register_ski"
-	EventTypeDeviceUnregisterSKI EventType = "device.unregister_ski"
-	EventTypeDiscoveryUpdated    EventType = "discovery.updated"
-	EventTypePairingUpdated      EventType = "pairing.updated"
+	EventTypeDeviceConnected    EventType = "device.connected"
+	EventTypeDeviceDisconnected EventType = "device.disconnected"
+	EventTypeDeviceTrustRemoved EventType = "device.trust_removed"
+	EventTypeDiscoveryUpdated   EventType = "discovery.updated"
+	EventTypePairingUpdated     EventType = "pairing.updated"
 
 	EventTypeMonitoringPowerUpdated                EventType = "monitoring.power_updated"
 	EventTypeMonitoringPowerPerPhaseUpdated        EventType = "monitoring.power_per_phase_updated"

--- a/eebus-bridge/internal/eebus/trust.go
+++ b/eebus-bridge/internal/eebus/trust.go
@@ -1,0 +1,53 @@
+package eebus
+
+import "errors"
+
+type remoteTrustService interface {
+	RegisterRemoteSKI(ski string)
+	UnregisterRemoteSKI(ski string)
+}
+
+// TrustController applies pairing commands synchronously and maintains the
+// bridge-owned device state that accompanies those commands.
+type TrustController struct {
+	bridge   remoteTrustService
+	registry *DeviceRegistry
+	bus      *EventBus
+}
+
+func NewTrustController(bridge *BridgeService, registry *DeviceRegistry, bus *EventBus) *TrustController {
+	if bridge == nil {
+		return &TrustController{registry: registry, bus: bus}
+	}
+	return &TrustController{bridge: bridge, registry: registry, bus: bus}
+}
+
+func (c *TrustController) RegisterSKI(ski string) error {
+	if c == nil || c.bridge == nil {
+		return errors.New("bridge service is required")
+	}
+	c.bridge.RegisterRemoteSKI(ski)
+	return nil
+}
+
+func (c *TrustController) UnregisterSKI(ski string) error {
+	if c == nil || c.bridge == nil {
+		return errors.New("bridge service is required")
+	}
+	if c.registry == nil {
+		return errors.New("device registry is required")
+	}
+	if c.bus == nil {
+		return errors.New("event bus is required")
+	}
+
+	c.bridge.UnregisterRemoteSKI(ski)
+	// eebus-go's UnregisterRemoteService only notifies via
+	// ServicePairingDetailUpdate, not ServiceAutoTrustRemoved, so the registry
+	// is cleared explicitly here rather than relying on a callback (cf.
+	// ServiceAutoTrustRemoved in callbacks.go, which handles remote-initiated
+	// revocation).
+	c.registry.RemoveDevice(ski)
+	c.bus.Publish(Event{SKI: ski, Type: EventTypeDeviceTrustRemoved})
+	return nil
+}

--- a/eebus-bridge/internal/eebus/trust_test.go
+++ b/eebus-bridge/internal/eebus/trust_test.go
@@ -1,0 +1,68 @@
+package eebus
+
+import "testing"
+
+type recordingRemoteTrustService struct {
+	registry                      *DeviceRegistry
+	events                        chan Event
+	registerCalls                 []string
+	unregisterCalls               []string
+	devicePresentDuringUnregister bool
+	eventCountDuringUnregister    int
+}
+
+func (s *recordingRemoteTrustService) RegisterRemoteSKI(ski string) {
+	s.registerCalls = append(s.registerCalls, ski)
+}
+
+func (s *recordingRemoteTrustService) UnregisterRemoteSKI(ski string) {
+	s.unregisterCalls = append(s.unregisterCalls, ski)
+	_, s.devicePresentDuringUnregister = s.registry.GetDevice(ski)
+	s.eventCountDuringUnregister = len(s.events)
+}
+
+func TestTrustControllerUnregisterOrderAndCleanup(t *testing.T) {
+	const ski = "682f708ceba5df9adcb9e6787ea911d9fc3ac490"
+	registry := NewDeviceRegistry()
+	registry.AddDevice(ski, DeviceInfo{Brand: "test device"})
+	bus := NewEventBus()
+	events := bus.Subscribe()
+	defer bus.Unsubscribe(events)
+	bridge := &recordingRemoteTrustService{registry: registry, events: events}
+	controller := &TrustController{bridge: bridge, registry: registry, bus: bus}
+
+	if err := controller.UnregisterSKI(ski); err != nil {
+		t.Fatalf("UnregisterSKI: %v", err)
+	}
+
+	wantSKI := NormalizeSKI(ski)
+	if len(bridge.unregisterCalls) != 1 || bridge.unregisterCalls[0] != ski {
+		t.Fatalf("UnregisterRemoteSKI calls = %v, want [%s]", bridge.unregisterCalls, ski)
+	}
+	if !bridge.devicePresentDuringUnregister {
+		t.Error("device was removed before BridgeService.UnregisterRemoteSKI")
+	}
+	if bridge.eventCountDuringUnregister != 0 {
+		t.Errorf("event count during BridgeService.UnregisterRemoteSKI = %d, want 0", bridge.eventCountDuringUnregister)
+	}
+	if _, ok := registry.GetDevice(ski); ok {
+		t.Fatal("device remains in registry after UnregisterSKI")
+	}
+	if devices := registry.ListDevices(); len(devices) != 0 {
+		t.Fatalf("ListDevices after UnregisterSKI = %v, want empty", devices)
+	}
+
+	select {
+	case event := <-events:
+		if event.Type != EventTypeDeviceTrustRemoved || event.SKI != wantSKI {
+			t.Errorf("event = %+v, want type=%s ski=%s", event, EventTypeDeviceTrustRemoved, wantSKI)
+		}
+	default:
+		t.Fatal("EventTypeDeviceTrustRemoved was not published after registry cleanup")
+	}
+	select {
+	case event := <-events:
+		t.Fatalf("unexpected second event: %+v", event)
+	default:
+	}
+}

--- a/eebus-bridge/internal/grpc/device_service.go
+++ b/eebus-bridge/internal/grpc/device_service.go
@@ -10,20 +10,27 @@ import (
 	"google.golang.org/grpc/status"
 )
 
+type TrustController interface {
+	RegisterSKI(ski string) error
+	UnregisterSKI(ski string) error
+}
+
 type DeviceService struct {
 	pb.UnimplementedDeviceServiceServer
 	callbacks *eebus.Callbacks
 	bus       *eebus.EventBus
 	localSKI  string
 	registry  *eebus.DeviceRegistry
+	trust     TrustController
 }
 
-func NewDeviceService(callbacks *eebus.Callbacks, bus *eebus.EventBus, localSKI string, registry *eebus.DeviceRegistry) *DeviceService {
+func NewDeviceService(callbacks *eebus.Callbacks, bus *eebus.EventBus, localSKI string, registry *eebus.DeviceRegistry, trust TrustController) *DeviceService {
 	return &DeviceService{
 		callbacks: callbacks,
 		bus:       bus,
 		localSKI:  localSKI,
 		registry:  registry,
+		trust:     trust,
 	}
 }
 
@@ -53,7 +60,9 @@ func (s *DeviceService) RegisterRemoteSKI(_ context.Context, req *pb.RegisterSKI
 	if !validSKI(ski) {
 		return nil, status.Errorf(codes.InvalidArgument, "ski must be 40 hex characters, got %q", req.Ski)
 	}
-	s.bus.Publish(eebus.Event{SKI: ski, Type: eebus.EventTypeDeviceRegisterSKI})
+	if err := s.trust.RegisterSKI(ski); err != nil {
+		return nil, status.Errorf(codes.Internal, "registering remote SKI: %v", err)
+	}
 	return &pb.Empty{}, nil
 }
 
@@ -66,7 +75,9 @@ func (s *DeviceService) UnregisterRemoteSKI(_ context.Context, req *pb.RegisterS
 	if !validSKI(ski) {
 		return nil, status.Errorf(codes.InvalidArgument, "ski must be 40 hex characters, got %q", req.Ski)
 	}
-	s.bus.Publish(eebus.Event{SKI: ski, Type: eebus.EventTypeDeviceUnregisterSKI})
+	if err := s.trust.UnregisterSKI(ski); err != nil {
+		return nil, status.Errorf(codes.Internal, "unregistering remote SKI: %v", err)
+	}
 	return &pb.Empty{}, nil
 }
 

--- a/eebus-bridge/internal/grpc/device_service_test.go
+++ b/eebus-bridge/internal/grpc/device_service_test.go
@@ -2,6 +2,7 @@ package grpc_test
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -15,12 +16,29 @@ import (
 	"google.golang.org/grpc/status"
 )
 
+type recordingTrustController struct {
+	registerCalls   []string
+	unregisterCalls []string
+	registerErr     error
+	unregisterErr   error
+}
+
+func (c *recordingTrustController) RegisterSKI(ski string) error {
+	c.registerCalls = append(c.registerCalls, ski)
+	return c.registerErr
+}
+
+func (c *recordingTrustController) UnregisterSKI(ski string) error {
+	c.unregisterCalls = append(c.unregisterCalls, ski)
+	return c.unregisterErr
+}
+
 func setupDeviceTest(t *testing.T) pb.DeviceServiceClient {
 	t.Helper()
 
 	bus := eebus.NewEventBus()
 	callbacks := eebus.NewCallbacks(bus, false)
-	svc := bridgegrpc.NewDeviceService(callbacks, bus, "test-local-ski", eebus.NewDeviceRegistry())
+	svc := bridgegrpc.NewDeviceService(callbacks, bus, "test-local-ski", eebus.NewDeviceRegistry(), &recordingTrustController{})
 
 	srv := bridgegrpc.NewServer("127.0.0.1", 0, false)
 	pb.RegisterDeviceServiceServer(srv.GRPCServer(), svc)
@@ -66,7 +84,7 @@ func TestListDevicesResponsesAreSortedByNormalizedSKI(t *testing.T) {
 	registry.AddDevice("cc:03", eebus.DeviceInfo{})
 	registry.AddDevice("AA-01", eebus.DeviceInfo{})
 	registry.AddDevice(" bb 02 ", eebus.DeviceInfo{})
-	svc := bridgegrpc.NewDeviceService(callbacks, bus, "local", registry)
+	svc := bridgegrpc.NewDeviceService(callbacks, bus, "local", registry, &recordingTrustController{})
 
 	discovered, err := svc.ListDiscoveredDevices(context.Background(), &pb.Empty{})
 	if err != nil {
@@ -111,24 +129,17 @@ func TestRegisterRemoteSKIAcceptsWellFormedSKI(t *testing.T) {
 func TestRegisterRemoteSKINormalizesColonSeparatedSKI(t *testing.T) {
 	bus := eebus.NewEventBus()
 	callbacks := eebus.NewCallbacks(bus, false)
-	svc := bridgegrpc.NewDeviceService(callbacks, bus, "test-local-ski", eebus.NewDeviceRegistry())
-
-	ch := bus.Subscribe()
-	defer bus.Unsubscribe(ch)
+	trust := &recordingTrustController{}
+	svc := bridgegrpc.NewDeviceService(callbacks, bus, "test-local-ski", eebus.NewDeviceRegistry(), trust)
 
 	colonSKI := "68:2f:70:8c:eb:a5:df:9a:dc:b9:e6:78:7e:a9:11:d9:fc:3a:c4:90"
 	if _, err := svc.RegisterRemoteSKI(context.Background(), &pb.RegisterSKIRequest{Ski: colonSKI}); err != nil {
 		t.Fatalf("RegisterRemoteSKI(colon-separated): %v", err)
 	}
 
-	want := eebus.NormalizeSKI(testValidSKI)
-	select {
-	case evt := <-ch:
-		if evt.SKI != want {
-			t.Errorf("published SKI = %q, want normalized %q", evt.SKI, want)
-		}
-	case <-time.After(time.Second):
-		t.Fatal("timeout waiting for register event")
+	want := testValidSKI
+	if len(trust.registerCalls) != 1 || trust.registerCalls[0] != want {
+		t.Fatalf("RegisterSKI calls = %v, want [%s]", trust.registerCalls, want)
 	}
 }
 
@@ -141,33 +152,82 @@ func TestUnregisterRemoteSKIRejectsMalformedSKI(t *testing.T) {
 	}
 }
 
-func TestUnregisterRemoteSKIPublishesEvent(t *testing.T) {
+func TestPairingCommandsBypassCongestedEventBus(t *testing.T) {
 	bus := eebus.NewEventBus()
 	callbacks := eebus.NewCallbacks(bus, false)
-	svc := bridgegrpc.NewDeviceService(callbacks, bus, "test-local-ski", eebus.NewDeviceRegistry())
+	trust := &recordingTrustController{}
+	svc := bridgegrpc.NewDeviceService(callbacks, bus, "test-local-ski", eebus.NewDeviceRegistry(), trust)
 
 	ch := bus.Subscribe()
 	defer bus.Unsubscribe(ch)
+	for range cap(ch) {
+		bus.Publish(eebus.Event{SKI: testValidSKI, Type: eebus.EventTypeDeviceConnected})
+	}
+	if len(ch) != cap(ch) {
+		t.Fatalf("subscriber buffer length = %d, want full capacity %d", len(ch), cap(ch))
+	}
 
+	if _, err := svc.RegisterRemoteSKI(context.Background(), &pb.RegisterSKIRequest{Ski: testValidSKI}); err != nil {
+		t.Fatalf("RegisterRemoteSKI: %v", err)
+	}
 	if _, err := svc.UnregisterRemoteSKI(context.Background(), &pb.RegisterSKIRequest{Ski: testValidSKI}); err != nil {
 		t.Fatalf("UnregisterRemoteSKI: %v", err)
 	}
 
-	want := eebus.NormalizeSKI(testValidSKI)
-	select {
-	case evt := <-ch:
-		if evt.Type != eebus.EventTypeDeviceUnregisterSKI || evt.SKI != want {
-			t.Errorf("event = %+v, want type=device.unregister_ski ski=%s", evt, want)
-		}
-	case <-time.After(time.Second):
-		t.Fatal("timeout waiting for unregister event")
+	want := testValidSKI
+	if len(trust.registerCalls) != 1 || trust.registerCalls[0] != want {
+		t.Errorf("RegisterSKI calls = %v, want [%s]", trust.registerCalls, want)
+	}
+	if len(trust.unregisterCalls) != 1 || trust.unregisterCalls[0] != want {
+		t.Errorf("UnregisterSKI calls = %v, want [%s]", trust.unregisterCalls, want)
+	}
+	if len(ch) != cap(ch) {
+		t.Errorf("subscriber buffer length = %d after commands, want %d", len(ch), cap(ch))
+	}
+}
+
+func TestPairingControllerErrorsReturnInternalStatus(t *testing.T) {
+	tests := []struct {
+		name  string
+		call  func(*bridgegrpc.DeviceService) (*pb.Empty, error)
+		trust *recordingTrustController
+	}{
+		{
+			name: "register",
+			call: func(svc *bridgegrpc.DeviceService) (*pb.Empty, error) {
+				return svc.RegisterRemoteSKI(context.Background(), &pb.RegisterSKIRequest{Ski: testValidSKI})
+			},
+			trust: &recordingTrustController{registerErr: errors.New("register failed")},
+		},
+		{
+			name: "unregister",
+			call: func(svc *bridgegrpc.DeviceService) (*pb.Empty, error) {
+				return svc.UnregisterRemoteSKI(context.Background(), &pb.RegisterSKIRequest{Ski: testValidSKI})
+			},
+			trust: &recordingTrustController{unregisterErr: errors.New("unregister failed")},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bus := eebus.NewEventBus()
+			svc := bridgegrpc.NewDeviceService(eebus.NewCallbacks(bus, false), bus, "test-local-ski", eebus.NewDeviceRegistry(), tt.trust)
+
+			resp, err := tt.call(svc)
+			if resp != nil {
+				t.Errorf("response = %v, want nil", resp)
+			}
+			if status.Code(err) != codes.Internal {
+				t.Fatalf("status code = %v, want Internal (error: %v)", status.Code(err), err)
+			}
+		})
 	}
 }
 
 func TestSubscribeDeviceEventsTrustRemoved(t *testing.T) {
 	bus := eebus.NewEventBus()
 	callbacks := eebus.NewCallbacks(bus, false)
-	svc := bridgegrpc.NewDeviceService(callbacks, bus, "test-local-ski", eebus.NewDeviceRegistry())
+	svc := bridgegrpc.NewDeviceService(callbacks, bus, "test-local-ski", eebus.NewDeviceRegistry(), &recordingTrustController{})
 
 	srv := bridgegrpc.NewServer("127.0.0.1", 0, false)
 	pb.RegisterDeviceServiceServer(srv.GRPCServer(), svc)

--- a/eebus-bridge/internal/grpc/integration_test.go
+++ b/eebus-bridge/internal/grpc/integration_test.go
@@ -20,7 +20,7 @@ func TestIntegrationDeviceServiceRoundTrip(t *testing.T) {
 	callbacks := eebus.NewCallbacks(bus, false)
 	registry := eebus.NewDeviceRegistry()
 
-	deviceSvc := bridgegrpc.NewDeviceService(callbacks, bus, "integration-test-ski", registry)
+	deviceSvc := bridgegrpc.NewDeviceService(callbacks, bus, "integration-test-ski", registry, &recordingTrustController{})
 	lpcSvc := bridgegrpc.NewLPCService(nil, bus, registry)
 	monSvc := bridgegrpc.NewMonitoringService(nil, bridgegrpc.MonitoringReaders{}, bus, registry)
 

--- a/eebus-bridge/internal/grpc/security_integration_test.go
+++ b/eebus-bridge/internal/grpc/security_integration_test.go
@@ -31,6 +31,11 @@ type acceptingLPCService struct {
 	pb.UnimplementedLPCServiceServer
 }
 
+type acceptingTrustController struct{}
+
+func (acceptingTrustController) RegisterSKI(string) error   { return nil }
+func (acceptingTrustController) UnregisterSKI(string) error { return nil }
+
 func (acceptingLPCService) WriteConsumptionLimit(context.Context, *pb.WriteLoadLimitRequest) (*pb.Empty, error) {
 	return &pb.Empty{}, nil
 }
@@ -112,7 +117,7 @@ func TestTLSTokenSecuresUnaryWriteStreamAndHealth(t *testing.T) {
 		t.Fatal(err)
 	}
 	bus := eebus.NewEventBus()
-	device := NewDeviceService(eebus.NewCallbacks(bus, false), bus, "local-ski", eebus.NewDeviceRegistry())
+	device := NewDeviceService(eebus.NewCallbacks(bus, false), bus, "local-ski", eebus.NewDeviceRegistry(), acceptingTrustController{})
 	pb.RegisterDeviceServiceServer(srv.GRPCServer(), device)
 	pb.RegisterLPCServiceServer(srv.GRPCServer(), acceptingLPCService{})
 	startErr := make(chan error, 1)


### PR DESCRIPTION
## Summary
- `DeviceService.RegisterRemoteSKI`/`UnregisterRemoteSKI` used to `bus.Publish` a command event and return success immediately; a background goroutine in `main.go` applied it later by consuming the event off the bus. `EventBus.Publish` is non-blocking and drops events when a subscriber's buffer is full, so the command could silently never execute while the RPC had already reported success — and no failure path existed either way.
- `DeviceService` now takes a narrow `TrustController` interface and calls `RegisterSKI`/`UnregisterSKI` synchronously; a non-nil error maps to `codes.Internal` instead of `Empty` success.
- `internal/eebus.TrustController` implements it, preserving the exact unregister order the removed goroutine had: bridge unregister call, then registry cleanup, then publishing `EventTypeDeviceTrustRemoved`.
- `EventTypeDeviceConnected`/`Disconnected`/`TrustRemoved` stay as observations on the bus — only the command path moved off it. `EventTypeDeviceRegisterSKI`/`UnregisterSKI` are removed.

Implements RF-03 from `docs/refactoring-optimization-spec.md`.

## Test plan
- [x] `go vet ./...` and `go test -race ./...` (from `eebus-bridge/`)
- [x] `ruff check custom_components/` (no Python touched, confirmed no-op)
- [x] New tests: pairing commands bypass a congested event bus (regression for the silent-drop bug), controller errors surface as `codes.Internal`, unregister ordering + registry cleanup verified via a recording fake
- [ ] CI