### PR TITLE
feat: RF-05 PR2 extract streams.py with backoff and bounded shutdown

### DIFF
--- a/custom_components/eebus/coordinator.py
+++ b/custom_components/eebus/coordinator.py
@@ -40,6 +40,7 @@ from .grpc_client import (
     is_unimplemented as _is_unimplemented,
     rpc_error_text as _rpc_error_text,
 )
+from .streams import ConsumeFn, StreamManager
 
 if TYPE_CHECKING:
     from . import proto_stubs
@@ -65,7 +66,6 @@ SOC_UNIT_TO_PCT: dict[str, float] = {PERCENTAGE: 1.0}
 # streams cannot carry (scoped energy, heartbeat, support flags).
 POLL_INTERVAL = timedelta(minutes=5)
 RE_REGISTER_NOT_FOUND_STREAK = 4
-STREAM_RETRY_SECONDS = 30
 
 
 def _normalize_ski(ski: str) -> str:
@@ -319,7 +319,7 @@ class EebusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self._channel_manager = GrpcChannelManager(
             host, port, security_mode, tls_ca_certificate, auth_token
         )
-        self._stream_tasks: list[asyncio.Task[None]] = []
+        self._stream_manager = StreamManager(self.hass, self._channel_manager)
         self._provider_pushers: list[_ProviderPusher] = []
         self._provider_push_failing: dict[str, bool] = {}
         self._was_unavailable: bool = False
@@ -1264,116 +1264,67 @@ class EebusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
     def async_start_streams(self) -> None:
         """Start background tasks consuming bridge event streams."""
-        if self._stream_tasks:
-            return
-        for name, runner in (
-            ("device_events", self._run_device_event_stream),
-            ("lpc_events", self._run_lpc_event_stream),
-            ("measurements", self._run_measurement_stream),
-            ("dhw_events", self._run_dhw_event_stream),
-            ("dhw_sysfn_events", self._run_dhw_sysfn_event_stream),
-            ("room_heating_events", self._run_room_heating_event_stream),
-        ):
-            self._stream_tasks.append(
-                self.hass.async_create_background_task(
-                    runner(), name=f"eebus_{name}_{self.ski}"
-                )
-            )
-
-    async def _run_stream(self, name: str, consume: Any) -> None:
-        """Run a stream consumer with reconnect/backoff until cancelled."""
-        while True:
-            try:
-                channel = await self._ensure_channel()
-                await consume(channel)
-            except asyncio.CancelledError:
-                raise
-            except grpc.aio.AioRpcError as err:
-                if _is_unimplemented(err):
-                    _LOGGER.info(
-                        "EEBUS %s stream not supported by bridge; relying on polling",
-                        name,
-                    )
-                    return
-                _LOGGER.debug(
-                    "EEBUS %s stream ended (%s); retrying in %ss",
-                    name,
-                    _rpc_error_text(err),
-                    STREAM_RETRY_SECONDS,
-                )
-            except Exception:  # noqa: BLE001
-                _LOGGER.exception("EEBUS %s stream failed; retrying", name)
-            await asyncio.sleep(STREAM_RETRY_SECONDS)
-
-    async def _run_device_event_stream(self) -> None:
-        from . import proto_stubs
-
         async def consume(channel: grpc.aio.Channel) -> None:
+            from . import proto_stubs
+
             stub = proto_stubs.device_service_stub(channel)
             async for event in stub.SubscribeDeviceEvents(proto_stubs.Empty()):
                 self._handle_device_event(event)
 
-        await self._run_stream("device", consume)
+        async def consume_lpc(channel: grpc.aio.Channel) -> None:
+            from . import proto_stubs
 
-    async def _run_lpc_event_stream(self) -> None:
-        from . import proto_stubs
-
-        async def consume(channel: grpc.aio.Channel) -> None:
             stub = proto_stubs.lpc_service_stub(channel)
             async for event in stub.SubscribeLPCEvents(
                 proto_stubs.DeviceRequest(ski=self.ski)
             ):
                 self._handle_lpc_event(event)
 
-        await self._run_stream("LPC", consume)
+        async def consume_measurements(channel: grpc.aio.Channel) -> None:
+            from . import proto_stubs
 
