### PR TITLE
feat: RF-05 PR3 extract models.py and snapshot.py

### DIFF
--- a/custom_components/eebus/climate.py
+++ b/custom_components/eebus/climate.py
@@ -14,6 +14,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .coordinator import EebusCoordinator
 from .entity import EebusEntity
+from .models import SetpointState, SystemFunctionState
 
 PARALLEL_UPDATES = 0
 _LOGGER = logging.getLogger(__name__)
@@ -44,10 +45,10 @@ class EebusRoomHeatingClimate(EebusEntity, ClimateEntity):
         super().__init__(coordinator)
         self._attr_unique_id = f"{coordinator.ski}_room_heating"
 
-    def _setpoint(self) -> dict[str, Any] | None:
+    def _setpoint(self) -> SetpointState | None:
         return (self.coordinator.data or {}).get("room_heating_setpoint")
 
-    def _system_function(self) -> dict[str, Any] | None:
+    def _system_function(self) -> SystemFunctionState | None:
         return (self.coordinator.data or {}).get("room_heating_system_function")
 
     @property

--- a/custom_components/eebus/coordinator.py
+++ b/custom_components/eebus/coordinator.py
@@ -9,8 +9,7 @@ from collections.abc import Awaitable, Callable
 from contextlib import suppress
 from datetime import timedelta
 from functools import lru_cache
-from types import ModuleType
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 import grpc
 import grpc.aio
@@ -36,10 +35,16 @@ from .grpc_client import (
     RPC_TIMEOUT,
     WRITE_VALIDATION_CODES,
     GrpcChannelManager,
-    is_not_found as _is_not_found,
     is_unimplemented as _is_unimplemented,
     rpc_error_text as _rpc_error_text,
 )
+from .models import (
+    CoordinatorSnapshot,
+    _dhw_system_function_to_dict,
+    _setpoint_to_dict,
+    _system_function_to_dict,
+)
+from .snapshot import SnapshotSupport, async_build_snapshot
 from .streams import ConsumeFn, StreamManager
 
 if TYPE_CHECKING:
@@ -65,56 +70,11 @@ SOC_UNIT_TO_PCT: dict[str, float] = {PERCENTAGE: 1.0}
 # Event streams deliver push updates; polling only reconciles state the
 # streams cannot carry (scoped energy, heartbeat, support flags).
 POLL_INTERVAL = timedelta(minutes=5)
-RE_REGISTER_NOT_FOUND_STREAK = 4
 
 
 def _normalize_ski(ski: str) -> str:
     """Normalize an SKI for comparisons without changing its stored form."""
     return ski.replace(":", "").replace("-", "").replace(" ", "").casefold()
-
-# Maps a GetMeasurements entry type (as emitted by the Go bridge) to the
-# coordinator data key consumed by the per-phase / grid / produced-energy
-# sensors. Types not present here (e.g. power_consumption, energy_consumed) are
-# handled by their own dedicated reads.
-FLAT_MEASUREMENT_TYPE_TO_KEY: dict[str, str] = {
-    "power_l1": "power_l1_w",
-    "power_l2": "power_l2_w",
-    "power_l3": "power_l3_w",
-    "current_l1": "current_l1_a",
-    "current_l2": "current_l2_a",
-    "current_l3": "current_l3_a",
-    "voltage_l1": "voltage_l1_v",
-    "voltage_l2": "voltage_l2_v",
-    "voltage_l3": "voltage_l3_v",
-    "frequency": "frequency_hz",
-    "energy_produced": "energy_produced_kwh",
-    "dhw_temperature": "dhw_temperature_c",
-    "room_temperature": "room_temperature_c",
-    "outdoor_temperature": "outdoor_temperature_c",
-    "flow_temperature": "flow_temperature_c",
-    "return_temperature": "return_temperature_c",
-    "compressor_temperature": "compressor_temperature_c",
-    "compressor_power": "compressor_power_w",
-}
-FLAT_MEASUREMENT_KEYS: tuple[str, ...] = tuple(FLAT_MEASUREMENT_TYPE_TO_KEY.values())
-
-
-def _dhw_system_function_to_dict(state: Any) -> dict[str, Any]:
-    """Convert a DHW system-function protobuf state into coordinator data."""
-    from . import proto_stubs
-
-    status = proto_stubs.DHWBoostStatus.Name(state.boost_status)
-    prefix = "DHW_BOOST_STATUS_"
-    if status.startswith(prefix):
-        status = status[len(prefix) :]
-    return {
-        "boost_status": status.lower(),
-        "boost_writable": state.boost_writable,
-        "operation_mode": state.operation_mode,
-        "available_modes": list(state.available_modes),
-        "mode_writable": state.mode_writable,
-    }
-
 
 @lru_cache(maxsize=1)
 def _measurement_event_map() -> tuple[dict[int, tuple[str, str, str]], frozenset[int]]:
@@ -174,28 +134,6 @@ def _measurement_event_map() -> tuple[dict[int, tuple[str, str, str]], frozenset
         }
     )
     return value_events, support_events
-
-
-def _setpoint_to_dict(setpoint: Any) -> dict[str, Any]:
-    """Convert a protobuf setpoint (value/min/max/step/writable) to coordinator data."""
-    return {
-        "value_celsius": setpoint.value_celsius,
-        "min_celsius": setpoint.min_celsius,
-        "max_celsius": setpoint.max_celsius,
-        "step_celsius": setpoint.step_celsius,
-        "writable": setpoint.writable,
-    }
-
-
-def _system_function_to_dict(system_function: Any) -> dict[str, Any]:
-    """Convert a protobuf system-function state to coordinator data."""
-    return {
-        "operation_mode": system_function.operation_mode,
-        "available_modes": list(system_function.available_modes),
-        "mode_writable": system_function.mode_writable,
-    }
-
-
 class _ProviderPusher:
     """Serialize and coalesce state-triggered pushes for one provider."""
 
@@ -267,7 +205,7 @@ class _ProviderPusher:
                 _LOGGER.exception("Unexpected failure pushing %s provider data", self._label)
 
 
