### PR TITLE
feat: RF-05 PR1 extract grpc_client.py, fix channel-creation race

### DIFF
--- a/custom_components/eebus/coordinator.py
+++ b/custom_components/eebus/coordinator.py
@@ -32,7 +32,14 @@ from homeassistant.helpers.event import (
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import SECURITY_MODE_LOOPBACK
-from .security import create_grpc_channel
+from .grpc_client import (
+    RPC_TIMEOUT,
+    WRITE_VALIDATION_CODES,
+    GrpcChannelManager,
+    is_not_found as _is_not_found,
+    is_unimplemented as _is_unimplemented,
+    rpc_error_text as _rpc_error_text,
+)
 
 if TYPE_CHECKING:
     from . import proto_stubs
@@ -57,16 +64,8 @@ SOC_UNIT_TO_PCT: dict[str, float] = {PERCENTAGE: 1.0}
 # Event streams deliver push updates; polling only reconciles state the
 # streams cannot carry (scoped energy, heartbeat, support flags).
 POLL_INTERVAL = timedelta(minutes=5)
-RPC_TIMEOUT = 10
 RE_REGISTER_NOT_FOUND_STREAK = 4
 STREAM_RETRY_SECONDS = 30
-# Write-RPC status codes surfaced to the user as a validation error instead of
-# a raw AioRpcError traceback (device-side rejections).
-WRITE_VALIDATION_CODES = (
-    grpc.StatusCode.INVALID_ARGUMENT,
-    grpc.StatusCode.FAILED_PRECONDITION,
-    grpc.StatusCode.NOT_FOUND,
-)
 
 
 def _normalize_ski(ski: str) -> str:
@@ -98,21 +97,6 @@ FLAT_MEASUREMENT_TYPE_TO_KEY: dict[str, str] = {
     "compressor_power": "compressor_power_w",
 }
 FLAT_MEASUREMENT_KEYS: tuple[str, ...] = tuple(FLAT_MEASUREMENT_TYPE_TO_KEY.values())
-
-
-def _is_unimplemented(err: grpc.aio.AioRpcError) -> bool:
-    """Return True when gRPC reports method/use case is not implemented."""
-    return err.code() == grpc.StatusCode.UNIMPLEMENTED
-
-
-def _is_not_found(err: grpc.aio.AioRpcError) -> bool:
-    """Return True when gRPC reports missing entity/data for requested SKI."""
-    return err.code() == grpc.StatusCode.NOT_FOUND
-
-
-def _rpc_error_text(err: grpc.aio.AioRpcError) -> str:
-    """Build compact debug output for gRPC errors."""
-    return f"code={err.code().name} details={err.details()}"
 
 
 def _dhw_system_function_to_dict(state: Any) -> dict[str, Any]:
@@ -332,7 +316,9 @@ class EebusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self.battery_charged_energy_entity = battery_charged_energy_entity
         self.battery_discharged_energy_entity = battery_discharged_energy_entity
         self.battery_soc_entity = battery_soc_entity
-        self._channel: grpc.aio.Channel | None = None
+        self._channel_manager = GrpcChannelManager(
+            host, port, security_mode, tls_ca_certificate, auth_token
+        )
         self._stream_tasks: list[asyncio.Task[None]] = []
         self._provider_pushers: list[_ProviderPusher] = []
         self._provider_push_failing: dict[str, bool] = {}
@@ -349,15 +335,7 @@ class EebusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
     async def _ensure_channel(self) -> grpc.aio.Channel:
         """Create or return existing gRPC channel."""
-        if self._channel is None:
-            self._channel = create_grpc_channel(
-                self.host,
-                self.port,
-                self.security_mode,
-                self.tls_ca_certificate,
-                self.auth_token,
-            )
-        return self._channel
+        return await self._channel_manager.ensure_channel()
 
     async def _async_update_data(self) -> dict[str, Any]:
         """Fetch data via gRPC polling."""
@@ -530,9 +508,7 @@ class EebusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
             return data
         except grpc.aio.AioRpcError as err:
-            if self._channel is not None:
-                await self._channel.close(None)
-                self._channel = None
+            await self._channel_manager.invalidate()
             self._not_found_streak = 0
 
             if err.code() == grpc.StatusCode.UNAUTHENTICATED:
@@ -1558,6 +1534,4 @@ class EebusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         for task in self._stream_tasks:
             task.cancel()
         self._stream_tasks.clear()
-        if self._channel is not None:
-            await self._channel.close(None)
-            self._channel = None
+        await self._channel_manager.close()

--- a/custom_components/eebus/grpc_client.py
+++ b/custom_components/eebus/grpc_client.py
@@ -1,0 +1,80 @@
+"""gRPC client lifecycle and error helpers for the EEBUS integration."""
+
+from __future__ import annotations
+
+import asyncio
+
+import grpc
+import grpc.aio
+
+from .security import create_grpc_channel
+
+RPC_TIMEOUT = 10
+
+# Write-RPC status codes surfaced to the user as a validation error instead of
+# a raw AioRpcError traceback (device-side rejections).
+WRITE_VALIDATION_CODES = (
+    grpc.StatusCode.INVALID_ARGUMENT,
+    grpc.StatusCode.FAILED_PRECONDITION,
+    grpc.StatusCode.NOT_FOUND,
+)
+
+
+def is_unimplemented(err: grpc.aio.AioRpcError) -> bool:
+    """Return True when gRPC reports method/use case is not implemented."""
+    return err.code() == grpc.StatusCode.UNIMPLEMENTED
+
+
+def is_not_found(err: grpc.aio.AioRpcError) -> bool:
+    """Return True when gRPC reports missing entity/data for requested SKI."""
+    return err.code() == grpc.StatusCode.NOT_FOUND
+
+
+def rpc_error_text(err: grpc.aio.AioRpcError) -> str:
+    """Build compact debug output for gRPC errors."""
+    return f"code={err.code().name} details={err.details()}"
+
+
+class GrpcChannelManager:
+    """Serialize creation and invalidation of the bridge gRPC channel."""
+
+    def __init__(
+        self,
+        host: str,
+        port: int,
+        security_mode: str,
+        tls_ca_certificate: str | None,
+        auth_token: str | None,
+    ) -> None:
+        """Initialize the channel manager with bridge connection settings."""
+        self._host = host
+        self._port = port
+        self._security_mode = security_mode
+        self._tls_ca_certificate = tls_ca_certificate
+        self._auth_token = auth_token
+        self._channel: grpc.aio.Channel | None = None
+        self._lock = asyncio.Lock()
+
+    async def ensure_channel(self) -> grpc.aio.Channel:
+        """Create the channel once and return it to all concurrent callers."""
+        async with self._lock:
+            if self._channel is None:
+                self._channel = create_grpc_channel(
+                    self._host,
+                    self._port,
+                    self._security_mode,
+                    self._tls_ca_certificate,
+                    self._auth_token,
+                )
+            return self._channel
+
+    async def invalidate(self) -> None:
+        """Close and discard the current channel, if one exists."""
+        async with self._lock:
+            if self._channel is not None:
+                await self._channel.close(None)
+                self._channel = None
+
+    async def close(self) -> None:
+        """Close the current channel during integration shutdown."""
+        await self.invalidate()

--- a/custom_components/eebus/tests/test_coordinator.py
+++ b/custom_components/eebus/tests/test_coordinator.py
@@ -52,21 +52,22 @@ def test_coordinator_init():
     coordinator.host = "192.168.1.100"
     coordinator.port = 50051
     coordinator.ski = "test-ski"
-    coordinator._channel = None
+    coordinator._channel_manager = MagicMock()
     coordinator._stream_tasks = []
     coordinator._was_unavailable = False
 
     assert coordinator.host == "192.168.1.100"
     assert coordinator.port == 50051
     assert coordinator.ski == "test-ski"
-    assert coordinator._channel is None
+    assert coordinator._channel_manager is not None
     assert coordinator._was_unavailable is False
 
 
 async def test_unauthenticated_poll_starts_reauthentication():
     """An invalid bridge token is surfaced as a config-entry auth failure."""
     coordinator = EebusCoordinator.__new__(EebusCoordinator)
-    coordinator._channel = None
+    coordinator._channel_manager = MagicMock()
+    coordinator._channel_manager.invalidate = AsyncMock()
     coordinator._not_found_streak = 0
     coordinator._was_unavailable = False
     coordinator._ensure_channel = AsyncMock(return_value=MagicMock())
@@ -83,6 +84,19 @@ async def test_unauthenticated_poll_starts_reauthentication():
     with patch.object(proto_stubs, "device_service_stub", return_value=stub):
         with pytest.raises(ConfigEntryAuthFailed):
             await coordinator._async_update_data()
+
+    coordinator._channel_manager.invalidate.assert_awaited_once_with()
+
+
+async def test_ensure_channel_delegates_to_channel_manager():
+    """The coordinator keeps its patchable channel-acquisition seam."""
+    coordinator = EebusCoordinator.__new__(EebusCoordinator)
+    channel = MagicMock()
+    coordinator._channel_manager = MagicMock()
+    coordinator._channel_manager.ensure_channel = AsyncMock(return_value=channel)
+
+    assert await coordinator._ensure_channel() is channel
+    coordinator._channel_manager.ensure_channel.assert_awaited_once_with()
 
 
 def _make_coordinator(ski="test-ski", data=None):

--- a/custom_components/eebus/tests/test_grid_push.py
+++ b/custom_components/eebus/tests/test_grid_push.py
@@ -1,7 +1,7 @@
 """Tests for the coordinator's MGCP grid-data push path."""
 
 from types import SimpleNamespace
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 from custom_components.eebus import proto_stubs
 from custom_components.eebus.coordinator import (
@@ -26,7 +26,7 @@ def _make_grid_coordinator(states, power=None, feed_in=None, consumed=None):
     hass = MagicMock()
     hass.states.get = lambda entity_id: states.get(entity_id)
     coordinator.hass = hass
-    coordinator._channel = object()  # _ensure_channel returns it without dialing
+    coordinator._ensure_channel = AsyncMock(return_value=object())
     return coordinator
 
 
@@ -61,7 +61,7 @@ def test_read_sensor_value_unavailable_returns_none():
 async def test_push_skips_without_power_entity():
     """No grid power mapped: push is a no-op and never builds a stub."""
     coordinator = _make_grid_coordinator({}, power=None)
-    coordinator._channel = None  # would fail if a channel were dialed
+    coordinator._ensure_channel = AsyncMock(side_effect=AssertionError("unexpected dial"))
     await coordinator.async_push_grid_data()  # must not raise
 
 

--- a/custom_components/eebus/tests/test_grpc_client.py
+++ b/custom_components/eebus/tests/test_grpc_client.py
@@ -1,0 +1,95 @@
+"""Tests for shared gRPC client lifecycle management."""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, call, patch
+
+import grpc
+from grpc.aio import AioRpcError, Metadata
+
+from custom_components.eebus.grpc_client import (
+    GrpcChannelManager,
+    is_not_found,
+    is_unimplemented,
+    rpc_error_text,
+)
+
+
+async def test_concurrent_ensure_channel_creates_one_channel():
+    """Six simultaneous stream callers share one channel creation."""
+    channel = MagicMock()
+    manager = GrpcChannelManager("localhost", 50051, "loopback", None, None)
+
+    with patch(
+        "custom_components.eebus.grpc_client.create_grpc_channel",
+        return_value=channel,
+    ) as create_channel:
+        await manager._lock.acquire()
+        tasks = [asyncio.create_task(manager.ensure_channel()) for _ in range(6)]
+        await asyncio.sleep(0)
+        manager._lock.release()
+        channels = await asyncio.gather(*tasks)
+
+    create_channel.assert_called_once_with("localhost", 50051, "loopback", None, None)
+    assert all(result is channel for result in channels)
+
+
+async def test_invalidate_racing_ensure_returns_fresh_channel():
+    """Acquisition waits for invalidation and never returns the closing channel."""
+    close_started = asyncio.Event()
+    finish_close = asyncio.Event()
+
+    async def slow_close(_grace):
+        close_started.set()
+        await finish_close.wait()
+
+    first = MagicMock()
+    first.close = AsyncMock(side_effect=slow_close)
+    second = MagicMock()
+    second.close = AsyncMock()
+    manager = GrpcChannelManager("localhost", 50051, "loopback", None, None)
+
+    with patch(
+        "custom_components.eebus.grpc_client.create_grpc_channel",
+        side_effect=[first, second],
+    ) as create_channel:
+        assert await manager.ensure_channel() is first
+        invalidate_task = asyncio.create_task(manager.invalidate())
+        await close_started.wait()
+        ensure_task = asyncio.create_task(manager.ensure_channel())
+        await asyncio.sleep(0)
+
+        assert ensure_task.done() is False
+        finish_close.set()
+        await invalidate_task
+        assert await ensure_task is second
+        await manager.close()
+        await manager.close()
+
+    assert create_channel.call_args_list == [
+        call("localhost", 50051, "loopback", None, None),
+        call("localhost", 50051, "loopback", None, None),
+    ]
+    first.close.assert_awaited_once_with(None)
+    second.close.assert_awaited_once_with(None)
+
+
+def test_rpc_error_helpers():
+    """gRPC status helpers retain the coordinator's previous behavior."""
+    unimplemented = AioRpcError(
+        grpc.StatusCode.UNIMPLEMENTED,
+        Metadata(),
+        Metadata(),
+        details="method unavailable",
+    )
+    not_found = AioRpcError(
+        grpc.StatusCode.NOT_FOUND,
+        Metadata(),
+        Metadata(),
+        details="device missing",
+    )
+
+    assert is_unimplemented(unimplemented) is True
+    assert is_unimplemented(not_found) is False
+    assert is_not_found(not_found) is True
+    assert is_not_found(unimplemented) is False
+    assert rpc_error_text(not_found) == "code=NOT_FOUND details=device missing"

--- a/custom_components/eebus/tests/test_provider_push.py
+++ b/custom_components/eebus/tests/test_provider_push.py
@@ -3,7 +3,7 @@
 import asyncio
 import logging
 from types import SimpleNamespace
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import grpc
 from grpc.aio import AioRpcError, Metadata
@@ -131,7 +131,7 @@ async def test_provider_push_failure_warning_is_rate_limited(monkeypatch, caplog
                 raise outcome
 
     coordinator = EebusCoordinator.__new__(EebusCoordinator)
-    coordinator._channel = object()
+    coordinator._ensure_channel = AsyncMock(return_value=object())
     coordinator._provider_push_failing = {}
     monkeypatch.setattr(
         proto_stubs,

--- a/custom_components/eebus/tests/test_visualization_push.py
+++ b/custom_components/eebus/tests/test_visualization_push.py
@@ -1,7 +1,7 @@
 """Tests for the coordinator's VAPD/VABD display-data push paths."""
 
 from types import SimpleNamespace
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 from custom_components.eebus import proto_stubs
 from custom_components.eebus.coordinator import (
@@ -30,7 +30,7 @@ def _make_coordinator(states):
     hass = MagicMock()
     hass.states.get = lambda entity_id: states.get(entity_id)
     coordinator.hass = hass
-    coordinator._channel = object()  # _ensure_channel returns it without dialing
+    coordinator._ensure_channel = AsyncMock(return_value=object())
     return coordinator
 
 
@@ -79,7 +79,7 @@ def test_read_sensor_value_enforces_range():
 async def test_pv_push_skips_without_power_entity():
     """No PV power mapped: push is a no-op and never builds a stub."""
     coordinator = _make_coordinator({})
-    coordinator._channel = None  # would fail if a channel were dialed
+    coordinator._ensure_channel = AsyncMock(side_effect=AssertionError("unexpected dial"))
     await coordinator.async_push_pv_data()  # must not raise
 
 
@@ -119,7 +119,7 @@ async def test_pv_push_publishes_power_and_optional_fields(monkeypatch):
 async def test_battery_push_skips_without_power_entity():
     """No battery power mapped: push is a no-op and never builds a stub."""
     coordinator = _make_coordinator({})
-    coordinator._channel = None  # would fail if a channel were dialed
+    coordinator._ensure_channel = AsyncMock(side_effect=AssertionError("unexpected dial"))
     await coordinator.async_push_battery_data()  # must not raise
 
 


### PR DESCRIPTION
## Summary
- First PR of RF-05's mandated small-PRs sequence (`docs/refactoring-optimization-spec.md`) — splits channel lifecycle and gRPC error classification out of `coordinator.py` (1563 lines) into a new `grpc_client.py`.
- Fixes an unlocked check-then-act race in the old `_ensure_channel`: `async_start_streams` launches 6 concurrent background tasks (device/LPC/measurement/DHW/DHW-sysfn/room-heating event streams), each calling `_ensure_channel()` on connect and every reconnect. All 6 could see `self._channel is None` at once and each construct their own channel — 5 of 6 silently overwritten and leaked. `GrpcChannelManager` now serializes creation/invalidation behind a single `asyncio.Lock`.
- `_ensure_channel` stays a coordinator method (thin delegator to the manager) — two existing tests monkeypatch it per-instance, kept working unchanged.
- `models.py`/`snapshot.py`/`streams.py`/`providers.py` extraction, stream reconnect backoff+jitter, and shutdown task-gathering are explicitly out of scope — separate follow-up PRs per the spec's "small, independently mergeable" mandate.

## Test plan
- [x] `ruff check custom_components/`
- [x] `mypy custom_components/eebus` (strict)
- [x] `PYTHONPATH=. pytest` — 102 passed, no regressions
- [x] New `test_grpc_client.py`: exercises real concurrency (6 tasks queued behind a held lock; invalidate-racing-ensure with controlled event ordering) rather than just sequential calls
- [x] Independent Codex review of the diff — clean, no findings