-    async def _run_measurement_stream(self) -> None:
-        from . import proto_stubs
-
-        async def consume(channel: grpc.aio.Channel) -> None:
             stub = proto_stubs.monitoring_service_stub(channel)
             async for event in stub.SubscribeMeasurements(
                 proto_stubs.DeviceRequest(ski=self.ski)
             ):
                 self._handle_measurement_event(event)
 
-        await self._run_stream("measurement", consume)
+        async def consume_dhw(channel: grpc.aio.Channel) -> None:
+            from . import proto_stubs
 
-    async def _run_dhw_event_stream(self) -> None:
-        from . import proto_stubs
-
-        async def consume(channel: grpc.aio.Channel) -> None:
             stub = proto_stubs.dhw_service_stub(channel)
             async for event in stub.SubscribeDHWEvents(
                 proto_stubs.DeviceRequest(ski=self.ski)
             ):
                 self._handle_dhw_event(event)
 
-        await self._run_stream("DHW", consume)
+        async def consume_dhw_sysfn(channel: grpc.aio.Channel) -> None:
+            from . import proto_stubs
 
-    async def _run_dhw_sysfn_event_stream(self) -> None:
-        from . import proto_stubs
-
-        async def consume(channel: grpc.aio.Channel) -> None:
             stub = proto_stubs.dhw_service_stub(channel)
             async for event in stub.SubscribeDHWSystemFunctionEvents(
                 proto_stubs.DeviceRequest(ski=self.ski)
             ):
                 self._handle_dhw_sysfn_event(event)
 
-        await self._run_stream("DHW system function", consume)
+        async def consume_room_heating(channel: grpc.aio.Channel) -> None:
+            from . import proto_stubs
 
-    async def _run_room_heating_event_stream(self) -> None:
-        from . import proto_stubs
-
-        async def consume(channel: grpc.aio.Channel) -> None:
             stub = proto_stubs.hvac_service_stub(channel)
             async for event in stub.SubscribeRoomHeatingEvents(
                 proto_stubs.DeviceRequest(ski=self.ski)
             ):
                 self._handle_room_heating_event(event)
 
-        await self._run_stream("room heating", consume)
+        streams: dict[str, ConsumeFn] = {
+            "device_events": consume,
+            "lpc_events": consume_lpc,
+            "measurements": consume_measurements,
+            "dhw_events": consume_dhw,
+            "dhw_sysfn_events": consume_dhw_sysfn,
+            "room_heating_events": consume_room_heating,
+        }
+        self._stream_manager.start(streams, f"eebus_{{name}}_{self.ski}")
 
     def _event_matches(self, event_ski: str) -> bool:
         """Return True when an event applies to the configured device."""
@@ -1531,7 +1482,5 @@ class EebusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         for pusher in self._provider_pushers:
             await pusher.stop()
         self._provider_pushers.clear()
-        for task in self._stream_tasks:
-            task.cancel()
-        self._stream_tasks.clear()
+        await self._stream_manager.stop()
         await self._channel_manager.close()

