### PR TITLE
RF-04: serialize and coalesce provider pushes

### DIFF
--- a/custom_components/eebus/coordinator.py
+++ b/custom_components/eebus/coordinator.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import asyncio
 import logging
 import math
+from collections.abc import Awaitable, Callable
+from contextlib import suppress
 from datetime import timedelta
 from functools import lru_cache
 from types import ModuleType
@@ -210,6 +212,77 @@ def _system_function_to_dict(system_function: Any) -> dict[str, Any]:
     }
 
 
+class _ProviderPusher:
+    """Serialize and coalesce state-triggered pushes for one provider."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        label: str,
+        ski: str,
+        tracked: tuple[str | None, ...],
+        push: Callable[[], Awaitable[None]],
+    ) -> None:
+        self._hass = hass
+        self._label = label
+        self._ski = ski
+        self._entity_ids = [entity_id for entity_id in tracked if entity_id]
+        self._push = push
+        self._dirty = asyncio.Event()
+        self._task: asyncio.Task[None] | None = None
+        self._unsub: Callable[[], None] | None = None
+
+    def start(self) -> None:
+        """Subscribe to state changes and schedule the initial push."""
+        if self._task is not None:
+            return
+
+        def _on_change(_event: Event[EventStateChangedData]) -> None:
+            self.signal()
+
+        self._unsub = async_track_state_change_event(
+            self._hass, self._entity_ids, _on_change
+        )
+        self.signal()
+        self._task = self._hass.async_create_background_task(
+            self._run(), name=f"eebus_{self._label}_provider_push_{self._ski}"
+        )
+
+    def signal(self) -> None:
+        """Mark provider data dirty, coalescing repeated signals."""
+        self._dirty.set()
+
+    async def stop(self) -> None:
+        """Unsubscribe, then cancel and await the worker task."""
+        unsub = self._unsub
+        self._unsub = None
+        task = self._task
+        if task is None:
+            if unsub is not None:
+                unsub()
+            return
+        try:
+            if unsub is not None:
+                unsub()
+        finally:
+            task.cancel()
+            with suppress(asyncio.CancelledError):
+                await task
+            self._task = None
+
+    async def _run(self) -> None:
+        """Push the freshest state once per coalesced dirty signal."""
+        while True:
+            await self._dirty.wait()
+            self._dirty.clear()
+            try:
+                await self._push()
+            except asyncio.CancelledError:
+                raise
+            except Exception:  # noqa: BLE001
+                _LOGGER.exception("Unexpected failure pushing %s provider data", self._label)
+
+
 class EebusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     """Coordinator that manages gRPC connection and data updates."""
 
@@ -261,9 +334,8 @@ class EebusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self.battery_soc_entity = battery_soc_entity
         self._channel: grpc.aio.Channel | None = None
         self._stream_tasks: list[asyncio.Task[None]] = []
-        self._grid_unsub: Any = None
-        self._pv_unsub: Any = None
-        self._battery_unsub: Any = None
+        self._provider_pushers: list[_ProviderPusher] = []
+        self._provider_push_failing: dict[str, bool] = {}
         self._was_unavailable: bool = False
         self._heartbeat_supported: bool | None = None
         self._lpc_supported: bool | None = None
@@ -1026,8 +1098,15 @@ class EebusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         from . import proto_stubs
 
         stub = getattr(proto_stubs, stub_factory)(channel)
+        failure_state: dict[str, bool] | None = getattr(
+            self, "_provider_push_failing", None
+        )
+        if failure_state is None:
+            failure_state = self._provider_push_failing = {}
         try:
             await getattr(stub, publish_method)(request, timeout=RPC_TIMEOUT)
+            if failure_state.pop(label, False):
+                _LOGGER.info("%s provider push recovered", label)
             _LOGGER.debug("Pushed %s data: %s", label, request)
         except grpc.aio.AioRpcError as err:
             if _is_unimplemented(err) or err.code() == grpc.StatusCode.UNAVAILABLE:
@@ -1035,32 +1114,28 @@ class EebusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     "%s provider not ready; skipping push: %s", label, _rpc_error_text(err)
                 )
                 return
-            _LOGGER.warning("Failed to push %s data: %s", label, _rpc_error_text(err))
+            if failure_state.get(label, False):
+                _LOGGER.debug("Failed to push %s data: %s", label, _rpc_error_text(err))
+            else:
+                _LOGGER.warning("Failed to push %s data: %s", label, _rpc_error_text(err))
+                failure_state[label] = True
 
     def _start_provider_push(
         self,
         label: str,
         tracked: tuple[str | None, ...],
-        unsub_attr: str,
-        push: Any,
+        push: Callable[[], Awaitable[None]],
     ) -> None:
-        """Track the mapped sensors and push provider data on every change."""
-
-        async def _on_change(_event: Event[EventStateChangedData]) -> None:
-            await push()
-
-        entity_ids = [entity_id for entity_id in tracked if entity_id]
-        setattr(
-            self,
-            unsub_attr,
-            async_track_state_change_event(self.hass, entity_ids, _on_change),
+        """Start one lifecycle-owning provider push worker."""
+        pusher = _ProviderPusher(
+            self.hass,
+            label,
+            self.ski,
+            tracked,
+            push,
         )
-        # Initial push so the provider has data before the first sensor change.
-        self._stream_tasks.append(
-            self.hass.async_create_background_task(
-                push(), name=f"eebus_{label}_initial_push_{self.ski}"
-            )
-        )
+        self._provider_pushers.append(pusher)
+        pusher.start()
 
     async def async_push_grid_data(self) -> None:
         """Push the mapped grid sensors to the bridge MGCP provider.