-class EebusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
+class EebusCoordinator(DataUpdateCoordinator[CoordinatorSnapshot]):
     """Coordinator that manages gRPC connection and data updates."""
 
     def __init__(
@@ -337,176 +275,40 @@ class EebusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         """Create or return existing gRPC channel."""
         return await self._channel_manager.ensure_channel()
 
-    async def _async_update_data(self) -> dict[str, Any]:
+    async def _async_update_data(self) -> CoordinatorSnapshot:
         """Fetch data via gRPC polling."""
         try:
             channel = await self._ensure_channel()
-            from . import proto_stubs
-
-            device_stub = proto_stubs.device_service_stub(channel)
-            status = await device_stub.GetStatus(proto_stubs.Empty())
-
-            if not self._ski_registered:
-                await self._async_register_remote_ski(device_stub, proto_stubs, force=False)
-
-            data: dict[str, Any] = {
-                "connected": status.running,
-                "local_ski": status.local_ski,
-                "ski_registered": self._ski_registered,
-            }
-            # Per-phase / grid / produced-energy measurements default to None and
-            # are populated from GetMeasurements when the device advertises them.
-            for _key in FLAT_MEASUREMENT_KEYS:
-                data[_key] = None
-            if self.ski == status.local_ski:
-                _LOGGER.warning(
-                    "Configured remote SKI %s matches bridge local SKI; monitoring reads will stay empty",
-                    self.ski,
-                )
-
-            monitoring_stub = proto_stubs.monitoring_service_stub(channel)
-            lpc_stub = proto_stubs.lpc_service_stub(channel)
-            request = proto_stubs.DeviceRequest(ski=self.ski)
-            flags = {"saw_not_found": False}
-
-            # The reads are independent; run them concurrently so poll latency
-            # is the slowest single read instead of the sum of all round-trips.
-            power, measurements, energy, limit, failsafe, hb = await asyncio.gather(
-                self._poll_read(
-                    "power", monitoring_stub.GetPowerConsumption, request, flags
-                ),
-                self._poll_read(
-                    "scoped energy", monitoring_stub.GetMeasurements, request, flags
-                ),
-                self._poll_read(
-                    "total energy", monitoring_stub.GetEnergyConsumed, request, flags
-                ),
-                self._poll_read(
-                    "consumption limit",
-                    lpc_stub.GetConsumptionLimit,
-                    request,
-                    flags,
-                    unsupported_attr="_lpc_supported",
-                ),
-                self._poll_read(
-                    "failsafe",
-                    lpc_stub.GetFailsafeLimit,
-                    request,
-                    flags,
-                    unsupported_attr="_failsafe_supported",
-                ),
-                self._poll_read(
-                    "heartbeat",
-                    lpc_stub.GetHeartbeatStatus,
-                    request,
-                    flags,
-                    unsupported_attr="_heartbeat_supported",
-                ),
-            )
-
-            data["power_watts"] = power.watts if power is not None else None
-
-            if measurements is not None:
-                scoped_energy = self._extract_scoped_energy_kwh(measurements.measurements)
-                data["energy_consumed_heating_kwh"] = scoped_energy["heating"]
-                data["energy_consumed_dhw_kwh"] = scoped_energy["dhw"]
-                data.update(self._extract_flat_measurements(measurements.measurements))
-            else:
-                data["energy_consumed_heating_kwh"] = None
-                data["energy_consumed_dhw_kwh"] = None
-
-            data["energy_consumed_kwh"] = (
-                energy.kilowatt_hours if energy is not None else None
-            )
-
-            if limit is not None:
-                self._lpc_supported = True
-                data["consumption_limit"] = {
-                    "value_watts": limit.value_watts,
-                    "is_active": limit.is_active,
-                    "is_changeable": limit.is_changeable,
-                }
-            else:
-                data["consumption_limit"] = None
-
-            if failsafe is not None:
-                self._failsafe_supported = True
-                data["failsafe_limit"] = {
-                    "value_watts": failsafe.value_watts,
-                    "duration_minimum_seconds": failsafe.duration_minimum_seconds,
-                }
-            else:
-                data["failsafe_limit"] = None
-
-            if hb is not None:
-                self._heartbeat_supported = True
-                data["heartbeat_status"] = {
-                    "running": hb.running,
-                    "within_duration": hb.within_duration,
-                }
-            else:
-                data["heartbeat_status"] = None
-
-            saw_not_found = flags["saw_not_found"]
-            data["heartbeat_supported"] = self._heartbeat_supported
-            data["lpc_supported"] = self._lpc_supported
-            data["failsafe_supported"] = self._failsafe_supported
-
-            # Remaining reads are independent too. OHPCF/DHW/room-heating stay
-            # unavailable when the bridge side is off; device diagnostics is
-            # best-effort.
-            (
-                data["device_info"],
-                data["compressor_flexibility"],
-                data["dhw_setpoint"],
-                data["dhw_system_function"],
-                room_heating,
-                data["device_operating_state"],
-            ) = await asyncio.gather(
-                self._async_fetch_device_info(device_stub, proto_stubs),
-                self._async_read_compressor_flexibility(channel, proto_stubs, request),
-                self._async_read_dhw_setpoint(channel, proto_stubs, request),
-                self._async_read_dhw_system_function(channel, proto_stubs, request),
-                self._async_read_room_heating(channel, proto_stubs, request),
-                self._async_read_device_diagnostics(channel, proto_stubs, request),
-            )
-            data["ohpcf_supported"] = self._ohpcf_supported
-            data["dhw_supported"] = self._dhw_supported
-            data["dhw_sysfn_supported"] = self._dhw_sysfn_supported
-            (
-                data["room_heating_setpoint"],
-                data["room_heating_system_function"],
-            ) = room_heating
-            data["room_heating_supported"] = self._room_heating_supported
-
-            if saw_not_found:
-                self._not_found_streak += 1
-            else:
-                self._not_found_streak = 0
-
-            if self._not_found_streak >= RE_REGISTER_NOT_FOUND_STREAK:
-                _LOGGER.warning(
-                    "EEBUS reads returned NOT_FOUND for %s consecutive polls; forcing remote SKI re-registration for %s",
-                    self._not_found_streak,
-                    self.ski,
-                )
-                await self._async_register_remote_ski(device_stub, proto_stubs, force=True)
-                self._not_found_streak = 0
-
-            _LOGGER.debug(
-                "EEBUS poll summary for SKI %s: power=%s energy_total=%s energy_heating=%s energy_dhw=%s",
+            result = await async_build_snapshot(
+                channel,
                 self.ski,
-                data["power_watts"],
-                data["energy_consumed_kwh"],
-                data["energy_consumed_heating_kwh"],
-                data["energy_consumed_dhw_kwh"],
+                SnapshotSupport(
+                    lpc=self._lpc_supported,
+                    failsafe=self._failsafe_supported,
+                    heartbeat=self._heartbeat_supported,
+                    ohpcf=self._ohpcf_supported,
+                    dhw=self._dhw_supported,
+                    dhw_system_function=self._dhw_sysfn_supported,
+                    room_heating=self._room_heating_supported,
+                ),
+                ski_registered=self._ski_registered,
+                not_found_streak=self._not_found_streak,
             )
+            self._lpc_supported = result.support.lpc
+            self._failsafe_supported = result.support.failsafe
+            self._heartbeat_supported = result.support.heartbeat
+            self._ohpcf_supported = result.support.ohpcf
+            self._dhw_supported = result.support.dhw
+            self._dhw_sysfn_supported = result.support.dhw_system_function
+            self._room_heating_supported = result.support.room_heating
+            self._ski_registered = result.ski_registered
+            self._not_found_streak = result.not_found_streak
 
             if self._was_unavailable:
                 _LOGGER.info("EEBUS bridge connection restored at %s:%s", self.host, self.port)
                 self._was_unavailable = False
 
-            return data
+            return result.snapshot
         except grpc.aio.AioRpcError as err:
             await self._channel_manager.invalidate()
             self._not_found_streak = 0
@@ -521,157 +323,6 @@ class EebusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 self._was_unavailable = True
 
             raise UpdateFailed(f"gRPC error: {err}") from err
-
-    async def _poll_read(
-        self,
-        label: str,
-        call: Any,
-        request: Any,
-        flags: dict[str, bool],
-        unsupported_attr: str | None = None,
-    ) -> Any:
-        """Call a device-scoped read RPC once.
-
-        Returns the response, or None on failure. Records NOT_FOUND in
-        ``flags``; when ``unsupported_attr`` is given, clears that support flag
-        on UNIMPLEMENTED.
-        """
-        try:
-            response = await call(request, timeout=RPC_TIMEOUT)
-        except grpc.aio.AioRpcError as err:
-            if _is_not_found(err):
-                flags["saw_not_found"] = True
-            _LOGGER.debug(
-                "EEBUS %s read failed for SKI %s: %s",
-                label,
-                self.ski,
-                _rpc_error_text(err),
-            )
-            if unsupported_attr is not None and _is_unimplemented(err):
-                setattr(self, unsupported_attr, False)
-            return None
-        except Exception:  # noqa: BLE001
-            _LOGGER.exception("Failed to read %s", label)
-            return None
-        _LOGGER.debug("EEBUS %s read for SKI %s succeeded", label, self.ski)
-        return response
-
-    async def _async_fetch_device_info(
-        self, device_stub: Any, proto_stubs: Any
-    ) -> dict[str, str] | None:
-        """Read manufacturer/model metadata for the configured device.
-
-        Returns the brand, model, serial and EEBUS device type reported by the
-        bridge so Home Assistant can label the device with real values instead of
-        a hardcoded manufacturer. Best-effort: returns None on any error.
-        """
-        try:
-            response = await device_stub.ListPairedDevices(
-                proto_stubs.Empty(), timeout=RPC_TIMEOUT
-            )
-        except grpc.aio.AioRpcError as err:
-            if not _is_unimplemented(err):
-                _LOGGER.debug(
-                    "ListPairedDevices failed for SKI %s: %s",
-                    self.ski,
-                    _rpc_error_text(err),
-                )
-            return None
-        except Exception:  # noqa: BLE001
-            _LOGGER.exception("Failed to list paired devices")
-            return None
-
-        devices = list(response.devices)
-        if not devices:
-            return None
-
-        match = next((d for d in devices if d.ski == self.ski), None)
-        if match is None:
-            return None
-
-        info: dict[str, str] = {}
-        if match.brand:
-            info["manufacturer"] = match.brand
-        if match.model:
-            info["model"] = match.model
-        if match.serial:
-            info["serial"] = match.serial
-        if match.device_type:
-            info["device_type"] = match.device_type
-        return info or None
-
-    async def _async_register_remote_ski(
-        self, device_stub: Any, proto_stubs_module: ModuleType, force: bool
-    ) -> None:
-        """Register remote SKI with bridge, optionally forcing re-registration."""
-        try:
-            await device_stub.RegisterRemoteSKI(
-                proto_stubs_module.RegisterSKIRequest(ski=self.ski), timeout=RPC_TIMEOUT
-            )
-            self._ski_registered = True
-            if force:
-                _LOGGER.info("Forced re-registration of remote SKI %s with bridge", self.ski)
-            else:
-                _LOGGER.info("Registered remote SKI %s with bridge", self.ski)
-        except grpc.aio.AioRpcError as err:
-            if force:
-                _LOGGER.warning(
-                    "Forced remote SKI re-registration failed for %s: %s",
-                    self.ski,
-                    _rpc_error_text(err),
-                )
-            else:
-                # Retry in next polling cycle until the bridge accepts registration.
-                _LOGGER.debug(
-                    "Remote SKI registration pending for %s: %s",
-                    self.ski,
-                    _rpc_error_text(err),
-                )
-
-    @staticmethod
-    def _extract_scoped_energy_kwh(measurements: list[Any]) -> dict[str, float | None]:
-        """Extract Vaillant/EEBUS scoped counters for heating and domestic hot water."""
-        result: dict[str, float | None] = {"heating": None, "dhw": None}
-        for measurement in measurements:
-            measurement_type = str(getattr(measurement, "type", "")).lower().strip()
-            if not measurement_type:
-                continue
-            normalized = measurement_type.replace("-", "_").replace(" ", "_")
-            value = getattr(measurement, "value", None)
-            if value is None:
-                continue
-
-            # Vaillant uses separate thermal storage contexts for heating and DHW.
-            if (
-                "energy" in normalized
-                and ("domestic_hot_water" in normalized or "hot_water" in normalized or "dhw" in normalized)
-            ):
-                result["dhw"] = value
-                continue
-
-            if "energy" in normalized and ("heating" in normalized or "space_heating" in normalized):
-                result["heating"] = value
-
-        return result
-
-    @staticmethod
-    def _extract_flat_measurements(measurements: list[Any]) -> dict[str, float | None]:
-        """Map per-phase / grid / produced-energy entries to coordinator keys."""
-        result: dict[str, float | None] = {}
-        for measurement in measurements:
-            measurement_type = str(getattr(measurement, "type", "")).lower().strip()
-            if not measurement_type:
-                continue
-            normalized = measurement_type.replace("-", "_").replace(" ", "_")
-            key = FLAT_MEASUREMENT_TYPE_TO_KEY.get(normalized)
-            if key is None:
-                continue
-            value = getattr(measurement, "value", None)
-            if value is None:
-                continue
-            result[key] = value
-        return result
-
     async def _async_write_rpc(
         self,
         label: str,
@@ -747,46 +398,6 @@ class EebusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             support_attr="_lpc_supported",
         )
 
-    async def _async_read_compressor_flexibility(
-        self, channel: grpc.aio.Channel, proto_stubs: Any, request: Any
-    ) -> dict[str, Any] | None:
-        """Read the OHPCF compressor flexibility offer/state, or None when off."""
-        from .generated.eebus.v1 import ohpcf_service_pb2 as ohpcf_pb2
-
-        try:
-            stub = proto_stubs.ohpcf_service_stub(channel)
-            flex = await stub.GetCompressorFlexibility(request, timeout=RPC_TIMEOUT)
-        except grpc.aio.AioRpcError as err:
-            if _is_unimplemented(err) or err.code() == grpc.StatusCode.UNAVAILABLE:
-                self._ohpcf_supported = False
-            else:
-                _LOGGER.debug(
-                    "EEBUS OHPCF read failed for SKI %s: %s",
-                    self.ski,
-                    _rpc_error_text(err),
-                )
-            return None
-
-        self._ohpcf_supported = True
-        return {
-            "available": flex.available,
-            "state": ohpcf_pb2.CompressorPowerConsumptionState.Name(flex.state),
-            "requested_power_estimate_w": (
-                flex.requested_power_estimate_w
-                if flex.HasField("requested_power_estimate_w")
-                else None
-            ),
-            "requested_power_max_w": (
-                flex.requested_power_max_w
-                if flex.HasField("requested_power_max_w")
-                else None
-            ),
-            "is_pausable": flex.is_pausable,
-            "is_stoppable": flex.is_stoppable,
-            "minimal_run_seconds": flex.minimal_run_seconds,
-            "minimal_pause_seconds": flex.minimal_pause_seconds,
-        }
-
     async def async_control_compressor(self, action: proto_stubs.OHPCFAction) -> None:
         """Schedule/pause/resume/abort the compressor's optional consumption."""
         channel = await self._ensure_channel()
@@ -812,30 +423,6 @@ class EebusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 f"Compressor flexibility control failed: {err.details()}"
             ) from err
 
-    async def _async_read_dhw_setpoint(
-        self, channel: grpc.aio.Channel, proto_stubs: Any, request: Any
-    ) -> dict[str, Any] | None:
-        """Read the DHW target and device-provided constraints."""
-        try:
-            stub = proto_stubs.dhw_service_stub(channel)
-            setpoint = await stub.GetDHWSetpoint(request, timeout=RPC_TIMEOUT)
-        except grpc.aio.AioRpcError as err:
-            if _is_unimplemented(err) or err.code() in (
-                grpc.StatusCode.NOT_FOUND,
-                grpc.StatusCode.UNAVAILABLE,
-            ):
-                self._dhw_supported = False
-            else:
-                _LOGGER.debug(
-                    "EEBUS DHW setpoint read failed for SKI %s: %s",
-                    self.ski,
-                    _rpc_error_text(err),
-                )
-            return None
-
-        self._dhw_supported = True
-        return _setpoint_to_dict(setpoint)
-
     async def async_write_dhw_setpoint(self, value_celsius: float) -> None:
         """Write the domestic-hot-water target via the bridge."""
         channel = await self._ensure_channel()
@@ -849,30 +436,6 @@ class EebusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             support_attr="_dhw_supported",
             validation=True,
         )