--- a/custom_components/eebus/streams.py
+++ b/custom_components/eebus/streams.py
@@ -1,0 +1,93 @@
+"""Background gRPC stream consumption with reconnect/backoff for the EEBUS integration."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import random
+from collections.abc import Awaitable, Callable
+
+import grpc
+import grpc.aio
+from homeassistant.core import HomeAssistant
+
+from .grpc_client import GrpcChannelManager, is_unimplemented, rpc_error_text
+
+_LOGGER = logging.getLogger(__name__)
+
+STREAM_BACKOFF_BASE_SECONDS = 2.0
+STREAM_BACKOFF_MAX_SECONDS = 60.0
+STREAM_BACKOFF_JITTER_SECONDS = 3.0
+
+ConsumeFn = Callable[[grpc.aio.Channel], Awaitable[None]]
+
+
+class StreamManager:
+    """Own the coordinator's long-lived event-stream task lifecycle."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        channel_manager: GrpcChannelManager,
+        sleep: Callable[[float], Awaitable[None]] = asyncio.sleep,
+        jitter: Callable[[float, float], float] = random.uniform,
+    ) -> None:
+        """Initialize stream lifecycle dependencies."""
+        self._hass = hass
+        self._channel_manager = channel_manager
+        self._sleep = sleep
+        self._jitter = jitter
+        self._tasks: list[asyncio.Task[None]] = []
+
+    def start(self, streams: dict[str, ConsumeFn], task_name_prefix: str) -> None:
+        """Launch one background task per named stream, unless already started."""
+        if self._tasks:
+            return
+        for name, consume in streams.items():
+            self._tasks.append(
+                self._hass.async_create_background_task(
+                    self._run_stream(name, consume),
+                    name=task_name_prefix.format(name, name=name),
+                )
+            )
+
+    async def stop(self) -> None:
+        """Cancel every stream task and await completion before returning."""
+        for task in self._tasks:
+            task.cancel()
+        await asyncio.gather(*self._tasks, return_exceptions=True)
+        self._tasks.clear()
+
+    async def _run_stream(self, name: str, consume: ConsumeFn) -> None:
+        """Consume one stream with reconnect/backoff until cancelled."""
+        attempt = 0
+        while True:
+            try:
+                channel = await self._channel_manager.ensure_channel()
+                await consume(channel)
+                attempt = 0
+            except asyncio.CancelledError:
+                raise
+            except grpc.aio.AioRpcError as err:
+                if is_unimplemented(err):
+                    _LOGGER.info(
+                        "EEBUS %s stream not supported by bridge; relying on polling",
+                        name,
+                    )
+                    return
+                attempt += 1
+                _LOGGER.debug(
+                    "EEBUS %s stream ended (%s); scheduling retry",
+                    name,
+                    rpc_error_text(err),
+                )
+            except Exception:  # noqa: BLE001
+                attempt += 1
+                _LOGGER.exception("EEBUS %s stream failed; scheduling retry", name)
+
+            delay = min(
+                STREAM_BACKOFF_BASE_SECONDS * (2**attempt),
+                STREAM_BACKOFF_MAX_SECONDS,
+            ) + self._jitter(0, STREAM_BACKOFF_JITTER_SECONDS)
+            _LOGGER.debug("Retrying EEBUS %s stream in %.1fs", name, delay)
+            await self._sleep(delay)

--- a/custom_components/eebus/tests/test_coordinator.py
+++ b/custom_components/eebus/tests/test_coordinator.py
@@ -4,7 +4,7 @@ import asyncio
 import inspect
 from datetime import timedelta
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import grpc
 import pytest
@@ -53,13 +53,14 @@ def test_coordinator_init():
     coordinator.port = 50051
     coordinator.ski = "test-ski"
     coordinator._channel_manager = MagicMock()
-    coordinator._stream_tasks = []
+    coordinator._stream_manager = MagicMock()
     coordinator._was_unavailable = False
 
     assert coordinator.host == "192.168.1.100"
     assert coordinator.port == 50051
     assert coordinator.ski == "test-ski"
     assert coordinator._channel_manager is not None
+    assert coordinator._stream_manager is not None
     assert coordinator._was_unavailable is False
 
 
@@ -97,6 +98,47 @@ async def test_ensure_channel_delegates_to_channel_manager():
 
     assert await coordinator._ensure_channel() is channel
     coordinator._channel_manager.ensure_channel.assert_awaited_once_with()
+
+
+def test_start_streams_delegates_all_consumers_to_stream_manager():
+    """The coordinator supplies all six event consumers to StreamManager."""
+    coordinator = EebusCoordinator.__new__(EebusCoordinator)
+    coordinator.ski = "test-ski"
+    coordinator._stream_manager = MagicMock()
+
+    coordinator.async_start_streams()
+
+    coordinator._stream_manager.start.assert_called_once()
+    streams, task_name_prefix = coordinator._stream_manager.start.call_args.args
+    assert list(streams) == [
+        "device_events",
+        "lpc_events",
+        "measurements",
+        "dhw_events",
+        "dhw_sysfn_events",
+        "room_heating_events",
+    ]
+    assert task_name_prefix == "eebus_{name}_test-ski"
+
+
+async def test_shutdown_stops_streams_before_closing_channel():
+    """Shutdown fully stops stream tasks before closing the shared channel."""
+    coordinator = EebusCoordinator.__new__(EebusCoordinator)
+    coordinator._provider_pushers = []
+    lifecycle = MagicMock()
+    coordinator._stream_manager = MagicMock()
+    coordinator._stream_manager.stop = AsyncMock()
+    coordinator._channel_manager = MagicMock()
+    coordinator._channel_manager.close = AsyncMock()
+    lifecycle.attach_mock(coordinator._stream_manager.stop, "stop_streams")
+    lifecycle.attach_mock(coordinator._channel_manager.close, "close_channel")
+
+    await coordinator.async_shutdown()
+
+    assert lifecycle.mock_calls == [
+        call.stop_streams(),
+        call.close_channel(),
+    ]
 
 
 def _make_coordinator(ski="test-ski", data=None):