@@ -1103,7 +1178,6 @@ class EebusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 self.grid_feed_in_energy_entity,
                 self.grid_consumption_energy_entity,
             ),
-            "_grid_unsub",
             self.async_push_grid_data,
         )
 
@@ -1154,7 +1228,6 @@ class EebusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 self.pv_yield_energy_entity,
                 self.pv_peak_power_entity,
             ),
-            "_pv_unsub",
             self.async_push_pv_data,
         )
 
@@ -1210,7 +1283,6 @@ class EebusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 self.battery_discharged_energy_entity,
                 self.battery_soc_entity,
             ),
-            "_battery_unsub",
             self.async_push_battery_data,
         )
 
@@ -1480,15 +1552,9 @@ class EebusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
     async def async_shutdown(self) -> None:
         """Close gRPC channel and cancel stream tasks."""
-        if self._grid_unsub is not None:
-            self._grid_unsub()
-            self._grid_unsub = None
-        if self._pv_unsub is not None:
-            self._pv_unsub()
-            self._pv_unsub = None
-        if self._battery_unsub is not None:
-            self._battery_unsub()
-            self._battery_unsub = None
+        for pusher in self._provider_pushers:
+            await pusher.stop()
+        self._provider_pushers.clear()
         for task in self._stream_tasks:
             task.cancel()
         self._stream_tasks.clear()