-
-    async def _async_read_dhw_system_function(
-        self, channel: grpc.aio.Channel, proto_stubs: Any, request: Any
-    ) -> dict[str, Any] | None:
-        """Read DHW boost and operation mode state."""
-        try:
-            stub = proto_stubs.dhw_service_stub(channel)
-            state = await stub.GetDHWSystemFunction(request, timeout=RPC_TIMEOUT)
-        except grpc.aio.AioRpcError as err:
-            if _is_unimplemented(err) or err.code() in (
-                grpc.StatusCode.NOT_FOUND,
-                grpc.StatusCode.UNAVAILABLE,
-            ):
-                self._dhw_sysfn_supported = False
-            else:
-                _LOGGER.debug(
-                    "EEBUS DHW system function read failed for SKI %s: %s",
-                    self.ski,
-                    _rpc_error_text(err),
-                )
-            return None
-
-        self._dhw_sysfn_supported = True
-        return _dhw_system_function_to_dict(state)
 
     async def async_set_dhw_boost(self, active: bool) -> None:
         """Activate or cancel DHW one-time boost."""
@@ -901,54 +464,6 @@ class EebusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             support_attr="_dhw_sysfn_supported",
             validation=True,
         )
-
-    async def _async_read_room_heating(
-        self, channel: grpc.aio.Channel, proto_stubs: Any, request: Any
-    ) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
-        """Read room-heating setpoint and system-function state."""
-        try:
-            state = await proto_stubs.hvac_service_stub(channel).GetRoomHeating(
-                request, timeout=RPC_TIMEOUT
-            )
-        except grpc.aio.AioRpcError as err:
-            if _is_unimplemented(err) or err.code() in (
-                grpc.StatusCode.NOT_FOUND,
-                grpc.StatusCode.UNAVAILABLE,
-            ):
-                self._room_heating_supported = False
-            return None, None
-        self._room_heating_supported = True
-        setpoint = None
-        if state.HasField("setpoint"):
-            setpoint = _setpoint_to_dict(state.setpoint)
-        system_function = None
-        if state.HasField("system_function"):
-            system_function = _system_function_to_dict(state.system_function)
-        if state.HasField("current_temperature_celsius"):
-            self._push_data({"room_temperature_c": state.current_temperature_celsius})
-        return setpoint, system_function
-
-    async def _async_read_device_diagnostics(
-        self, channel: grpc.aio.Channel, proto_stubs: Any, request: Any
-    ) -> str | None:
-        """Read the device operating state without mutating coordinator data."""
-        try:
-            diagnostics = await proto_stubs.monitoring_service_stub(
-                channel
-            ).GetDeviceDiagnostics(request, timeout=RPC_TIMEOUT)
-        except grpc.aio.AioRpcError as err:
-            if not (
-                _is_unimplemented(err)
-                or err.code()
-                in (grpc.StatusCode.NOT_FOUND, grpc.StatusCode.UNAVAILABLE)
-            ):
-                _LOGGER.debug(
-                    "EEBUS device diagnosis read failed for SKI %s: %s",
-                    self.ski,
-                    _rpc_error_text(err),
-                )
-            return None
-        return diagnostics.operating_state or None
 
     async def async_set_room_heating_temperature(self, value_celsius: float) -> None:
         """Set the room-heating target temperature."""
@@ -1334,7 +849,9 @@ class EebusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         """Merge stream updates into coordinator data and notify listeners."""
         if self.data is None:
             return
-        self.async_set_updated_data({**self.data, **updates})
+        merged = dict(self.data)
+        merged.update(updates)
+        self.async_set_updated_data(cast(CoordinatorSnapshot, merged))
 
     def _handle_device_event(self, event: Any) -> None:
         from . import proto_stubs

