### PR TITLE
feat: RF-06 per-device, state-aware watchdog

### DIFF
--- a/eebus-bridge/cmd/eebus-bridge/main.go
+++ b/eebus-bridge/cmd/eebus-bridge/main.go
@@ -17,13 +17,17 @@ import (
 	"github.com/volschin/eebus-bridge/internal/usecases"
 )
 
-// monitoringStaleThreshold bounds how long a trusted device may go without a
+// monitoringStaleThreshold bounds how long a connected device may go without a
 // successful Monitoring entity resolution before the watchdog restarts the
 // process. Reconnects (SHIP re-pair) can leave the SPINE entity binding stuck
 // with no error logged, silently starving Home Assistant of data; a restart
 // forces a clean re-handshake. The device normally pushes updates ~every 60s,
 // so 10min gives ample margin against brief legitimate gaps.
 const monitoringStaleThreshold = 10 * time.Minute
+
+// monitoringGracePeriod allows a newly connected device to establish its
+// first monitoring binding before watchdog staleness applies.
+const monitoringGracePeriod = 2 * time.Minute
 
 const watchdogInterval = 30 * time.Second
 
@@ -278,24 +282,47 @@ func main() {
 		log.Println("[DEBUG] EEBUS event debug logging enabled; waiting for incoming callbacks")
 	}
 