--- a/custom_components/eebus/tests/test_provider_push.py
+++ b/custom_components/eebus/tests/test_provider_push.py
@@ -1,0 +1,170 @@
+"""Tests for serialized and coalesced provider pushes."""
+
+import asyncio
+import logging
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import grpc
+from grpc.aio import AioRpcError, Metadata
+
+from custom_components.eebus import coordinator as coordinator_module
+from custom_components.eebus import proto_stubs
+from custom_components.eebus.coordinator import EebusCoordinator, _ProviderPusher
+
+
+def _fake_hass():
+    """Build the task-creation surface used by a provider pusher."""
+
+    def _create_background_task(coro, *, name):
+        return asyncio.create_task(coro, name=name)
+
+    return SimpleNamespace(async_create_background_task=_create_background_task)
+
+
+async def test_provider_pusher_coalesces_burst_and_publishes_latest(monkeypatch):
+    """A 100-change burst stays serialized and ends with the newest value."""
+    callbacks = []
+    unsub = MagicMock()
+
+    def _track_state_changes(_hass, entity_ids, callback):
+        assert entity_ids == ["sensor.provider"]
+        callbacks.append(callback)
+        return unsub
+
+    monkeypatch.setattr(
+        coordinator_module, "async_track_state_change_event", _track_state_changes
+    )
+
+    current_value = 0
+    in_flight = 0
+    max_in_flight = 0
+    published = []
+    first_started = asyncio.Event()
+    release_first = asyncio.Event()
+    drained = asyncio.Event()
+
+    async def _push():
+        nonlocal in_flight, max_in_flight
+        in_flight += 1
+        max_in_flight = max(max_in_flight, in_flight)
+        assert in_flight == 1
+        try:
+            published.append(current_value)
+            if len(published) == 1:
+                first_started.set()
+                await release_first.wait()
+            await asyncio.sleep(0.001)
+        finally:
+            in_flight -= 1
+            if len(published) >= 2:
+                drained.set()
+
+    pusher = _ProviderPusher(
+        _fake_hass(), "test", "test-ski", ("sensor.provider",), _push
+    )
+    pusher.start()
+    await asyncio.wait_for(first_started.wait(), timeout=1)
+
+    callback = callbacks[0]
+    for value in range(1, 101):
+        current_value = value
+        assert callback(None) is None
+
+    release_first.set()
+    await asyncio.wait_for(drained.wait(), timeout=1)
+
+    assert max_in_flight == 1
+    assert len(published) < 100
+    assert published[-1] == 100
+
+    await pusher.stop()
+    unsub.assert_called_once_with()
+
+
+async def test_provider_pusher_stop_cancels_in_flight_push(monkeypatch):
+    """Stopping during a blocked RPC awaits cancellation and leaks no task."""
+    unsub = MagicMock()
+    monkeypatch.setattr(
+        coordinator_module,
+        "async_track_state_change_event",
+        lambda *_args: unsub,
+    )
+    push_started = asyncio.Event()
+    never_release = asyncio.Event()
+
+    async def _push():
+        push_started.set()
+        await never_release.wait()
+
+    pusher = _ProviderPusher(
+        _fake_hass(), "test", "test-ski", ("sensor.provider",), _push
+    )
+    pusher.start()
+    await asyncio.wait_for(push_started.wait(), timeout=1)
+    pusher.signal()
+    worker_task = pusher._task
+    assert worker_task is not None
+
+    await asyncio.wait_for(pusher.stop(), timeout=1)
+
+    assert worker_task.done()
+    assert worker_task.cancelled()
+    assert pusher._task is None
+    unsub.assert_called_once_with()
+
+
+async def test_provider_push_failure_warning_is_rate_limited(monkeypatch, caplog):
+    """Only a new failure streak warns, and recovery resets that streak."""
+    failure = AioRpcError(
+        grpc.StatusCode.INTERNAL,
+        Metadata(),
+        Metadata(),
+        details="provider failed",
+    )
+    outcomes = [failure, failure, failure, None, failure]
+
+    class _FakeStub:
+        async def Publish(self, _request, timeout=None):  # noqa: N802
+            outcome = outcomes.pop(0)
+            if outcome is not None:
+                raise outcome
+
+    coordinator = EebusCoordinator.__new__(EebusCoordinator)
+    coordinator._channel = object()
+    coordinator._provider_push_failing = {}
+    monkeypatch.setattr(
+        proto_stubs,
+        "test_provider_stub",
+        lambda _channel: _FakeStub(),
+        raising=False,
+    )
+    caplog.set_level(logging.DEBUG, logger=coordinator_module.__name__)
+
+    for _ in range(3):
+        await coordinator._async_publish_provider(
+            "test", "test_provider_stub", "Publish", object()
+        )
+    await coordinator._async_publish_provider(
+        "test", "test_provider_stub", "Publish", object()
+    )
+    await coordinator._async_publish_provider(
+        "test", "test_provider_stub", "Publish", object()
+    )
+
+    failure_records = [
+        record
+        for record in caplog.records
+        if record.getMessage().startswith("Failed to push test data")
+    ]
+    assert [record.levelno for record in failure_records] == [
+        logging.WARNING,
+        logging.DEBUG,
+        logging.DEBUG,
+        logging.WARNING,
+    ]
+    assert [
+        record.getMessage()
+        for record in caplog.records
+        if record.levelno == logging.INFO
+    ] == ["test provider push recovered"]


### PR DESCRIPTION
## Summary
- Grid/PV/battery sensor changes each `await push()`ed directly in the HA state-change callback, so a burst of sensor updates could have several gRPC pushes to the bridge in flight concurrently with no ordering guarantee — a slower/older RPC could complete after and overwrite a newer one. Unload also only cancelled the one-off initial-push task without awaiting it, so an in-flight push wasn't guaranteed gone by the time shutdown returned.
- Added `_ProviderPusher`: a persistent per-provider worker loop gated by an `asyncio.Event`. State changes just `signal()`; any number of signals raised while a push is in flight coalesce into exactly one follow-up push reading the freshest HA state, and at most one push is ever in flight per provider. The pusher owns its full lifecycle (initial push, unsub, `stop()` cancelling+awaiting its worker task), replacing the coordinator's separate `_grid_unsub`/`_pv_unsub`/`_battery_unsub` bookkeeping.
- `_async_publish_provider` now rate-limits the "other error" warning per provider: first failure warns, repeats log at debug, a later success logs a recovery message.

Implements RF-04 from `docs/refactoring-optimization-spec.md`.

## Test plan
- [x] `ruff check custom_components/`
- [x] `mypy custom_components/eebus`
- [x] `PYTHONPATH=. pytest` (98 passed)
- [x] New tests: 100-change burst proves `max_in_flight == 1` and the latest value is published last; unload during a blocked in-flight push completes cleanly with no leaked task; failure-warning rate limiting (warn once, debug on repeats, info on recovery, warn again after a later relapse)
- [x] Existing `test_grid_push.py`/`test_visualization_push.py` unit/range-validation tests pass unchanged
- [ ] CI