--- a/custom_components/eebus/tests/test_streams.py
+++ b/custom_components/eebus/tests/test_streams.py
@@ -1,0 +1,219 @@
+"""Tests for background gRPC stream lifecycle management."""
+
+import asyncio
+from collections.abc import Coroutine
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import grpc
+import pytest
+from grpc.aio import AioRpcError, Metadata
+
+from custom_components.eebus.streams import StreamManager
+
+
+def _rpc_error(code: grpc.StatusCode) -> AioRpcError:
+    """Build an async gRPC error with the requested status code."""
+    return AioRpcError(code, Metadata(), Metadata(), details="stream failed")
+
+
+def _manager(
+    *,
+    sleep: AsyncMock | None = None,
+) -> tuple[StreamManager, MagicMock, AsyncMock]:
+    """Build a stream manager with deterministic lifecycle dependencies."""
+    channel_manager = MagicMock()
+    channel_manager.ensure_channel = AsyncMock(return_value=MagicMock())
+    fake_sleep = sleep or AsyncMock()
+    manager = StreamManager(
+        MagicMock(),
+        channel_manager,
+        sleep=fake_sleep,
+        jitter=lambda _minimum, _maximum: 0.0,
+    )
+    return manager, channel_manager, fake_sleep
+
+
+async def test_stream_abort_backs_off_and_reacquires_channel() -> None:
+    """A failed stream backs off, reacquires the channel, and retries."""
+    manager, channel_manager, sleep = _manager()
+    calls = 0
+
+    async def consume(_channel: grpc.aio.Channel) -> None:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise _rpc_error(grpc.StatusCode.UNAVAILABLE)
+        raise asyncio.CancelledError
+
+    with pytest.raises(asyncio.CancelledError):
+        await manager._run_stream("device_events", consume)
+
+    assert calls == 2
+    assert channel_manager.ensure_channel.await_count == 2
+    sleep.assert_awaited_once_with(4.0)
+
+
+async def test_unimplemented_stream_stops_permanently() -> None:
+    """An unsupported bridge stream returns without sleeping or retrying."""
+    manager, channel_manager, sleep = _manager()
+    consume = AsyncMock(side_effect=_rpc_error(grpc.StatusCode.UNIMPLEMENTED))
+
+    await manager._run_stream("device_events", consume)
+
+    consume.assert_awaited_once()
+    channel_manager.ensure_channel.assert_awaited_once_with()
+    sleep.assert_not_awaited()
+
+
+async def test_normal_completion_backs_off_before_retry() -> None:
+    """A graceful stream end cannot cause a tight restart loop."""
+    manager, _channel_manager, sleep = _manager()
+    calls = 0
+
+    async def consume(_channel: grpc.aio.Channel) -> None:
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            raise asyncio.CancelledError
+
+    with pytest.raises(asyncio.CancelledError):
+        await manager._run_stream("measurements", consume)
+
+    assert calls == 2
+    sleep.assert_awaited_once_with(2.0)
+
+
+async def test_cancellation_during_backoff_propagates() -> None:
+    """Cancellation from the backoff await is never swallowed or retried."""
+    sleep = AsyncMock(side_effect=asyncio.CancelledError)
+    manager, _channel_manager, _sleep = _manager(sleep=sleep)
+    consume = AsyncMock()
+
+    with pytest.raises(asyncio.CancelledError):
+        await manager._run_stream("lpc_events", consume)
+
+    consume.assert_awaited_once()
+    sleep.assert_awaited_once_with(2.0)
+
+
+async def test_backoff_resets_after_successful_reconnect() -> None:
+    """A successful stream completion resets its escalating failure counter."""
+    manager, _channel_manager, sleep = _manager()
+    outcomes: list[BaseException | None] = [
+        _rpc_error(grpc.StatusCode.UNAVAILABLE),
+        RuntimeError("consumer failed"),
+        None,
+        _rpc_error(grpc.StatusCode.UNKNOWN),
+        asyncio.CancelledError(),
+    ]
+
+    async def consume(_channel: grpc.aio.Channel) -> None:
+        outcome = outcomes.pop(0)
+        if outcome is not None:
+            raise outcome
+
+    with pytest.raises(asyncio.CancelledError):
+        await manager._run_stream("dhw_events", consume)
+
+    assert [call.args[0] for call in sleep.await_args_list] == [4.0, 8.0, 2.0, 4.0]
+
+
+async def test_backoff_is_bounded_and_adds_jitter() -> None:
+    """Repeated failures cap the exponential component and retain jitter."""
+    channel_manager = MagicMock()
+    channel_manager.ensure_channel = AsyncMock(return_value=MagicMock())
+    sleep = AsyncMock()
+    jitter = MagicMock(return_value=2.5)
+    manager = StreamManager(
+        MagicMock(),
+        channel_manager,
+        sleep=sleep,
+        jitter=jitter,
+    )
+    outcomes: list[BaseException] = [
+        *[_rpc_error(grpc.StatusCode.UNAVAILABLE) for _ in range(5)],
+        asyncio.CancelledError(),
+    ]
+
+    async def consume(_channel: grpc.aio.Channel) -> None:
+        raise outcomes.pop(0)
+
+    with pytest.raises(asyncio.CancelledError):
+        await manager._run_stream("room_heating_events", consume)
+
+    assert [call.args[0] for call in sleep.await_args_list] == [
+        6.5,
+        10.5,
+        18.5,
+        34.5,
+        62.5,
+    ]
+    assert jitter.call_count == 5
+    jitter.assert_called_with(0, 3.0)
+
+
+class _TaskCreatingHass:
+    """Minimal Home Assistant task-creation seam for lifecycle tests."""
+
+    def __init__(self) -> None:
+        self.task_names: list[str] = []
+
+    def async_create_background_task(
+        self,
+        coro: Coroutine[Any, Any, None],
+        *,
+        name: str,
+    ) -> asyncio.Task[None]:
+        """Create and record a real asyncio task."""
+        self.task_names.append(name)
+        return asyncio.create_task(coro, name=name)
+
+
+async def test_start_is_idempotent_and_preserves_task_names() -> None:
+    """Starting twice creates one task with the established observable name."""
+    hass = _TaskCreatingHass()
+    channel_manager = MagicMock()
+    channel_manager.ensure_channel = AsyncMock(return_value=MagicMock())
+    manager = StreamManager(hass, channel_manager)  # type: ignore[arg-type]
+    started = asyncio.Event()
+
+    async def consume(_channel: grpc.aio.Channel) -> None:
+        started.set()
+        await asyncio.Event().wait()
+
+    streams = {"room_heating_events": consume}
+    manager.start(streams, "eebus_{name}_test-ski")
+    manager.start(streams, "eebus_{name}_test-ski")
+    await started.wait()
+
+    assert hass.task_names == ["eebus_room_heating_events_test-ski"]
+    await manager.stop()
+
+
+async def test_stop_awaits_cancelled_tasks() -> None:
+    """Stop waits until a cancelled consumer has completely unwound."""
+    hass = _TaskCreatingHass()
+    channel_manager = MagicMock()
+    channel_manager.ensure_channel = AsyncMock(return_value=MagicMock())
+    manager = StreamManager(hass, channel_manager)  # type: ignore[arg-type]
+    started = asyncio.Event()
+    unwound = False
+
+    async def consume(_channel: grpc.aio.Channel) -> None:
+        nonlocal unwound
+        started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            await asyncio.sleep(0)
+            unwound = True
+            raise
+
+    manager.start({"device_events": consume}, "eebus_{name}_test-ski")
+    await started.wait()
+
+    await manager.stop()
+
+    assert unwound is True
+    assert manager._tasks == []


### PR DESCRIPTION
## Summary
- Extracts stream-consumer lifecycle out of `coordinator.py` into new `streams.py` (`StreamManager`)
- Replaces flat 30s retry with exponential backoff (2s base, 60s cap, jitter), reset on successful reconnect
- Shutdown now awaits cancelled stream tasks (bounded, via `asyncio.gather`) instead of fire-and-forget cancel

Part of RF-05 (Python lifecycle split), see `docs/refactoring-optimization-spec.md`.

## Test plan
- [x] `pytest` — 112 passed
- [x] `ruff check custom_components/` — clean
- [x] `mypy custom_components/eebus` — strict, no issues