--- a/custom_components/eebus/models.py
+++ b/custom_components/eebus/models.py
@@ -1,0 +1,244 @@
+"""Typed coordinator snapshot models and protobuf conversion helpers."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, TypedDict, cast
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from . import proto_stubs
+
+
+class SetpointState(TypedDict):
+    """Temperature setpoint and its device-provided constraints."""
+
+    value_celsius: float
+    min_celsius: float
+    max_celsius: float
+    step_celsius: float
+    writable: bool
+
+
+class SystemFunctionState(TypedDict):
+    """Operation mode state shared by system-function use cases."""
+
+    operation_mode: str
+    available_modes: list[str]
+    mode_writable: bool
+
+
+class DHWSystemFunctionState(TypedDict):
+    """Domestic-hot-water boost and operation mode state."""
+
+    boost_status: str
+    boost_writable: bool
+    operation_mode: str
+    available_modes: list[str]
+    mode_writable: bool
+
+
+class ConsumptionLimitState(TypedDict):
+    """Current limitation-of-power-consumption state."""
+
+    value_watts: float
+    is_active: bool
+    is_changeable: bool
+
+
+class FailsafeState(TypedDict):
+    """Current failsafe limit state."""
+
+    value_watts: float
+    duration_minimum_seconds: int
+
+
+class HeartbeatState(TypedDict):
+    """Current heartbeat state."""
+
+    running: bool
+    within_duration: bool
+
+
+class CompressorFlexibilityState(TypedDict):
+    """OHPCF compressor offer and process state."""
+
+    available: bool
+    state: str
+    requested_power_estimate_w: float | None
+    requested_power_max_w: float | None
+    is_pausable: bool
+    is_stoppable: bool
+    minimal_run_seconds: int
+    minimal_pause_seconds: int
+
+
+class DeviceInfo(TypedDict, total=False):
+    """Optional device classification fields reported by the bridge."""
+
+    manufacturer: str
+    model: str
+    serial: str
+    device_type: str
+
+
+class CoordinatorSnapshot(TypedDict):
+    """Complete atomically published coordinator polling snapshot."""
+
+    connected: bool
+    local_ski: str
+    ski_registered: bool
+    power_l1_w: float | None
+    power_l2_w: float | None
+    power_l3_w: float | None
+    current_l1_a: float | None
+    current_l2_a: float | None
+    current_l3_a: float | None
+    voltage_l1_v: float | None
+    voltage_l2_v: float | None
+    voltage_l3_v: float | None
+    frequency_hz: float | None
+    energy_produced_kwh: float | None
+    dhw_temperature_c: float | None
+    room_temperature_c: float | None
+    outdoor_temperature_c: float | None
+    flow_temperature_c: float | None
+    return_temperature_c: float | None
+    compressor_temperature_c: float | None
+    compressor_power_w: float | None
+    power_watts: float | None
+    energy_consumed_heating_kwh: float | None
+    energy_consumed_dhw_kwh: float | None
+    energy_consumed_kwh: float | None
+    consumption_limit: ConsumptionLimitState | None
+    failsafe_limit: FailsafeState | None
+    heartbeat_status: HeartbeatState | None
+    heartbeat_supported: bool | None
+    lpc_supported: bool | None
+    failsafe_supported: bool | None
+    device_info: DeviceInfo | None
+    compressor_flexibility: CompressorFlexibilityState | None
+    dhw_setpoint: SetpointState | None
+    dhw_system_function: DHWSystemFunctionState | None
+    room_heating_setpoint: SetpointState | None
+    room_heating_system_function: SystemFunctionState | None
+    device_operating_state: str | None
+    ohpcf_supported: bool | None
+    dhw_supported: bool | None
+    dhw_sysfn_supported: bool | None
+    room_heating_supported: bool | None
+
+
+# Maps a GetMeasurements entry type (as emitted by the Go bridge) to the
+# coordinator data key consumed by the per-phase / grid / produced-energy
+# sensors. Types not present here (e.g. power_consumption, energy_consumed) are
+# handled by their own dedicated reads.
+FLAT_MEASUREMENT_TYPE_TO_KEY: dict[str, str] = {
+    "power_l1": "power_l1_w",
+    "power_l2": "power_l2_w",
+    "power_l3": "power_l3_w",
+    "current_l1": "current_l1_a",
+    "current_l2": "current_l2_a",
+    "current_l3": "current_l3_a",
+    "voltage_l1": "voltage_l1_v",
+    "voltage_l2": "voltage_l2_v",
+    "voltage_l3": "voltage_l3_v",
+    "frequency": "frequency_hz",
+    "energy_produced": "energy_produced_kwh",
+    "dhw_temperature": "dhw_temperature_c",
+    "room_temperature": "room_temperature_c",
+    "outdoor_temperature": "outdoor_temperature_c",
+    "flow_temperature": "flow_temperature_c",
+    "return_temperature": "return_temperature_c",
+    "compressor_temperature": "compressor_temperature_c",
+    "compressor_power": "compressor_power_w",
+}
+FLAT_MEASUREMENT_KEYS: tuple[str, ...] = tuple(FLAT_MEASUREMENT_TYPE_TO_KEY.values())
+
+
+def _dhw_system_function_to_dict(state: proto_stubs.DHWSystemFunctionState) -> DHWSystemFunctionState:
+    """Convert a DHW system-function protobuf state into coordinator data."""
+    from . import proto_stubs
+
+    status = proto_stubs.DHWBoostStatus.Name(state.boost_status)
+    prefix = "DHW_BOOST_STATUS_"
+    if status.startswith(prefix):
+        status = status[len(prefix) :]
+    return {
+        "boost_status": status.lower(),
+        "boost_writable": state.boost_writable,
+        "operation_mode": state.operation_mode,
+        "available_modes": list(state.available_modes),
+        "mode_writable": state.mode_writable,
+    }
+
+
+def _setpoint_to_dict(
+    setpoint: proto_stubs.DHWSetpoint | proto_stubs.RoomHeatingSetpoint,
+) -> SetpointState:
+    """Convert a protobuf setpoint (value/min/max/step/writable) to coordinator data."""
+    return {
+        "value_celsius": setpoint.value_celsius,
+        "min_celsius": setpoint.min_celsius,
+        "max_celsius": setpoint.max_celsius,
+        "step_celsius": setpoint.step_celsius,
+        "writable": setpoint.writable,
+    }
+
+
+def _system_function_to_dict(
+    system_function: proto_stubs.RoomHeatingSystemFunction,
+) -> SystemFunctionState:
+    """Convert a protobuf system-function state to coordinator data."""
+    return {
+        "operation_mode": system_function.operation_mode,
+        "available_modes": list(system_function.available_modes),
+        "mode_writable": system_function.mode_writable,
+    }
+
+
+def _extract_scoped_energy_kwh(
+    measurements: Sequence[proto_stubs.MeasurementEntry],
+) -> dict[str, float | None]:
+    """Extract Vaillant/EEBUS scoped counters for heating and domestic hot water."""
+    result: dict[str, float | None] = {"heating": None, "dhw": None}
+    for measurement in measurements:
+        measurement_type = str(getattr(measurement, "type", "")).lower().strip()
+        if not measurement_type:
+            continue
+        normalized = measurement_type.replace("-", "_").replace(" ", "_")
+        value = getattr(measurement, "value", None)
+        if value is None:
+            continue
+
+        # Vaillant uses separate thermal storage contexts for heating and DHW.
+        if "energy" in normalized and (
+            "domestic_hot_water" in normalized or "hot_water" in normalized or "dhw" in normalized
+        ):
+            result["dhw"] = cast(float, value)
+            continue
+
+        if "energy" in normalized and ("heating" in normalized or "space_heating" in normalized):
+            result["heating"] = cast(float, value)
+
+    return result
+
+
+def _extract_flat_measurements(
+    measurements: Sequence[proto_stubs.MeasurementEntry],
+) -> dict[str, float | None]:
+    """Map per-phase / grid / produced-energy entries to coordinator keys."""
+    result: dict[str, float | None] = {}
+    for measurement in measurements:
+        measurement_type = str(getattr(measurement, "type", "")).lower().strip()
+        if not measurement_type:
+            continue
+        normalized = measurement_type.replace("-", "_").replace(" ", "_")
+        key = FLAT_MEASUREMENT_TYPE_TO_KEY.get(normalized)
+        if key is None:
+            continue
+        value = getattr(measurement, "value", None)
+        if value is None:
+            continue
+        result[key] = cast(float, value)
+    return result

--- a/custom_components/eebus/proto_stubs.py
+++ b/custom_components/eebus/proto_stubs.py
@@ -20,11 +20,13 @@ from .generated.eebus.v1.common_pb2 import (  # noqa: F401
 from .generated.eebus.v1.device_service_pb2 import (  # noqa: F401
     DeviceEventType,
     RegisterSKIRequest,
+    ServiceStatus,
 )
 from .generated.eebus.v1.device_service_pb2_grpc import DeviceServiceStub  # noqa: F401
 from .generated.eebus.v1.dhw_service_pb2 import (  # noqa: F401
     DHWBoostStatus,
     DHWEventType,
+    DHWSetpoint,
     DHWSystemFunctionEvent,
     DHWSystemFunctionEventType,
     DHWSystemFunctionState,
@@ -46,12 +48,16 @@ from .generated.eebus.v1.hvac_service_pb2 import (  # noqa: F401
 from .generated.eebus.v1.hvac_service_pb2_grpc import HVACServiceStub  # noqa: F401
 from .generated.eebus.v1.grid_service_pb2_grpc import GridServiceStub  # noqa: F401
 from .generated.eebus.v1.lpc_service_pb2 import (  # noqa: F401
+    FailsafeLimit,
+    HeartbeatStatus,
     LPCEventType,
     WriteFailsafeLimitRequest,
     WriteLoadLimitRequest,
 )
 from .generated.eebus.v1.monitoring_service_pb2 import (  # noqa: F401
     DeviceDiagnosticsData,
+    EnergyMeasurement,
+    MeasurementList,
     MeasurementEventType,
 )
 from .generated.eebus.v1.lpc_service_pb2_grpc import LPCServiceStub  # noqa: F401
@@ -64,6 +70,7 @@ from .generated.eebus.v1.visualization_service_pb2_grpc import (  # noqa: F401
     VisualizationServiceStub,
 )
 from .generated.eebus.v1.ohpcf_service_pb2 import (  # noqa: F401
+    CompressorFlexibility,
     CompressorPowerConsumptionState,
     ControlCompressorRequest,
     OHPCFAction,
@@ -113,6 +120,7 @@ def visualization_service_stub(channel: grpc.aio.Channel) -> VisualizationServic
 
 __all__ = [
     "BatteryData",
+    "CompressorFlexibility",
     "CompressorPowerConsumptionState",
     "ControlCompressorRequest",
     "DeviceEventType",
@@ -121,19 +129,24 @@ __all__ = [
     "DeviceServiceStub",
     "DHWBoostStatus",
     "DHWEventType",
+    "DHWSetpoint",
     "DHWServiceStub",
     "DHWSystemFunctionEvent",
     "DHWSystemFunctionEventType",
     "DHWSystemFunctionState",
     "Empty",
+    "EnergyMeasurement",
+    "FailsafeLimit",
     "GridData",
     "GridServiceStub",
     "HVACServiceStub",
+    "HeartbeatStatus",
     "LPCEventType",
     "LPCServiceStub",
     "LoadLimit",
     "MeasurementEntry",
     "MeasurementEventType",
+    "MeasurementList",
     "MonitoringServiceStub",
     "OHPCFAction",
     "OHPCFEventType",
@@ -151,6 +164,7 @@ __all__ = [
     "SetDHWSetpointRequest",
     "SetRoomHeatingModeRequest",
     "SetRoomHeatingTemperatureRequest",
+    "ServiceStatus",
     "VisualizationServiceStub",
     "WriteFailsafeLimitRequest",
     "WriteLoadLimitRequest",

--- a/custom_components/eebus/select.py
+++ b/custom_components/eebus/select.py
@@ -11,6 +11,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .coordinator import EebusCoordinator
 from .entity import EebusEntity
+from .models import CompressorFlexibilityState
 
 PARALLEL_UPDATES = 0  # Coordinator-based, no per-entity polling
 
@@ -60,7 +61,7 @@ class EebusCompressorFlexibilitySelect(EebusEntity, SelectEntity):
         super().__init__(coordinator)
         self._attr_unique_id = f"{coordinator.ski}_compressor_flexibility"
 
-    def _flex(self) -> dict[str, Any] | None:
+    def _flex(self) -> CompressorFlexibilityState | None:
         if self.coordinator.data is None:
             return None
         return self.coordinator.data.get("compressor_flexibility")
@@ -99,11 +100,11 @@ class EebusCompressorFlexibilitySelect(EebusEntity, SelectEntity):
         """Schedule/resume, pause, or abort the optional power consumption."""
         from . import proto_stubs
 
-        flex = self._flex() or {}
+        flex = self._flex()
         if option == OPTION_ON:
             action = (
                 proto_stubs.OHPCFAction.OHPCF_ACTION_RESUME
-                if flex.get("state") == _OHPCF_PAUSED_STATE
+                if flex is not None and flex.get("state") == _OHPCF_PAUSED_STATE
                 else proto_stubs.OHPCFAction.OHPCF_ACTION_SCHEDULE
             )
         elif option == OPTION_PAUSED:

--- a/custom_components/eebus/sensor.py
+++ b/custom_components/eebus/sensor.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
-from typing import Any
+from typing import cast
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -28,6 +28,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .coordinator import EebusCoordinator
 from .entity import EebusEntity
+from .models import CoordinatorSnapshot
 
 _OHPCF_STATUS_OPTIONS = [
     "available",
@@ -42,34 +43,34 @@ _OHPCF_STATE_PREFIX = "COMPRESSOR_STATE_"
 
 def _nested_float(
     container_key: str, value_key: str
-) -> Callable[[dict[str, Any]], float | None]:
+) -> Callable[[CoordinatorSnapshot], float | None]:
     """Build a value_fn reading ``data[container_key][value_key]`` as float."""
 
-    def _get(data: dict[str, Any]) -> float | None:
-        container = data.get(container_key)
+    def _get(data: CoordinatorSnapshot) -> float | None:
+        container = cast(Mapping[str, object] | None, data.get(container_key))
         if container is None:
             return None
         value = container.get(value_key)
-        return None if value is None else float(value)
+        return None if value is None else float(cast(float, value))
 
     return _get
 
 
-def _key_is_present(key: str) -> Callable[[dict[str, Any]], bool]:
+def _key_is_present(key: str) -> Callable[[CoordinatorSnapshot], bool]:
     """Build an available_fn requiring ``data[key]`` to be non-None."""
 
-    def _check(data: dict[str, Any]) -> bool:
+    def _check(data: CoordinatorSnapshot) -> bool:
         return data.get(key) is not None
 
     return _check
 
 
-def _failsafe_available(data: dict[str, Any]) -> bool:
+def _failsafe_available(data: CoordinatorSnapshot) -> bool:
     """Failsafe sensors stay available until support is known to be absent."""
     return data.get("failsafe_supported") is not False
 
 
-def _ohpcf_status(data: dict[str, Any]) -> str | None:
+def _ohpcf_status(data: CoordinatorSnapshot) -> str | None:
     """Return the raw OHPCF process state, lower-cased and without the enum prefix.
 
     The compressor_flexibility select folds five of the six process states into