+	shutdownCh := make(chan string, 1)
 	go func() {
 		ticker := time.NewTicker(watchdogInterval)
 		defer ticker.Stop()
 		for range ticker.C {
-			stale := registry.MonitoringStale(monitoringStaleThreshold)
-			grpcSrv.SetHealthy(!stale)
-			if stale {
-				log.Fatalf(
-					"monitoring watchdog: no successful entity resolution for a trusted device in over %s; exiting for restart",
+			staleDevices := registry.StaleDevices(monitoringStaleThreshold, monitoringGracePeriod)
+			grpcSrv.SetHealthy(len(staleDevices) == 0)
+			if len(staleDevices) > 0 {
+				details := make([]string, 0, len(staleDevices))
+				for _, ski := range staleDevices {
+					lastSuccessAge := "never"
+					if age, ok := registry.MonitoringLastSuccessAge(ski); ok {
+						lastSuccessAge = age.Round(time.Second).String()
+					}
+					details = append(details, eebus.ShortSKI(ski)+"(last_success_age="+lastSuccessAge+")")
+				}
+
+				reason := "monitoring watchdog detected stale connected devices"
+				log.Printf(
+					"%s: devices=[%s] threshold=%s grace_period=%s; requesting restart",
+					reason,
+					strings.Join(details, ", "),
 					monitoringStaleThreshold,
+					monitoringGracePeriod,
 				)
+				shutdownCh <- reason
+				return
 			}
 		}
 	}()
 
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
-	<-sigCh
+	exitCode := 0
+	select {
+	case sig := <-sigCh:
+		log.Printf("Received signal %s", sig)
+	case reason := <-shutdownCh:
+		exitCode = 1
+		log.Printf("Controlled shutdown requested: %s", reason)
+	}
 
 	log.Println("Shutting down...")
 	if err := lpcWrapper.StopHeartbeat(); err != nil {
@@ -304,4 +331,7 @@ func main() {
 	grpcSrv.Stop()
 	bridgeSvc.Shutdown()
 	log.Println("Shutdown complete")
+	if exitCode != 0 {
+		os.Exit(exitCode)
+	}
 }

--- a/eebus-bridge/internal/eebus/callbacks.go
+++ b/eebus-bridge/internal/eebus/callbacks.go
@@ -44,6 +44,7 @@ func (c *Callbacks) RemoteServiceConnected(_ api.ServiceInterface, identity ship
 
 	if c.registry != nil {
 		c.registry.AddDevice(ski, DeviceInfo{SKI: ski})
+		c.registry.MarkConnected(ski)
 	}
 
 	c.bus.Publish(Event{
@@ -62,6 +63,7 @@ func (c *Callbacks) RemoteServiceDisconnected(_ api.ServiceInterface, identity s
 	// Drop cached entity references so a later re-pair re-populates them from
 	// fresh observations instead of writing to an orphaned entity.
 	if c.registry != nil {
+		c.registry.MarkDisconnected(ski)
 		c.registry.ClearEntities(ski)
 	}
 
@@ -134,6 +136,7 @@ func (c *Callbacks) ServiceAutoTrustRemoved(_ api.ServiceInterface, identity shi
 	}
 
 	if c.registry != nil {
+		c.registry.MarkDisconnected(ski)
 		c.registry.ClearEntities(ski)
 	}
 

--- a/eebus-bridge/internal/eebus/callbacks_test.go
+++ b/eebus-bridge/internal/eebus/callbacks_test.go
@@ -33,7 +33,8 @@ func TestCallbacksDispatchConnect(t *testing.T) {
 
 func TestCallbacksConnectAddsDeviceToRegistry(t *testing.T) {
 	bus := eebus.NewEventBus()
-	reg := eebus.NewDeviceRegistry()
+	clock := &fakeClock{now: time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)}
+	reg := eebus.NewDeviceRegistryWithClock(clock)
 	cb := eebus.NewCallbacks(bus, false)
 	cb.SetRegistry(reg)
 
@@ -41,6 +42,10 @@ func TestCallbacksConnectAddsDeviceToRegistry(t *testing.T) {
 
 	if _, ok := reg.GetDevice("test-ski-123"); !ok {
 		t.Fatal("connected remote service was not added to registry")
+	}
+	clock.Advance(3 * time.Minute)
+	if got := reg.StaleDevices(10*time.Minute, 2*time.Minute); len(got) != 1 || got[0] != "TESTSKI123" {
+		t.Errorf("connect callback did not mark device connected: StaleDevices() = %v", got)
 	}
 }
 
@@ -64,11 +69,13 @@ func TestCallbacksDispatchDisconnect(t *testing.T) {
 
 func TestCallbacksDisconnectClearsCachedEntities(t *testing.T) {
 	bus := eebus.NewEventBus()
-	reg := eebus.NewDeviceRegistry()
+	clock := &fakeClock{now: time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)}
+	reg := eebus.NewDeviceRegistryWithClock(clock)
 	reg.AddDevice("test-ski-456", eebus.DeviceInfo{
 		Brand:          "Vaillant",
 		RemoteEntities: []spineapi.EntityRemoteInterface{nil},
 	})
+	reg.MarkConnected("test-ski-456")
 
 	cb := eebus.NewCallbacks(bus, false)
 	cb.SetRegistry(reg)
@@ -84,6 +91,10 @@ func TestCallbacksDisconnectClearsCachedEntities(t *testing.T) {
 	if info.Brand != "Vaillant" {
 		t.Error("classification metadata must survive disconnect")
 	}
+	clock.Advance(24 * time.Hour)
+	if got := reg.StaleDevices(10*time.Minute, 2*time.Minute); len(got) != 0 {
+		t.Errorf("disconnect callback left device monitored: StaleDevices() = %v", got)
+	}
 }
 
 func TestCallbacksTrustRemovedClearsCachedEntitiesAndPublishes(t *testing.T) {
@@ -91,11 +102,13 @@ func TestCallbacksTrustRemovedClearsCachedEntitiesAndPublishes(t *testing.T) {
 	ch := bus.Subscribe()
 	defer bus.Unsubscribe(ch)
 
-	reg := eebus.NewDeviceRegistry()
+	clock := &fakeClock{now: time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)}
+	reg := eebus.NewDeviceRegistryWithClock(clock)
 	reg.AddDevice("test-ski-789", eebus.DeviceInfo{
 		Brand:          "Vaillant",
 		RemoteEntities: []spineapi.EntityRemoteInterface{nil},
 	})
+	reg.MarkConnected("test-ski-789")
 
 	cb := eebus.NewCallbacks(bus, false)
 	cb.SetRegistry(reg)
@@ -107,6 +120,10 @@ func TestCallbacksTrustRemovedClearsCachedEntitiesAndPublishes(t *testing.T) {
 	}
 	if len(info.RemoteEntities) != 0 {
 		t.Errorf("cached entities not cleared on trust removal: got %d", len(info.RemoteEntities))
+	}
+	clock.Advance(24 * time.Hour)
+	if got := reg.StaleDevices(10*time.Minute, 2*time.Minute); len(got) != 0 {
+		t.Errorf("trust-removal callback left device monitored: StaleDevices() = %v", got)
 	}
 
 	select {

--- a/eebus-bridge/internal/eebus/registry.go
+++ b/eebus-bridge/internal/eebus/registry.go
@@ -5,7 +5,6 @@ import (
 	"sort"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	spineapi "github.com/enbility/spine-go/api"
@@ -44,37 +43,130 @@ func (r EntityResolution) Ambiguous() bool {
 }
 
 type DeviceRegistry struct {
-	mu                    sync.RWMutex
-	devices               map[string]DeviceInfo
-	lastMonitoringSuccess atomic.Int64 // unix nano; set at construction so a stuck startup also counts as stale
+	mu         sync.RWMutex
+	devices    map[string]DeviceInfo
+	monitoring map[string]deviceMonitoringState
+	clock      Clock
+}
+
+type deviceMonitoringState struct {
+	connected                  bool
+	connectedAt                time.Time
+	lastMonitoringSuccess      time.Time
+	monitoringSuccessOnConnect bool
+}
+
+// Clock provides the current time for monitoring-health tracking. Tests can
+// inject a deterministic implementation through NewDeviceRegistryWithClock.
+type Clock interface {
+	Now() time.Time
+}
+
+type realClock struct{}
+
+func (realClock) Now() time.Time {
+	return time.Now()
 }
 
 func NewDeviceRegistry() *DeviceRegistry {
-	r := &DeviceRegistry{
-		devices: make(map[string]DeviceInfo),
+	return NewDeviceRegistryWithClock(realClock{})
+}
+
+func NewDeviceRegistryWithClock(clock Clock) *DeviceRegistry {
+	if clock == nil {
+		clock = realClock{}
 	}
-	r.lastMonitoringSuccess.Store(time.Now().UnixNano())
-	return r
+	return &DeviceRegistry{
+		devices:    make(map[string]DeviceInfo),
+		monitoring: make(map[string]deviceMonitoringState),
+		clock:      clock,
+	}
+}
+
+// MarkConnected starts a fresh monitoring grace period for a device. The last
+// success timestamp is retained for diagnostics, but cannot satisfy the new
+// connection until RecordMonitoringSuccess is called again.
+func (r *DeviceRegistry) MarkConnected(ski string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	ski = NormalizeSKI(ski)
+	state := r.monitoring[ski]
+	if state.connected {
+		return
+	}
+	state.connected = true
+	state.connectedAt = r.clock.Now()
+	state.monitoringSuccessOnConnect = false
+	r.monitoring[ski] = state
+}
+
+// MarkDisconnected excludes a device from monitoring-health checks. Unknown
+// devices are ignored so a stray disconnect callback does not create state.
+func (r *DeviceRegistry) MarkDisconnected(ski string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	ski = NormalizeSKI(ski)
+	state, ok := r.monitoring[ski]
+	if !ok {
+		return
+	}
+	state.connected = false
+	r.monitoring[ski] = state
 }
 
 // RecordMonitoringSuccess marks that a remote entity was just successfully
 // resolved for a live monitoring read. Call only on a real eebus-go scenario
 // match (not a registry cache hit), so a stuck SPINE entity binding after
 // reconnect is actually detected instead of masked by stale cached entities.
-func (r *DeviceRegistry) RecordMonitoringSuccess() {
-	r.lastMonitoringSuccess.Store(time.Now().UnixNano())
+func (r *DeviceRegistry) RecordMonitoringSuccess(ski string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	ski = NormalizeSKI(ski)
+	state := r.monitoring[ski]
+	state.lastMonitoringSuccess = r.clock.Now()
+	state.monitoringSuccessOnConnect = state.connected
+	r.monitoring[ski] = state
 }
 
-// MonitoringStale reports whether monitoring reads have produced no
-// successful entity resolution for longer than threshold, while at least one
-// device is trusted. Returns false with no trusted device, since a bridge
-// that has never been paired isn't a monitoring outage.
-func (r *DeviceRegistry) MonitoringStale(threshold time.Duration) bool {
-	if len(r.ListDevices()) == 0 {
-		return false
+// StaleDevices returns connected device SKIs whose grace period has elapsed
+// without a success on the current connection, or whose most recent success
+// on that connection is older than threshold.
+func (r *DeviceRegistry) StaleDevices(threshold, gracePeriod time.Duration) []string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	now := r.clock.Now()
+	result := make([]string, 0)
+	for ski, state := range r.monitoring {
+		if !state.connected || now.Sub(state.connectedAt) <= gracePeriod {
+			continue
+		}
+		if !state.monitoringSuccessOnConnect || now.Sub(state.lastMonitoringSuccess) > threshold {
+			result = append(result, ski)
+		}
 	}
-	last := time.Unix(0, r.lastMonitoringSuccess.Load())
-	return time.Since(last) > threshold
+	sort.Strings(result)
+	return result
+}
+
+// MonitoringLastSuccessAge returns the age of a device's latest monitoring
+// success, including one from a previous connection for watchdog diagnostics.
+func (r *DeviceRegistry) MonitoringLastSuccessAge(ski string) (time.Duration, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	state, ok := r.monitoring[NormalizeSKI(ski)]
+	if !ok || state.lastMonitoringSuccess.IsZero() {
+		return 0, false
+	}
+	age := r.clock.Now().Sub(state.lastMonitoringSuccess)
+	if age < 0 {
+		age = 0
+	}
+	return age, true
 }
 
 // NormalizeSKI canonicalizes a SKI for use as a registry key: uppercase, with
@@ -84,6 +176,15 @@ func (r *DeviceRegistry) MonitoringStale(threshold time.Duration) bool {
 func NormalizeSKI(ski string) string {
 	replacer := strings.NewReplacer(" ", "", "\t", "", "\n", "", "\r", "", ":", "", "-", "")
 	return strings.ToUpper(replacer.Replace(strings.TrimSpace(ski)))
+}
+
+// ShortSKI returns a normalized, redacted SKI suitable for log messages.
+func ShortSKI(ski string) string {
+	ski = NormalizeSKI(ski)
+	if len(ski) <= 6 {
+		return "…" + ski
+	}
+	return "…" + ski[len(ski)-6:]
 }
 
 func (r *DeviceRegistry) AddDevice(ski string, info DeviceInfo) {
@@ -178,6 +279,7 @@ func (r *DeviceRegistry) RemoveDevice(ski string) {
 	r.mu.Lock()
 	ski = NormalizeSKI(ski)
 	delete(r.devices, ski)
+	delete(r.monitoring, ski)
 	r.mu.Unlock()
 }
 

--- a/eebus-bridge/internal/eebus/registry_test.go
+++ b/eebus-bridge/internal/eebus/registry_test.go
@@ -1,6 +1,7 @@
 package eebus_test
 
 import (
+	"reflect"
 	"testing"
 	"time"
 
@@ -8,6 +9,18 @@ import (
 	"github.com/enbility/spine-go/mocks"
 	"github.com/volschin/eebus-bridge/internal/eebus"
 )
+
+type fakeClock struct {
+	now time.Time
+}
+
+func (c *fakeClock) Now() time.Time {
+	return c.now
+}
+
+func (c *fakeClock) Advance(duration time.Duration) {
+	c.now = c.now.Add(duration)
+}
 
 func TestRegistryAddAndLookup(t *testing.T) {
 	reg := eebus.NewDeviceRegistry()
@@ -116,6 +129,12 @@ func TestNormalizeSKI(t *testing.T) {
 	}
 }
 
+func TestShortSKI(t *testing.T) {
+	if got, want := eebus.ShortSKI("ab:cd:ef:12:34"), "…EF1234"; got != want {
+		t.Errorf("ShortSKI() = %q, want %q", got, want)
+	}
+}
+
 func TestRegistrySKINormalizationConsistency(t *testing.T) {
 	reg := eebus.NewDeviceRegistry()
 
@@ -193,29 +212,104 @@ func TestRegistryEntityHelpersEmpty(t *testing.T) {
 	}
 }
 
-func TestMonitoringStaleNoTrustedDevice(t *testing.T) {
-	reg := eebus.NewDeviceRegistry()
-	if reg.MonitoringStale(0) {
-		t.Error("MonitoringStale should be false with no trusted device, regardless of threshold")
+func TestStaleDevicesNoConnectedDevice(t *testing.T) {
+	clock := &fakeClock{now: time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)}
+	reg := eebus.NewDeviceRegistryWithClock(clock)
+
+	clock.Advance(24 * time.Hour)
+	if got := reg.StaleDevices(time.Minute, time.Minute); len(got) != 0 {
+		t.Errorf("StaleDevices() = %v, want none with no connected device", got)
 	}
 }
 
-func TestMonitoringStaleWithinThreshold(t *testing.T) {
-	reg := eebus.NewDeviceRegistry()
-	reg.AddDevice("ski-1", eebus.DeviceInfo{Brand: "Vaillant"})
-	reg.RecordMonitoringSuccess()
+func TestStaleDevicesWithinThreshold(t *testing.T) {
+	clock := &fakeClock{now: time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)}
+	reg := eebus.NewDeviceRegistryWithClock(clock)
+	reg.MarkConnected("ski-1")
+	reg.RecordMonitoringSuccess("ski-1")
 
-	if reg.MonitoringStale(time.Minute) {
-		t.Error("MonitoringStale should be false right after a recorded success")
+	clock.Advance(3 * time.Minute)
+	if got := reg.StaleDevices(10*time.Minute, 2*time.Minute); len(got) != 0 {
+		t.Errorf("StaleDevices() = %v, want none within the success threshold", got)
 	}
 }
 
-func TestMonitoringStaleExceedsThreshold(t *testing.T) {
-	reg := eebus.NewDeviceRegistry()
-	reg.AddDevice("ski-1", eebus.DeviceInfo{Brand: "Vaillant"})
-	reg.RecordMonitoringSuccess()
+func TestStaleDevicesExceedsThreshold(t *testing.T) {
+	clock := &fakeClock{now: time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)}
+	reg := eebus.NewDeviceRegistryWithClock(clock)
+	reg.MarkConnected("ski-1")
+	reg.RecordMonitoringSuccess("ski-1")
 
-	if !reg.MonitoringStale(0) {
-		t.Error("MonitoringStale should be true once elapsed time exceeds a zero threshold")
+	clock.Advance(11 * time.Minute)
+	if got, want := reg.StaleDevices(10*time.Minute, 2*time.Minute), []string{"SKI1"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("StaleDevices() = %v, want %v once the success threshold is exceeded", got, want)
+	}
+}
+
+func TestStaleDevicesSuccessForOneDeviceDoesNotMaskAnother(t *testing.T) {
+	clock := &fakeClock{now: time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)}
+	reg := eebus.NewDeviceRegistryWithClock(clock)
+	reg.MarkConnected("aa:aa:aa")
+	reg.MarkConnected("bb:bb:bb")
+	reg.RecordMonitoringSuccess("aa-aa-aa")
+
+	clock.Advance(3 * time.Minute)
+	if got, want := reg.StaleDevices(10*time.Minute, 2*time.Minute), []string{"BBBBBB"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("StaleDevices() = %v, want only device B (%v)", got, want)
+	}
+}
+
+func TestStaleDevicesIgnoresDisconnectedDevice(t *testing.T) {
+	clock := &fakeClock{now: time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)}
+	reg := eebus.NewDeviceRegistryWithClock(clock)
+	reg.MarkConnected("ski-1")
+
+	clock.Advance(11 * time.Minute)
+	reg.MarkDisconnected("ski-1")
+	if got := reg.StaleDevices(10*time.Minute, 2*time.Minute); len(got) != 0 {
+		t.Errorf("StaleDevices() = %v, want none after a clean disconnect", got)
+	}
+}
+
+func TestStaleDevicesReconnectStartsFreshGracePeriod(t *testing.T) {
+	clock := &fakeClock{now: time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)}
+	reg := eebus.NewDeviceRegistryWithClock(clock)
+	reg.MarkConnected("ski-1")
+
+	clock.Advance(3 * time.Minute)
+	if got, want := reg.StaleDevices(10*time.Minute, 2*time.Minute), []string{"SKI1"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("StaleDevices() before reconnect = %v, want %v", got, want)
+	}
+
+	reg.MarkDisconnected("ski-1")
+	reg.MarkConnected("ski-1")
+	if got := reg.StaleDevices(10*time.Minute, 2*time.Minute); len(got) != 0 {
+		t.Fatalf("StaleDevices() immediately after reconnect = %v, want fresh grace period", got)
+	}
+
+	clock.Advance(3 * time.Minute)
+	if got, want := reg.StaleDevices(10*time.Minute, 2*time.Minute), []string{"SKI1"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("StaleDevices() after reconnect grace = %v, want stale again (%v)", got, want)
+	}
+}
+
+func TestStaleDevicesReconnectRetainsLastSuccessOnlyForDiagnostics(t *testing.T) {
+	clock := &fakeClock{now: time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)}
+	reg := eebus.NewDeviceRegistryWithClock(clock)
+	reg.MarkConnected("ski-1")
+	reg.RecordMonitoringSuccess("ski-1")
+
+	clock.Advance(time.Minute)
+	reg.MarkDisconnected("ski-1")
+	reg.MarkConnected("ski-1")
+	clock.Advance(3 * time.Minute)
+
+	// The old success is younger than the steady-state threshold but must not
+	// satisfy the new connection once its fresh grace period has elapsed.
+	if got, want := reg.StaleDevices(10*time.Minute, 2*time.Minute), []string{"SKI1"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("StaleDevices() = %v, want %v without a success after reconnect", got, want)
+	}
+	if age, ok := reg.MonitoringLastSuccessAge("s:k-i 1"); !ok || age != 4*time.Minute {
+		t.Errorf("MonitoringLastSuccessAge() = (%s, %t), want (4m, true)", age, ok)
 	}
 }

--- a/eebus-bridge/internal/grpc/monitoring_service.go
+++ b/eebus-bridge/internal/grpc/monitoring_service.go
@@ -357,7 +357,17 @@ func (s *MonitoringService) resolveEntity(ski string) (spineapi.EntityRemoteInte
 		}
 		if resolution.Entity != nil {
 			if s.registry != nil {
-				s.registry.RecordMonitoringSuccess()
+				// ski can be empty, or normalize to empty (whitespace/display
+				// separators only), on the single-device convenience path
+				// (EntityResolution resolves it via CompatibleEntity); fall
+				// back to the resolved entity's own device SKI so the
+				// per-device watchdog state lands on the real device instead
+				// of an empty-string key.
+				recordSKI := eebus.NormalizeSKI(ski)
+				if recordSKI == "" && resolution.Entity.Device() != nil {
+					recordSKI = resolution.Entity.Device().Ski()
+				}
+				s.registry.RecordMonitoringSuccess(recordSKI)
 			}
 			return resolution.Entity, nil
 		}

--- a/eebus-bridge/internal/grpc/server.go
+++ b/eebus-bridge/internal/grpc/server.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net"
 	"sync"
+	"time"
 
 	"github.com/volschin/eebus-bridge/internal/config"
 	"google.golang.org/grpc"
@@ -11,6 +12,15 @@ import (
 	"google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/reflection"
 )
+
+// gracefulStopTimeout bounds how long Stop waits for in-flight RPCs (notably
+// HA's long-lived SubscribeMeasurements/SubscribeLPCEvents/SubscribeDeviceEvents
+// streams) to drain before forcing the connection closed. Without a bound,
+// GracefulStop blocks until every open stream's context is canceled by its
+// client, which HA's local_push streams never do on their own — a controlled
+// shutdown (SIGTERM or the RF-06 watchdog) would then hang indefinitely
+// instead of restarting.
+const gracefulStopTimeout = 5 * time.Second
 
 type Server struct {
 	grpcServer *grpc.Server
@@ -92,5 +102,15 @@ func (s *Server) Addr() string {
 }
 
 func (s *Server) Stop() {
-	s.grpcServer.GracefulStop()
+	done := make(chan struct{})
+	go func() {
+		s.grpcServer.GracefulStop()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(gracefulStopTimeout):
+		s.grpcServer.Stop()
+		<-done
+	}
 }

--- a/eebus-bridge/internal/grpc/server_test.go
+++ b/eebus-bridge/internal/grpc/server_test.go
@@ -43,3 +43,53 @@ func TestServerStartStop(t *testing.T) {
 
 	srv.Stop()
 }
+
+// TestServerStopReturnsWithOpenStream guards against a regression where Stop
+// blocks forever behind grpc.Server.GracefulStop when a client holds a
+// long-lived stream open (e.g. HA's SubscribeMeasurements) and never cancels
+// it — exactly what a controlled shutdown (SIGTERM, RF-06 watchdog restart)
+// must not depend on.
+func TestServerStopReturnsWithOpenStream(t *testing.T) {
+	srv := bridgegrpc.NewServer("127.0.0.1", 0, false)
+
+	go func() {
+		if err := srv.Start(); err != nil {
+			t.Logf("server stopped: %v", err)
+		}
+	}()
+
+	time.Sleep(100 * time.Millisecond)
+	addr := srv.Addr()
+	if addr == "" {
+		t.Fatal("server has no address")
+	}
+
+	conn, err := grpc.NewClient(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("dial failed: %v", err)
+	}
+	defer conn.Close()
+
+	client := grpc_health_v1.NewHealthClient(conn)
+	// Watch is a server-streaming RPC; leaving its context uncancelled
+	// simulates a client (HA) that never tears down its subscribe stream.
+	stream, err := client.Watch(context.Background(), &grpc_health_v1.HealthCheckRequest{})
+	if err != nil {
+		t.Fatalf("watch failed: %v", err)
+	}
+	if _, err := stream.Recv(); err != nil {
+		t.Fatalf("initial watch recv failed: %v", err)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		srv.Stop()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("Stop() did not return within 10s with an open stream; GracefulStop is hanging")
+	}
+}


### PR DESCRIPTION
## Summary
- Per-SKI monitoring/connection state in `DeviceRegistry` (injected `Clock`, zero `time.Sleep` in tests) replaces the global single-timestamp watchdog: one device's success can no longer mask another device's staleness, a clean disconnect stops contributing to staleness, and reconnect starts a fresh grace period.
- Watchdog goroutine (`cmd/eebus-bridge/main.go`) no longer calls `log.Fatalf` directly; it signals a shutdown channel that runs the same cleanup as SIGINT/SIGTERM, then exits non-zero.
- Fixes 2 issues found by independent Codex review of this diff:
  - `Server.Stop()` used unbounded `GracefulStop()`, which blocks forever behind HA's long-lived subscribe streams — the watchdog's controlled shutdown could hang indefinitely instead of restarting. Now bounded (5s) with a hard `Stop()` fallback, covered by a new regression test that holds a stream open.
  - `RecordMonitoringSuccess`'s empty-SKI fallback path compared the raw SKI instead of the normalized one.

Implements RF-06 from `docs/refactoring-optimization-spec.md`, all 4 spec acceptance criteria covered by tests.

## Test plan
- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `go test -race ./...` (all packages, including gRPC integration tests)
- [x] New regression test `TestServerStopReturnsWithOpenStream` proves `Stop()` returns within bounds with an open stream instead of hanging