@@ -94,8 +95,8 @@ class EebusMeasurementDescription(SensorEntityDescription):
     """
 
     data_key: str = ""
-    value_fn: Callable[[dict[str, Any]], float | str | None] | None = None
-    available_fn: Callable[[dict[str, Any]], bool] | None = None
+    value_fn: Callable[[CoordinatorSnapshot], float | str | None] | None = None
+    available_fn: Callable[[CoordinatorSnapshot], bool] | None = None
     unique_id_suffix: str | None = None
 
 
@@ -378,4 +379,4 @@ class EebusMeasurementSensor(EebusEntity, SensorEntity):
         description = self.entity_description
         if description.value_fn is not None:
             return description.value_fn(data)
-        return data.get(description.data_key)
+        return cast(float | str | None, data.get(description.data_key))

--- a/custom_components/eebus/snapshot.py
+++ b/custom_components/eebus/snapshot.py
@@ -1,0 +1,539 @@
+"""Atomic EEBUS polling snapshot construction without Home Assistant side effects."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Awaitable
+from dataclasses import dataclass
+from typing import Generic, Protocol, TypeVar, cast
+
+import grpc
+import grpc.aio
+
+from . import proto_stubs
+from .grpc_client import (
+    RPC_TIMEOUT,
+    is_not_found as _is_not_found,
+    is_unimplemented as _is_unimplemented,
+    rpc_error_text as _rpc_error_text,
+)
+from .models import (
+    CompressorFlexibilityState,
+    ConsumptionLimitState,
+    CoordinatorSnapshot,
+    DHWSystemFunctionState,
+    DeviceInfo,
+    FailsafeState,
+    HeartbeatState,
+    SetpointState,
+    SystemFunctionState,
+    _dhw_system_function_to_dict,
+    _extract_flat_measurements,
+    _extract_scoped_energy_kwh,
+    _setpoint_to_dict,
+    _system_function_to_dict,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+RE_REGISTER_NOT_FOUND_STREAK = 4
+
+_ResponseT = TypeVar("_ResponseT")
+_ResponseT_co = TypeVar("_ResponseT_co", covariant=True)
+
+
+class _ReadCall(Protocol[_ResponseT_co]):
+    """Typed shape of an asynchronous unary device read."""
+
+    def __call__(self, request: proto_stubs.DeviceRequest, *, timeout: float) -> Awaitable[_ResponseT_co]: ...
+
+
+@dataclass(frozen=True, slots=True)
+class _ReadResult(Generic[_ResponseT]):
+    """One best-effort read plus its deferred support result."""
+
+    value: _ResponseT | None
+    supported: bool | None
+    saw_not_found: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class SnapshotSupport:
+    """Support flags carried into and returned from one polling cycle."""
+
+    lpc: bool | None = None
+    failsafe: bool | None = None
+    heartbeat: bool | None = None
+    ohpcf: bool | None = None
+    dhw: bool | None = None
+    dhw_system_function: bool | None = None
+    room_heating: bool | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class SnapshotResult:
+    """Complete polling result and coordinator-owned state updates."""
+
+    snapshot: CoordinatorSnapshot
+    support: SnapshotSupport
+    ski_registered: bool
+    not_found_streak: int
+
+
+@dataclass(frozen=True, slots=True)
+class _RoomHeatingRead:
+    """Room-heating fields returned together so they can be published atomically."""
+
+    setpoint: SetpointState | None
+    system_function: SystemFunctionState | None
+    current_temperature_celsius: float | None
+
+
+async def _poll_read(
+    label: str,
+    call: _ReadCall[_ResponseT],
+    request: proto_stubs.DeviceRequest,
+    ski: str,
+    *,
+    track_support: bool = False,
+    current_support: bool | None = None,
+) -> _ReadResult[_ResponseT]:
+    """Call a device-scoped read RPC once and return deferred status metadata."""
+    try:
+        response = await call(request, timeout=RPC_TIMEOUT)
+    except grpc.aio.AioRpcError as err:
+        _LOGGER.debug(
+            "EEBUS %s read failed for SKI %s: %s",
+            label,
+            ski,
+            _rpc_error_text(err),
+        )
+        supported = False if track_support and _is_unimplemented(err) else current_support
+        return _ReadResult(None, supported, _is_not_found(err))
+    except Exception:  # noqa: BLE001
+        _LOGGER.exception("Failed to read %s", label)
+        return _ReadResult(None, current_support)
+    _LOGGER.debug("EEBUS %s read for SKI %s succeeded", label, ski)
+    return _ReadResult(response, True if track_support else current_support)
+
+
+async def _async_register_remote_ski(
+    device_stub: proto_stubs.DeviceServiceStub,
+    ski: str,
+    *,
+    force: bool,
+    registered: bool,
+) -> bool:
+    """Register remote SKI with bridge, optionally forcing re-registration."""
+    try:
+        await device_stub.RegisterRemoteSKI(proto_stubs.RegisterSKIRequest(ski=ski), timeout=RPC_TIMEOUT)
+        if force:
+            _LOGGER.info("Forced re-registration of remote SKI %s with bridge", ski)
+        else:
+            _LOGGER.info("Registered remote SKI %s with bridge", ski)
+        return True
+    except grpc.aio.AioRpcError as err:
+        if force:
+            _LOGGER.warning(
+                "Forced remote SKI re-registration failed for %s: %s",
+                ski,
+                _rpc_error_text(err),
+            )
+        else:
+            # Retry in next polling cycle until the bridge accepts registration.
+            _LOGGER.debug(
+                "Remote SKI registration pending for %s: %s",
+                ski,
+                _rpc_error_text(err),
+            )
+        return registered
+
+
+async def _async_fetch_device_info(
+    device_stub: proto_stubs.DeviceServiceStub, ski: str
+) -> DeviceInfo | None:
+    """Read classification metadata for the configured device, best-effort."""
+    try:
+        response = await device_stub.ListPairedDevices(proto_stubs.Empty(), timeout=RPC_TIMEOUT)
+    except grpc.aio.AioRpcError as err:
+        if not _is_unimplemented(err):
+            _LOGGER.debug(
+                "ListPairedDevices failed for SKI %s: %s",
+                ski,
+                _rpc_error_text(err),
+            )
+        return None
+    except Exception:  # noqa: BLE001
+        _LOGGER.exception("Failed to list paired devices")
+        return None
+
+    devices = list(response.devices)
+    if not devices:
+        return None
+
+    match = next((device for device in devices if device.ski == ski), None)
+    if match is None:
+        return None
+
+    info: DeviceInfo = {}
+    if match.brand:
+        info["manufacturer"] = match.brand
+    if match.model:
+        info["model"] = match.model
+    if match.serial:
+        info["serial"] = match.serial
+    if match.device_type:
+        info["device_type"] = match.device_type
+    return info or None
+
+
+async def _async_read_compressor_flexibility(
+    channel: grpc.aio.Channel,
+    request: proto_stubs.DeviceRequest,
+    ski: str,
+    current_support: bool | None,
+) -> _ReadResult[CompressorFlexibilityState]:
+    """Read the OHPCF compressor flexibility offer/state, or None when off."""
+    try:
+        stub = proto_stubs.ohpcf_service_stub(channel)
+        flex: proto_stubs.CompressorFlexibility = await stub.GetCompressorFlexibility(
+            request, timeout=RPC_TIMEOUT
+        )
+    except grpc.aio.AioRpcError as err:
+        supported = current_support
+        if _is_unimplemented(err) or err.code() == grpc.StatusCode.UNAVAILABLE:
+            supported = False
+        else:
+            _LOGGER.debug(
+                "EEBUS OHPCF read failed for SKI %s: %s",
+                ski,
+                _rpc_error_text(err),
+            )
+        return _ReadResult(None, supported)
+
+    value: CompressorFlexibilityState = {
+        "available": flex.available,
+        "state": proto_stubs.CompressorPowerConsumptionState.Name(flex.state),
+        "requested_power_estimate_w": (
+            flex.requested_power_estimate_w if flex.HasField("requested_power_estimate_w") else None
+        ),
+        "requested_power_max_w": flex.requested_power_max_w if flex.HasField("requested_power_max_w") else None,
+        "is_pausable": flex.is_pausable,
+        "is_stoppable": flex.is_stoppable,
+        "minimal_run_seconds": flex.minimal_run_seconds,
+        "minimal_pause_seconds": flex.minimal_pause_seconds,
+    }
+    return _ReadResult(value, True)
+
+
+async def _async_read_dhw_setpoint(
+    channel: grpc.aio.Channel,
+    request: proto_stubs.DeviceRequest,
+    ski: str,
+    current_support: bool | None,
+) -> _ReadResult[SetpointState]:
+    """Read the DHW target and device-provided constraints."""
+    try:
+        stub = proto_stubs.dhw_service_stub(channel)
+        setpoint: proto_stubs.DHWSetpoint = await stub.GetDHWSetpoint(request, timeout=RPC_TIMEOUT)
+    except grpc.aio.AioRpcError as err:
+        supported = current_support
+        if _is_unimplemented(err) or err.code() in (
+            grpc.StatusCode.NOT_FOUND,
+            grpc.StatusCode.UNAVAILABLE,
+        ):
+            supported = False
+        else:
+            _LOGGER.debug(
+                "EEBUS DHW setpoint read failed for SKI %s: %s",
+                ski,
+                _rpc_error_text(err),
+            )
+        return _ReadResult(None, supported)
+    return _ReadResult(_setpoint_to_dict(setpoint), True)
+
+
+async def _async_read_dhw_system_function(
+    channel: grpc.aio.Channel,
+    request: proto_stubs.DeviceRequest,
+    ski: str,
+    current_support: bool | None,
+) -> _ReadResult[DHWSystemFunctionState]:
+    """Read DHW boost and operation mode state."""
+    try:
+        stub = proto_stubs.dhw_service_stub(channel)
+        state: proto_stubs.DHWSystemFunctionState = await stub.GetDHWSystemFunction(
+            request, timeout=RPC_TIMEOUT
+        )
+    except grpc.aio.AioRpcError as err:
+        supported = current_support
+        if _is_unimplemented(err) or err.code() in (
+            grpc.StatusCode.NOT_FOUND,
+            grpc.StatusCode.UNAVAILABLE,
+        ):
+            supported = False
+        else:
+            _LOGGER.debug(
+                "EEBUS DHW system function read failed for SKI %s: %s",
+                ski,
+                _rpc_error_text(err),
+            )
+        return _ReadResult(None, supported)
+    return _ReadResult(_dhw_system_function_to_dict(state), True)
+
+
+async def _async_read_room_heating(
+    channel: grpc.aio.Channel,
+    request: proto_stubs.DeviceRequest,
+    current_support: bool | None,
+) -> _ReadResult[_RoomHeatingRead]:
+    """Read all room-heating fields without publishing a partial update."""
+    try:
+        state: proto_stubs.RoomHeatingState = await proto_stubs.hvac_service_stub(channel).GetRoomHeating(
+            request, timeout=RPC_TIMEOUT
+        )
+    except grpc.aio.AioRpcError as err:
+        supported = current_support
+        if _is_unimplemented(err) or err.code() in (
+            grpc.StatusCode.NOT_FOUND,
+            grpc.StatusCode.UNAVAILABLE,
+        ):
+            supported = False
+        return _ReadResult(None, supported)
+
+    setpoint = _setpoint_to_dict(state.setpoint) if state.HasField("setpoint") else None
+    system_function = (
+        _system_function_to_dict(state.system_function) if state.HasField("system_function") else None
+    )
+    current_temperature = (
+        state.current_temperature_celsius if state.HasField("current_temperature_celsius") else None
+    )
+    return _ReadResult(_RoomHeatingRead(setpoint, system_function, current_temperature), True)
+
+
+async def _async_read_device_diagnostics(
+    channel: grpc.aio.Channel, request: proto_stubs.DeviceRequest, ski: str
+) -> str | None:
+    """Read the device operating state."""
+    try:
+        diagnostics: proto_stubs.DeviceDiagnosticsData = await proto_stubs.monitoring_service_stub(
+            channel
+        ).GetDeviceDiagnostics(request, timeout=RPC_TIMEOUT)
+    except grpc.aio.AioRpcError as err:
+        if not (
+            _is_unimplemented(err)
+            or err.code() in (grpc.StatusCode.NOT_FOUND, grpc.StatusCode.UNAVAILABLE)
+        ):
+            _LOGGER.debug(
+                "EEBUS device diagnosis read failed for SKI %s: %s",
+                ski,
+                _rpc_error_text(err),
+            )
+        return None
+    return diagnostics.operating_state or None
+
+
+async def async_build_snapshot(
+    channel: grpc.aio.Channel,
+    ski: str,
+    support: SnapshotSupport,
+    *,
+    ski_registered: bool,
+    not_found_streak: int,
+) -> SnapshotResult:
+    """Read and assemble one complete coordinator snapshot atomically."""
+    device_stub = proto_stubs.device_service_stub(channel)
+    status: proto_stubs.ServiceStatus = await device_stub.GetStatus(proto_stubs.Empty())
+
+    registered = ski_registered
+    if not registered:
+        registered = await _async_register_remote_ski(
+            device_stub,
+            ski,
+            force=False,
+            registered=registered,
+        )
+
+    if ski == status.local_ski:
+        _LOGGER.warning(
+            "Configured remote SKI %s matches bridge local SKI; monitoring reads will stay empty",
+            ski,
+        )
+
+    monitoring_stub = proto_stubs.monitoring_service_stub(channel)
+    lpc_stub = proto_stubs.lpc_service_stub(channel)
+    request = proto_stubs.DeviceRequest(ski=ski)
+
+    power, measurements, energy, limit, failsafe, heartbeat = await asyncio.gather(
+        _poll_read(
+            "power",
+            cast(_ReadCall[proto_stubs.PowerMeasurement], monitoring_stub.GetPowerConsumption),
+            request,
+            ski,
+        ),
+        _poll_read(
+            "scoped energy",
+            cast(_ReadCall[proto_stubs.MeasurementList], monitoring_stub.GetMeasurements),
+            request,
+            ski,
+        ),
+        _poll_read(
+            "total energy",
+            cast(_ReadCall[proto_stubs.EnergyMeasurement], monitoring_stub.GetEnergyConsumed),
+            request,
+            ski,
+        ),
+        _poll_read(
+            "consumption limit",
+            cast(_ReadCall[proto_stubs.LoadLimit], lpc_stub.GetConsumptionLimit),
+            request,
+            ski,
+            track_support=True,
+            current_support=support.lpc,
+        ),
+        _poll_read(
+            "failsafe",
+            cast(_ReadCall[proto_stubs.FailsafeLimit], lpc_stub.GetFailsafeLimit),
+            request,
+            ski,
+            track_support=True,
+            current_support=support.failsafe,
+        ),
+        _poll_read(
+            "heartbeat",
+            cast(_ReadCall[proto_stubs.HeartbeatStatus], lpc_stub.GetHeartbeatStatus),
+            request,
+            ski,
+            track_support=True,
+            current_support=support.heartbeat,
+        ),
+    )
+
+    device_info, compressor, dhw_setpoint, dhw_system_function, room_heating, diagnostics = await asyncio.gather(
+        _async_fetch_device_info(device_stub, ski),
+        _async_read_compressor_flexibility(channel, request, ski, support.ohpcf),
+        _async_read_dhw_setpoint(channel, request, ski, support.dhw),
+        _async_read_dhw_system_function(channel, request, ski, support.dhw_system_function),
+        _async_read_room_heating(channel, request, support.room_heating),
+        _async_read_device_diagnostics(channel, request, ski),
+    )
+
+    updated_support = SnapshotSupport(
+        lpc=limit.supported,
+        failsafe=failsafe.supported,
+        heartbeat=heartbeat.supported,
+        ohpcf=compressor.supported,
+        dhw=dhw_setpoint.supported,
+        dhw_system_function=dhw_system_function.supported,
+        room_heating=room_heating.supported,
+    )
+
+    flat_measurements: dict[str, float | None] = {}
+    scoped_energy: dict[str, float | None] = {"heating": None, "dhw": None}
+    if measurements.value is not None:
+        scoped_energy = _extract_scoped_energy_kwh(measurements.value.measurements)
+        flat_measurements = _extract_flat_measurements(measurements.value.measurements)
+
+    consumption_limit: ConsumptionLimitState | None = None
+    if limit.value is not None:
+        consumption_limit = {
+            "value_watts": limit.value.value_watts,
+            "is_active": limit.value.is_active,
+            "is_changeable": limit.value.is_changeable,
+        }
+
+    failsafe_limit: FailsafeState | None = None
+    if failsafe.value is not None:
+        failsafe_limit = {
+            "value_watts": failsafe.value.value_watts,
+            "duration_minimum_seconds": failsafe.value.duration_minimum_seconds,
+        }
+
+    heartbeat_status: HeartbeatState | None = None
+    if heartbeat.value is not None:
+        heartbeat_status = {
+            "running": heartbeat.value.running,
+            "within_duration": heartbeat.value.within_duration,
+        }
+
+    room_heating_value = room_heating.value
+    room_temperature_c = flat_measurements.get("room_temperature_c")
+    if room_heating_value is not None and room_heating_value.current_temperature_celsius is not None:
+        room_temperature_c = room_heating_value.current_temperature_celsius
+
+    snapshot = CoordinatorSnapshot(
+        connected=status.running,
+        local_ski=status.local_ski,
+        ski_registered=registered,
+        power_l1_w=flat_measurements.get("power_l1_w"),
+        power_l2_w=flat_measurements.get("power_l2_w"),
+        power_l3_w=flat_measurements.get("power_l3_w"),
+        current_l1_a=flat_measurements.get("current_l1_a"),
+        current_l2_a=flat_measurements.get("current_l2_a"),
+        current_l3_a=flat_measurements.get("current_l3_a"),
+        voltage_l1_v=flat_measurements.get("voltage_l1_v"),
+        voltage_l2_v=flat_measurements.get("voltage_l2_v"),
+        voltage_l3_v=flat_measurements.get("voltage_l3_v"),
+        frequency_hz=flat_measurements.get("frequency_hz"),
+        energy_produced_kwh=flat_measurements.get("energy_produced_kwh"),
+        dhw_temperature_c=flat_measurements.get("dhw_temperature_c"),
+        room_temperature_c=room_temperature_c,
+        outdoor_temperature_c=flat_measurements.get("outdoor_temperature_c"),
+        flow_temperature_c=flat_measurements.get("flow_temperature_c"),
+        return_temperature_c=flat_measurements.get("return_temperature_c"),
+        compressor_temperature_c=flat_measurements.get("compressor_temperature_c"),
+        compressor_power_w=flat_measurements.get("compressor_power_w"),
+        power_watts=power.value.watts if power.value is not None else None,
+        energy_consumed_heating_kwh=scoped_energy["heating"],
+        energy_consumed_dhw_kwh=scoped_energy["dhw"],
+        energy_consumed_kwh=energy.value.kilowatt_hours if energy.value is not None else None,
+        consumption_limit=consumption_limit,
+        failsafe_limit=failsafe_limit,
+        heartbeat_status=heartbeat_status,
+        heartbeat_supported=updated_support.heartbeat,
+        lpc_supported=updated_support.lpc,
+        failsafe_supported=updated_support.failsafe,
+        device_info=device_info,
+        compressor_flexibility=compressor.value,
+        dhw_setpoint=dhw_setpoint.value,
+        dhw_system_function=dhw_system_function.value,
+        room_heating_setpoint=room_heating_value.setpoint if room_heating_value is not None else None,
+        room_heating_system_function=(
+            room_heating_value.system_function if room_heating_value is not None else None
+        ),
+        device_operating_state=diagnostics,
+        ohpcf_supported=updated_support.ohpcf,
+        dhw_supported=updated_support.dhw,
+        dhw_sysfn_supported=updated_support.dhw_system_function,
+        room_heating_supported=updated_support.room_heating,
+    )
+
+    saw_not_found = any(
+        result.saw_not_found for result in (power, measurements, energy, limit, failsafe, heartbeat)
+    )
+    updated_not_found_streak = not_found_streak + 1 if saw_not_found else 0
+    if updated_not_found_streak >= RE_REGISTER_NOT_FOUND_STREAK:
+        _LOGGER.warning(
+            "EEBUS reads returned NOT_FOUND for %s consecutive polls; forcing remote SKI re-registration for %s",
+            updated_not_found_streak,
+            ski,
+        )
+        registered = await _async_register_remote_ski(
+            device_stub,
+            ski,
+            force=True,
+            registered=registered,
+        )
+        updated_not_found_streak = 0
+
+    _LOGGER.debug(
+        "EEBUS poll summary for SKI %s: power=%s energy_total=%s energy_heating=%s energy_dhw=%s",
+        ski,
+        snapshot["power_watts"],
+        snapshot["energy_consumed_kwh"],
+        snapshot["energy_consumed_heating_kwh"],
+        snapshot["energy_consumed_dhw_kwh"],
+    )
+
+    return SnapshotResult(snapshot, updated_support, registered, updated_not_found_streak)

--- a/custom_components/eebus/switch.py
+++ b/custom_components/eebus/switch.py
@@ -12,6 +12,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .coordinator import EebusCoordinator
 from .entity import EebusEntity
+from .models import DHWSystemFunctionState
 
 PARALLEL_UPDATES = 0  # Coordinator-based, no per-entity polling
 
@@ -110,7 +111,7 @@ class EebusDHWBoostSwitch(EebusEntity, SwitchEntity):
         super().__init__(coordinator)
         self._attr_unique_id = f"{coordinator.ski}_dhw_boost"
 
-    def _state(self) -> dict[str, Any] | None:
+    def _state(self) -> DHWSystemFunctionState | None:
         if self.coordinator.data is None:
             return None
         return self.coordinator.data.get("dhw_system_function")

--- a/custom_components/eebus/tests/test_coordinator.py
+++ b/custom_components/eebus/tests/test_coordinator.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import inspect
+from contextlib import ExitStack, contextmanager
 from datetime import timedelta
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, call, patch
@@ -13,8 +14,15 @@ from homeassistant.exceptions import ConfigEntryAuthFailed
 
 from custom_components.eebus import proto_stubs
 from custom_components.eebus.coordinator import EebusCoordinator, POLL_INTERVAL
+from custom_components.eebus.models import _extract_flat_measurements
+from custom_components.eebus.snapshot import (
+    _async_fetch_device_info,
+    _async_read_device_diagnostics,
+    _poll_read,
+)
 from custom_components.eebus.generated.eebus.v1 import (
     device_service_pb2,
+    hvac_service_pb2,
     lpc_service_pb2,
     monitoring_service_pb2,
 )
@@ -30,6 +38,107 @@ def _device_stub_returning(*devices):
     stub = MagicMock()
     stub.ListPairedDevices = _list
     return stub
+
+
+def _poll_stubs(room_heating_read):
+    """Build complete service stubs for one polling snapshot."""
+    unsupported = AioRpcError(
+        grpc.StatusCode.UNIMPLEMENTED,
+        Metadata(),
+        Metadata(),
+        details="use case disabled",
+    )
+    device_stub = SimpleNamespace(
+        GetStatus=AsyncMock(
+            return_value=device_service_pb2.ServiceStatus(
+                running=True, local_ski="bridge-ski"
+            )
+        ),
+        ListPairedDevices=AsyncMock(
+            return_value=device_service_pb2.ListPairedDevicesResponse()
+        ),
+        RegisterRemoteSKI=AsyncMock(return_value=proto_stubs.Empty()),
+    )
+    monitoring_stub = SimpleNamespace(
+        GetPowerConsumption=AsyncMock(
+            return_value=proto_stubs.PowerMeasurement(watts=1234.0)
+        ),
+        GetMeasurements=AsyncMock(
+            return_value=monitoring_service_pb2.MeasurementList()
+        ),
+        GetEnergyConsumed=AsyncMock(
+            return_value=monitoring_service_pb2.EnergyMeasurement(
+                kilowatt_hours=42.0
+            )
+        ),
+        GetDeviceDiagnostics=AsyncMock(
+            return_value=proto_stubs.DeviceDiagnosticsData(
+                operating_state="normalOperation"
+            )
+        ),
+    )
+    lpc_stub = SimpleNamespace(
+        GetConsumptionLimit=AsyncMock(
+            return_value=proto_stubs.LoadLimit(
+                value_watts=4200.0, is_active=True, is_changeable=True
+            )
+        ),
+        GetFailsafeLimit=AsyncMock(
+            return_value=lpc_service_pb2.FailsafeLimit(
+                value_watts=3000.0, duration_minimum_seconds=7200
+            )
+        ),
+        GetHeartbeatStatus=AsyncMock(
+            return_value=lpc_service_pb2.HeartbeatStatus(
+                running=True, within_duration=True
+            )
+        ),
+    )
+    return {
+        "device_service_stub": device_stub,
+        "monitoring_service_stub": monitoring_stub,
+        "lpc_service_stub": lpc_stub,
+        "ohpcf_service_stub": SimpleNamespace(
+            GetCompressorFlexibility=AsyncMock(side_effect=unsupported)
+        ),
+        "dhw_service_stub": SimpleNamespace(
+            GetDHWSetpoint=AsyncMock(side_effect=unsupported),
+            GetDHWSystemFunction=AsyncMock(side_effect=unsupported),
+        ),
+        "hvac_service_stub": SimpleNamespace(GetRoomHeating=room_heating_read),
+    }
+
+
+def _poll_coordinator():
+    """Build a coordinator skeleton with all snapshot-owned state initialized."""
+    coordinator = EebusCoordinator.__new__(EebusCoordinator)
+    coordinator.host = "bridge.local"
+    coordinator.port = 50051
+    coordinator.ski = "device-ski"
+    coordinator.data = {"room_temperature_c": 18.0}
+    coordinator._channel_manager = MagicMock()
+    coordinator._channel_manager.invalidate = AsyncMock()
+    coordinator._ensure_channel = AsyncMock(return_value=MagicMock())
+    coordinator._was_unavailable = False
+    coordinator._lpc_supported = None
+    coordinator._failsafe_supported = None
+    coordinator._heartbeat_supported = None
+    coordinator._ohpcf_supported = None
+    coordinator._dhw_supported = None
+    coordinator._dhw_sysfn_supported = None
+    coordinator._room_heating_supported = None
+    coordinator._ski_registered = True
+    coordinator._not_found_streak = 0
+    return coordinator
+
+
+@contextmanager
+def _patch_poll_stubs(stubs):
+    """Patch every snapshot stub factory with the supplied fake service."""
+    with ExitStack() as stack:
+        for factory, stub in stubs.items():
+            stack.enter_context(patch.object(proto_stubs, factory, return_value=stub))
+        yield
 
 
 def test_coordinator_poll_interval():
@@ -69,8 +178,17 @@ async def test_unauthenticated_poll_starts_reauthentication():
     coordinator = EebusCoordinator.__new__(EebusCoordinator)
     coordinator._channel_manager = MagicMock()
     coordinator._channel_manager.invalidate = AsyncMock()
+    coordinator.ski = "test-ski"
     coordinator._not_found_streak = 0
     coordinator._was_unavailable = False
+    coordinator._lpc_supported = None
+    coordinator._failsafe_supported = None
+    coordinator._heartbeat_supported = None
+    coordinator._ohpcf_supported = None
+    coordinator._dhw_supported = None
+    coordinator._dhw_sysfn_supported = None
+    coordinator._room_heating_supported = None
+    coordinator._ski_registered = False
     coordinator._ensure_channel = AsyncMock(return_value=MagicMock())
     stub = MagicMock()
     stub.GetStatus = AsyncMock(
@@ -87,6 +205,62 @@ async def test_unauthenticated_poll_starts_reauthentication():
             await coordinator._async_update_data()
 
     coordinator._channel_manager.invalidate.assert_awaited_once_with()
+
+
+async def test_poll_returns_room_temperature_without_mid_poll_push():
+    """Room-heating temperature is part of the atomic poll snapshot."""
+    room_temperature = 21.5
+    room_read = AsyncMock(
+        return_value=hvac_service_pb2.RoomHeatingState(
+            current_temperature_celsius=room_temperature
+        )
+    )
+    coordinator = _poll_coordinator()
+    coordinator._push_data = MagicMock()
+
+    with _patch_poll_stubs(_poll_stubs(room_read)):
+        snapshot = await coordinator._async_update_data()
+
+    assert snapshot["room_temperature_c"] == room_temperature
+    assert coordinator.data == {"room_temperature_c": 18.0}
+    coordinator._push_data.assert_not_called()
+
+
+async def test_poll_applies_support_flags_only_after_all_reads_complete():
+    """Completed reads cannot mutate coordinator support flags while a peer read is pending."""
+    room_read_started = asyncio.Event()
+    finish_room_read = asyncio.Event()
+
+    async def room_read(_request, timeout=None):
+        room_read_started.set()
+        await finish_room_read.wait()
+        return hvac_service_pb2.RoomHeatingState(current_temperature_celsius=20.0)
+
+    coordinator = _poll_coordinator()
+    with _patch_poll_stubs(_poll_stubs(room_read)):
+        poll_task = asyncio.create_task(coordinator._async_update_data())
+        await room_read_started.wait()
+        await asyncio.sleep(0)
+
+        assert poll_task.done() is False
+        assert coordinator._lpc_supported is None
+        assert coordinator._failsafe_supported is None
+        assert coordinator._heartbeat_supported is None
+        assert coordinator._ohpcf_supported is None
+        assert coordinator._dhw_supported is None
+        assert coordinator._dhw_sysfn_supported is None
+        assert coordinator._room_heating_supported is None
+
+        finish_room_read.set()
+        await poll_task
+
+    assert coordinator._lpc_supported is True
+    assert coordinator._failsafe_supported is True
+    assert coordinator._heartbeat_supported is True
+    assert coordinator._ohpcf_supported is False
+    assert coordinator._dhw_supported is False
+    assert coordinator._dhw_sysfn_supported is False
+    assert coordinator._room_heating_supported is True
 
 
 async def test_ensure_channel_delegates_to_channel_manager():
@@ -202,12 +376,10 @@ async def test_read_device_diagnostics_returns_operating_state():
         async def GetDeviceDiagnostics(self, _request, timeout=None):
             return proto_stubs.DeviceDiagnosticsData(operating_state="normalOperation")
 
-    coordinator, _ = _make_coordinator()
-    module = SimpleNamespace(monitoring_service_stub=lambda _channel: MonitoringStub())
-
-    result = await coordinator._async_read_device_diagnostics(
-        MagicMock(), module, proto_stubs.DeviceRequest(ski="test-ski")
-    )
+    with patch.object(proto_stubs, "monitoring_service_stub", return_value=MonitoringStub()):
+        result = await _async_read_device_diagnostics(
+            MagicMock(), proto_stubs.DeviceRequest(ski="test-ski"), "test-ski"
+        )
 
     assert result == "normalOperation"
 
@@ -224,12 +396,10 @@ async def test_read_device_diagnostics_unavailable_returns_none():
                 details="device operating state unavailable",
             )
 
-    coordinator, _ = _make_coordinator()
-    module = SimpleNamespace(monitoring_service_stub=lambda _channel: MonitoringStub())
-
-    result = await coordinator._async_read_device_diagnostics(
-        MagicMock(), module, proto_stubs.DeviceRequest(ski="test-ski")
-    )
+    with patch.object(proto_stubs, "monitoring_service_stub", return_value=MonitoringStub()):
+        result = await _async_read_device_diagnostics(
+            MagicMock(), proto_stubs.DeviceRequest(ski="test-ski"), "test-ski"
+        )
 
     assert result is None
 
@@ -349,7 +519,6 @@ def test_measurement_power_event_without_payload_refreshes():
 
 def test_fetch_device_info_uses_matching_ski():
     """Real brand/model/serial for the configured SKI is surfaced (issue #28)."""
-    coordinator, _ = _make_coordinator(ski="bosch-ski")
     stub = _device_stub_returning(
         device_service_pb2.PairedDevice(ski="other", brand="Vaillant", model="VR940f"),
         device_service_pb2.PairedDevice(
@@ -360,7 +529,7 @@ def test_fetch_device_info_uses_matching_ski():
             device_type="HeatPumpAppliance",
         ),
     )
-    info = asyncio.run(coordinator._async_fetch_device_info(stub, proto_stubs))
+    info = asyncio.run(_async_fetch_device_info(stub, "bosch-ski"))
     assert info == {
         "manufacturer": "Bosch",
         "model": "Compress 5800i",
@@ -371,22 +540,20 @@ def test_fetch_device_info_uses_matching_ski():
 
 def test_fetch_device_info_single_mismatched_device_returns_none():
     """A sole mismatched device is not used as metadata fallback."""
-    coordinator, _ = _make_coordinator(ski="configured-ski")
     stub = _device_stub_returning(
         device_service_pb2.PairedDevice(ski="actual-ski", brand="Bosch")
     )
-    info = asyncio.run(coordinator._async_fetch_device_info(stub, proto_stubs))
+    info = asyncio.run(_async_fetch_device_info(stub, "configured-ski"))
     assert info is None
 
 
 def test_fetch_device_info_no_match_returns_none():
     """No SKI match yields None (no cross-device mislabeling)."""
-    coordinator, _ = _make_coordinator(ski="configured-ski")
     stub = _device_stub_returning(
         device_service_pb2.PairedDevice(ski="a", brand="Bosch"),
         device_service_pb2.PairedDevice(ski="b", brand="Vaillant"),
     )
-    info = asyncio.run(coordinator._async_fetch_device_info(stub, proto_stubs))
+    info = asyncio.run(_async_fetch_device_info(stub, "configured-ski"))
     assert info is None
 
 
@@ -404,8 +571,8 @@ async def test_two_coordinators_isolate_device_info_and_events():
     )
 
     info_a, info_b = await asyncio.gather(
-        coordinator_a._async_fetch_device_info(stub, proto_stubs),
-        coordinator_b._async_fetch_device_info(stub, proto_stubs),
+        _async_fetch_device_info(stub, coordinator_a.ski),
+        _async_fetch_device_info(stub, coordinator_b.ski),
     )
     assert info_a == {"manufacturer": "Brand A"}
     assert info_b == {"manufacturer": "Brand B"}
@@ -424,7 +591,6 @@ async def test_two_coordinators_isolate_device_info_and_events():
 
 async def test_poll_read_not_found_does_not_retry_with_empty_ski():
     """A failed device-scoped read is attempted exactly once."""
-    coordinator, _ = _make_coordinator(ski="ski-a")
     call = AsyncMock(
         side_effect=AioRpcError(
             grpc.StatusCode.NOT_FOUND,
@@ -434,12 +600,10 @@ async def test_poll_read_not_found_does_not_retry_with_empty_ski():
         )
     )
     request = proto_stubs.DeviceRequest(ski="ski-a")
-    flags = {"saw_not_found": False}
+    result = await _poll_read("power", call, request, "ski-a")
 
-    result = await coordinator._poll_read("power", call, request, flags)
-
-    assert result is None
-    assert flags["saw_not_found"] is True
+    assert result.value is None
+    assert result.saw_not_found is True
     call.assert_awaited_once_with(request, timeout=10)
 
 
@@ -475,7 +639,7 @@ def test_extract_flat_measurements_maps_types():
         # Unrelated / scoped types are ignored by the flat extractor.
         _entry("energy_consumed", 99.0),
     ]
-    result = EebusCoordinator._extract_flat_measurements(entries)
+    result = _extract_flat_measurements(entries)
     assert result == {
         "power_l1_w": 230.0,
         "current_l2_a": 4.5,
@@ -495,7 +659,7 @@ def test_extract_flat_measurements_ignores_blank_and_missing():
         _entry("voltage_l1", None),
         _entry("power_l1", 0.0),
     ]
-    result = EebusCoordinator._extract_flat_measurements(entries)
+    result = _extract_flat_measurements(entries)
     assert result == {"power_l1_w": 0.0}
 
 

--- a/custom_components/eebus/tests/test_dhw.py
+++ b/custom_components/eebus/tests/test_dhw.py
@@ -12,6 +12,10 @@ from homeassistant.const import ATTR_TEMPERATURE
 from custom_components.eebus import proto_stubs
 from custom_components.eebus.coordinator import EebusCoordinator
 from custom_components.eebus.generated.eebus.v1 import dhw_service_pb2
+from custom_components.eebus.snapshot import (
+    _async_read_dhw_setpoint,
+    _async_read_dhw_system_function,
+)
 from custom_components.eebus.switch import EebusDHWBoostSwitch
 from custom_components.eebus.water_heater import EebusDHWWaterHeater
 
@@ -23,10 +27,6 @@ def _coordinator(data=None):
     coordinator._dhw_supported = None
     coordinator._dhw_sysfn_supported = None
     return coordinator
-
-
-def _fake_proto(stub):
-    return SimpleNamespace(dhw_service_stub=lambda _channel: stub)
 
 
 def test_read_dhw_setpoint_maps_value_and_constraints():
@@ -41,20 +41,25 @@ def test_read_dhw_setpoint_maps_value_and_constraints():
     stub = SimpleNamespace(GetDHWSetpoint=AsyncMock(return_value=response))
     coordinator = _coordinator()
 
-    result = asyncio.run(
-        coordinator._async_read_dhw_setpoint(
-            None, _fake_proto(stub), proto_stubs.DeviceRequest(ski=coordinator.ski)
+    with patch.object(proto_stubs, "dhw_service_stub", return_value=stub):
+        result = asyncio.run(
+            _async_read_dhw_setpoint(
+                None,
+                proto_stubs.DeviceRequest(ski=coordinator.ski),
+                coordinator.ski,
+                coordinator._dhw_supported,
+            )
         )
-    )
 
-    assert result == {
+    assert result.value == {
         "value_celsius": 46,
         "min_celsius": 35,
         "max_celsius": 70,
         "step_celsius": 1,
         "writable": True,
     }
-    assert coordinator._dhw_supported is True
+    assert result.supported is True
+    assert coordinator._dhw_supported is None
 
 
 def test_read_dhw_setpoint_not_found_marks_unsupported():
@@ -63,14 +68,19 @@ def test_read_dhw_setpoint_not_found_marks_unsupported():
     stub = SimpleNamespace(GetDHWSetpoint=AsyncMock(side_effect=error))
     coordinator = _coordinator()
 
-    result = asyncio.run(
-        coordinator._async_read_dhw_setpoint(
-            None, _fake_proto(stub), proto_stubs.DeviceRequest(ski=coordinator.ski)
+    with patch.object(proto_stubs, "dhw_service_stub", return_value=stub):
+        result = asyncio.run(
+            _async_read_dhw_setpoint(
+                None,
+                proto_stubs.DeviceRequest(ski=coordinator.ski),
+                coordinator.ski,
+                coordinator._dhw_supported,
+            )
         )
-    )
 
-    assert result is None
-    assert coordinator._dhw_supported is False
+    assert result.value is None
+    assert result.supported is False
+    assert coordinator._dhw_supported is None
 
 
 def test_dhw_water_heater_combines_temperatures_modes_and_writes():
@@ -197,20 +207,25 @@ def test_read_dhw_system_function_maps_state():
     stub = SimpleNamespace(GetDHWSystemFunction=AsyncMock(return_value=response))
     coordinator = _coordinator()
 
-    result = asyncio.run(
-        coordinator._async_read_dhw_system_function(
-            None, _fake_proto(stub), proto_stubs.DeviceRequest(ski=coordinator.ski)
+    with patch.object(proto_stubs, "dhw_service_stub", return_value=stub):
+        result = asyncio.run(
+            _async_read_dhw_system_function(
+                None,
+                proto_stubs.DeviceRequest(ski=coordinator.ski),
+                coordinator.ski,
+                coordinator._dhw_sysfn_supported,
+            )
         )
-    )
 
-    assert result == {
+    assert result.value == {
         "boost_status": "running",
         "boost_writable": True,
         "operation_mode": "auto",
         "available_modes": ["auto", "on", "off"],
         "mode_writable": True,
     }
-    assert coordinator._dhw_sysfn_supported is True
+    assert result.supported is True
+    assert coordinator._dhw_sysfn_supported is None
 
 
 def test_read_dhw_system_function_not_found_marks_unsupported():
@@ -219,14 +234,19 @@ def test_read_dhw_system_function_not_found_marks_unsupported():
     stub = SimpleNamespace(GetDHWSystemFunction=AsyncMock(side_effect=error))
     coordinator = _coordinator()
 
-    result = asyncio.run(
-        coordinator._async_read_dhw_system_function(
-            None, _fake_proto(stub), proto_stubs.DeviceRequest(ski=coordinator.ski)
+    with patch.object(proto_stubs, "dhw_service_stub", return_value=stub):
+        result = asyncio.run(
+            _async_read_dhw_system_function(
+                None,
+                proto_stubs.DeviceRequest(ski=coordinator.ski),
+                coordinator.ski,
+                coordinator._dhw_sysfn_supported,
+            )
         )
-    )
 
-    assert result is None
-    assert coordinator._dhw_sysfn_supported is False
+    assert result.value is None
+    assert result.supported is False
+    assert coordinator._dhw_sysfn_supported is None
 
 
 def test_dhw_system_function_writes_map_validation_errors():

--- a/custom_components/eebus/tests/test_ohpcf.py
+++ b/custom_components/eebus/tests/test_ohpcf.py
@@ -14,6 +14,7 @@ from custom_components.eebus.coordinator import EebusCoordinator
 from custom_components.eebus.generated.eebus.v1 import ohpcf_service_pb2 as ohpcf_pb2
 from custom_components.eebus.select import EebusCompressorFlexibilitySelect
 from custom_components.eebus.sensor import EebusMeasurementSensor, STATE_SENSORS
+from custom_components.eebus.snapshot import _async_read_compressor_flexibility
 
 
 def _coordinator(ski="test-ski"):
@@ -21,10 +22,6 @@ def _coordinator(ski="test-ski"):
     c.ski = ski
     c._ohpcf_supported = None
     return c
-
-
-def _fake_proto(stub):
-    return SimpleNamespace(ohpcf_service_stub=lambda _channel: stub)
 
 
 def test_read_compressor_flexibility_maps_fields():
@@ -40,11 +37,20 @@ def test_read_compressor_flexibility_maps_fields():
     )
     stub = SimpleNamespace(GetCompressorFlexibility=AsyncMock(return_value=flex))
 
-    out = asyncio.run(
-        c._async_read_compressor_flexibility(None, _fake_proto(stub), proto_stubs.DeviceRequest(ski=c.ski))
-    )
+    with patch.object(proto_stubs, "ohpcf_service_stub", return_value=stub):
+        result = asyncio.run(
+            _async_read_compressor_flexibility(
+                None,
+                proto_stubs.DeviceRequest(ski=c.ski),
+                c.ski,
+                c._ohpcf_supported,
+            )
+        )
+    out = result.value
 
-    assert c._ohpcf_supported is True
+    assert result.supported is True
+    assert c._ohpcf_supported is None
+    assert out is not None
     assert out["available"] is True
     assert out["state"] == "COMPRESSOR_STATE_RUNNING"
     assert out["requested_power_estimate_w"] == 1500.0
@@ -59,12 +65,19 @@ def test_read_compressor_flexibility_unavailable_marks_unsupported():
     err = AioRpcError(grpc.StatusCode.UNAVAILABLE, Metadata(), Metadata(), details="off")
     stub = SimpleNamespace(GetCompressorFlexibility=AsyncMock(side_effect=err))
 
-    out = asyncio.run(
-        c._async_read_compressor_flexibility(None, _fake_proto(stub), proto_stubs.DeviceRequest(ski=c.ski))
-    )
+    with patch.object(proto_stubs, "ohpcf_service_stub", return_value=stub):
+        result = asyncio.run(
+            _async_read_compressor_flexibility(
+                None,
+                proto_stubs.DeviceRequest(ski=c.ski),
+                c.ski,
+                c._ohpcf_supported,
+            )
+        )
 
-    assert out is None
-    assert c._ohpcf_supported is False
+    assert result.value is None
+    assert result.supported is False
+    assert c._ohpcf_supported is None
 
 
 def _select_with(flex):

--- a/custom_components/eebus/water_heater.py
+++ b/custom_components/eebus/water_heater.py
@@ -12,6 +12,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .coordinator import EebusCoordinator
 from .entity import EebusEntity
+from .models import DHWSystemFunctionState, SetpointState
 
 PARALLEL_UPDATES = 0  # Coordinator-based, no per-entity polling
 
@@ -37,13 +38,13 @@ class EebusDHWWaterHeater(EebusEntity, WaterHeaterEntity):
         super().__init__(coordinator)
         self._attr_unique_id = f"{coordinator.ski}_domestic_hot_water"
 
-    def _setpoint(self) -> dict[str, Any] | None:
+    def _setpoint(self) -> SetpointState | None:
         data = self.coordinator.data or {}
         if data.get("dhw_supported") is False:
             return None
         return data.get("dhw_setpoint")
 
-    def _system_function(self) -> dict[str, Any] | None:
+    def _system_function(self) -> DHWSystemFunctionState | None:
         data = self.coordinator.data or {}
         if data.get("dhw_sysfn_supported") is False:
             return None


### PR DESCRIPTION
## Summary
- New `models.py`: TypedDicts for coordinator state (`SetpointState`, `SystemFunctionState`, `DHWSystemFunctionState`, `ConsumptionLimitState`, `FailsafeState`, `HeartbeatState`, `CompressorFlexibilityState`, `DeviceInfo`, `CoordinatorSnapshot`) plus the existing pure proto→dict converters, now typed.
- New `snapshot.py`: `async_build_snapshot()` — moves the polling read/gather fan-out out of `coordinator.py`, returns one complete `CoordinatorSnapshot` + updated support flags.
- `coordinator._async_update_data` is now a thin wrapper: build snapshot, apply returned support flags, publish.
- Fixes an RF-05 spec violation found during extraction: room-heating temperature was pushed via `self._push_data(...)` mid-poll, before the rest of the snapshot was ready. Now returned through the snapshot so polling publishes atomically. Support flags (`_lpc_supported` etc.) are applied only after all reads complete, no longer mutated in-flight inside each read helper.
- Entity files (sensor/climate/select/switch/water_heater) consume the typed models instead of `dict[str, Any]`; `coordinator.data`'s observable keys/shape unchanged.

Part of RF-05 (Python lifecycle split), see `docs/refactoring-optimization-spec.md`.

## Test plan
- [x] `pytest` — 114 passed (+2 new regression tests: room_temperature_c returned via snapshot not mid-poll push; support flags applied only after all reads complete)
- [x] `ruff check custom_components/` — clean
- [x] `mypy custom_components/eebus` — strict, no issues