### PR TITLE
feat: RF-05 PR4 extract providers.py

### DIFF
--- a/custom_components/eebus/coordinator.py
+++ b/custom_components/eebus/coordinator.py
@@ -2,11 +2,7 @@
 
 from __future__ import annotations
 
-import asyncio
 import logging
-import math
-from collections.abc import Awaitable, Callable
-from contextlib import suppress
 from datetime import timedelta
 from functools import lru_cache
 from typing import TYPE_CHECKING, Any, cast
@@ -14,20 +10,8 @@ from typing import TYPE_CHECKING, Any, cast
 import grpc
 import grpc.aio
 
-from homeassistant.const import (
-    ATTR_UNIT_OF_MEASUREMENT,
-    PERCENTAGE,
-    STATE_UNAVAILABLE,
-    STATE_UNKNOWN,
-    UnitOfEnergy,
-    UnitOfPower,
-)
-from homeassistant.core import Event, HomeAssistant
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, ServiceValidationError
-from homeassistant.helpers.event import (
-    EventStateChangedData,
-    async_track_state_change_event,
-)
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import SECURITY_MODE_LOOPBACK
@@ -36,7 +20,6 @@ from .grpc_client import (
     WRITE_VALIDATION_CODES,
     GrpcChannelManager,
     is_unimplemented as _is_unimplemented,
-    rpc_error_text as _rpc_error_text,
 )
 from .models import (
     CoordinatorSnapshot,
@@ -44,6 +27,7 @@ from .models import (
     _setpoint_to_dict,
     _system_function_to_dict,
 )
+from .providers import ProviderManager
 from .snapshot import SnapshotSupport, async_build_snapshot
 from .streams import ConsumeFn, StreamManager
 
@@ -51,21 +35,6 @@ if TYPE_CHECKING:
     from . import proto_stubs
 
 _LOGGER = logging.getLogger(__name__)
-
-# Convert a Home Assistant grid sensor's value to the unit the MGCP provider
-# expects (power in W, energy in Wh) using its unit_of_measurement attribute.
-POWER_UNIT_TO_W: dict[str, float] = {
-    UnitOfPower.WATT: 1.0,
-    UnitOfPower.KILO_WATT: 1000.0,
-    UnitOfPower.MEGA_WATT: 1_000_000.0,
-}
-ENERGY_UNIT_TO_WH: dict[str, float] = {
-    UnitOfEnergy.WATT_HOUR: 1.0,
-    UnitOfEnergy.KILO_WATT_HOUR: 1000.0,
-    UnitOfEnergy.MEGA_WATT_HOUR: 1_000_000.0,
-}
-# State of charge is a plain percentage (0-100); no conversion needed.
-SOC_UNIT_TO_PCT: dict[str, float] = {PERCENTAGE: 1.0}
 
 # Event streams deliver push updates; polling only reconciles state the
 # streams cannot carry (scoped energy, heartbeat, support flags).
@@ -134,75 +103,6 @@ def _measurement_event_map() -> tuple[dict[int, tuple[str, str, str]], frozenset
         }
     )
     return value_events, support_events
-class _ProviderPusher:
-    """Serialize and coalesce state-triggered pushes for one provider."""
-
-    def __init__(
-        self,
-        hass: HomeAssistant,
-        label: str,
-        ski: str,
-        tracked: tuple[str | None, ...],
-        push: Callable[[], Awaitable[None]],
-    ) -> None:
-        self._hass = hass
-        self._label = label
-        self._ski = ski
-        self._entity_ids = [entity_id for entity_id in tracked if entity_id]
-        self._push = push
-        self._dirty = asyncio.Event()
-        self._task: asyncio.Task[None] | None = None
-        self._unsub: Callable[[], None] | None = None
-
-    def start(self) -> None:
-        """Subscribe to state changes and schedule the initial push."""
-        if self._task is not None:
-            return
-
-        def _on_change(_event: Event[EventStateChangedData]) -> None:
-            self.signal()
-
-        self._unsub = async_track_state_change_event(
-            self._hass, self._entity_ids, _on_change
-        )
-        self.signal()
-        self._task = self._hass.async_create_background_task(
-            self._run(), name=f"eebus_{self._label}_provider_push_{self._ski}"
-        )
-
-    def signal(self) -> None:
-        """Mark provider data dirty, coalescing repeated signals."""
-        self._dirty.set()
-
-    async def stop(self) -> None:
-        """Unsubscribe, then cancel and await the worker task."""
-        unsub = self._unsub
-        self._unsub = None
-        task = self._task
-        if task is None:
-            if unsub is not None:
-                unsub()
-            return
-        try:
-            if unsub is not None:
-                unsub()
-        finally:
-            task.cancel()
-            with suppress(asyncio.CancelledError):
-                await task
-            self._task = None
-
-    async def _run(self) -> None:
-        """Push the freshest state once per coalesced dirty signal."""
-        while True:
-            await self._dirty.wait()
-            self._dirty.clear()
-            try:
-                await self._push()
-            except asyncio.CancelledError:
-                raise
-            except Exception:  # noqa: BLE001
-                _LOGGER.exception("Unexpected failure pushing %s provider data", self._label)
 
 
 class EebusCoordinator(DataUpdateCoordinator[CoordinatorSnapshot]):
@@ -241,25 +141,25 @@ class EebusCoordinator(DataUpdateCoordinator[CoordinatorSnapshot]):
         self.security_mode = security_mode
         self.tls_ca_certificate = tls_ca_certificate
         self.auth_token = auth_token
-        # Optional grid sensors feeding the bridge MGCP provider (PV-surplus).
-        self.grid_power_entity = grid_power_entity
-        self.grid_feed_in_energy_entity = grid_feed_in_energy_entity
-        self.grid_consumption_energy_entity = grid_consumption_energy_entity
-        # Optional PV sensors feeding the bridge VAPD (display) provider.
-        self.pv_power_entity = pv_power_entity
-        self.pv_yield_energy_entity = pv_yield_energy_entity
-        self.pv_peak_power_entity = pv_peak_power_entity
-        # Optional battery sensors feeding the bridge VABD (display) provider.
-        self.battery_power_entity = battery_power_entity
-        self.battery_charged_energy_entity = battery_charged_energy_entity
-        self.battery_discharged_energy_entity = battery_discharged_energy_entity
-        self.battery_soc_entity = battery_soc_entity
         self._channel_manager = GrpcChannelManager(
             host, port, security_mode, tls_ca_certificate, auth_token
         )
         self._stream_manager = StreamManager(self.hass, self._channel_manager)
-        self._provider_pushers: list[_ProviderPusher] = []
-        self._provider_push_failing: dict[str, bool] = {}
+        self._provider_manager = ProviderManager(
+            self.hass,
+            self.ski,
+            self._ensure_channel,
+            grid_power_entity=grid_power_entity,
+            grid_feed_in_energy_entity=grid_feed_in_energy_entity,
+            grid_consumption_energy_entity=grid_consumption_energy_entity,
+            pv_power_entity=pv_power_entity,
+            pv_yield_energy_entity=pv_yield_energy_entity,
+            pv_peak_power_entity=pv_peak_power_entity,
+            battery_power_entity=battery_power_entity,
+            battery_charged_energy_entity=battery_charged_energy_entity,
+            battery_discharged_energy_entity=battery_discharged_energy_entity,
+            battery_soc_entity=battery_soc_entity,
+        )
         self._was_unavailable: bool = False
         self._heartbeat_supported: bool | None = None
         self._lpc_supported: bool | None = None
@@ -520,262 +420,41 @@ class EebusCoordinator(DataUpdateCoordinator[CoordinatorSnapshot]):
     @property
     def grid_push_enabled(self) -> bool:
         """Return True when a grid power sensor is mapped to the MGCP provider."""
-        return bool(self.grid_power_entity)
-
-    def _read_sensor_value(
-        self,
-        entity_id: str | None,
-        unit_map: dict[str, float],
-        kind: str,
-        *,
-        minimum: float | None = None,
-        maximum: float | None = None,
-    ) -> float | None:
-        """Read an HA sensor and normalize it via unit_map (W / Wh / %).
-
-        Returns None when the entity is unset, missing, unavailable,
-        non-numeric, non-finite (NaN/Inf), or outside ``[minimum, maximum]`` so
-        the caller can omit it from the push instead of advertising a bogus
-        reading to downstream equipment. ``kind`` is a short descriptor (e.g.
-        "grid power", "PV yield") used only for debug logging.
-        """
-        if not entity_id:
-            return None
-        state = self.hass.states.get(entity_id)
-        if state is None or state.state in (STATE_UNKNOWN, STATE_UNAVAILABLE, "", None):
-            return None
-        try:
-            value = float(state.state)
-        except (TypeError, ValueError):
-            _LOGGER.debug("%s sensor %s has non-numeric state %r", kind, entity_id, state.state)
-            return None
-        unit = state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
-        factor = unit_map.get(unit) if isinstance(unit, str) else None
-        if factor is None:
-            _LOGGER.debug(
-                "%s sensor %s has unknown unit %r; assuming base unit",
-                kind,
-                entity_id,
-                unit,
-            )
-            factor = 1.0
-        result = value * factor
-        if not math.isfinite(result):
-            _LOGGER.debug("%s sensor %s produced non-finite value %r", kind, entity_id, result)
-            return None
-        if (minimum is not None and result < minimum) or (
-            maximum is not None and result > maximum
-        ):
-            _LOGGER.debug(
-                "%s sensor %s value %r out of range [%s, %s]; omitting",
-                kind,
-                entity_id,
-                result,
-                minimum,
-                maximum,
-            )
-            return None
-        return result
-
-    async def _async_publish_provider(
-        self, label: str, stub_factory: str, publish_method: str, request: Any
-    ) -> None:
-        """Publish a provider reading to the bridge, quiet when the provider is off.
-
-        UNIMPLEMENTED/UNAVAILABLE mean the provider is disabled or the bridge is
-        down; skip quietly so a missing provider never spams or fails HA.
-        """
-        channel = await self._ensure_channel()
-        from . import proto_stubs
-
-        stub = getattr(proto_stubs, stub_factory)(channel)
-        failure_state: dict[str, bool] | None = getattr(
-            self, "_provider_push_failing", None
-        )
-        if failure_state is None:
-            failure_state = self._provider_push_failing = {}
-        try:
-            await getattr(stub, publish_method)(request, timeout=RPC_TIMEOUT)
-            if failure_state.pop(label, False):
-                _LOGGER.info("%s provider push recovered", label)
-            _LOGGER.debug("Pushed %s data: %s", label, request)
-        except grpc.aio.AioRpcError as err:
-            if _is_unimplemented(err) or err.code() == grpc.StatusCode.UNAVAILABLE:
-                _LOGGER.debug(
-                    "%s provider not ready; skipping push: %s", label, _rpc_error_text(err)
-                )
-                return
-            if failure_state.get(label, False):
-                _LOGGER.debug("Failed to push %s data: %s", label, _rpc_error_text(err))
-            else:
-                _LOGGER.warning("Failed to push %s data: %s", label, _rpc_error_text(err))
-                failure_state[label] = True
-
-    def _start_provider_push(
-        self,
-        label: str,
-        tracked: tuple[str | None, ...],
-        push: Callable[[], Awaitable[None]],
-    ) -> None:
-        """Start one lifecycle-owning provider push worker."""
-        pusher = _ProviderPusher(
-            self.hass,
-            label,
-            self.ski,
-            tracked,
-            push,
-        )
-        self._provider_pushers.append(pusher)
-        pusher.start()
+        return self._provider_manager.grid_push_enabled
 
     async def async_push_grid_data(self) -> None:
-        """Push the mapped grid sensors to the bridge MGCP provider.
-
-        Grid power is the surplus signal (negative = export); the energy totals
-        are optional. No-op when no grid power sensor is mapped or its value is
-        currently unavailable.
-        """
-        if not self.grid_power_entity:
-            return
-        power_w = self._read_sensor_value(self.grid_power_entity, POWER_UNIT_TO_W, "grid power")
-        if power_w is None:
-            return
-        feed_in_wh = self._read_sensor_value(
-            self.grid_feed_in_energy_entity, ENERGY_UNIT_TO_WH, "grid feed-in", minimum=0
-        )
-        consumed_wh = self._read_sensor_value(
-            self.grid_consumption_energy_entity, ENERGY_UNIT_TO_WH, "grid consumption", minimum=0
-        )
-
-        from . import proto_stubs
-
-        request = proto_stubs.GridData(power_w=power_w)
-        if feed_in_wh is not None:
-            request.feed_in_wh = feed_in_wh
-        if consumed_wh is not None:
-            request.consumed_wh = consumed_wh
-        await self._async_publish_provider(
-            "grid", "grid_service_stub", "PublishGridData", request
-        )
+        """Push mapped grid sensor values to the bridge."""
+        await self._provider_manager.async_push_grid_data()
 
     def async_start_grid_push(self) -> None:
         """Track mapped grid sensors and push their values to the bridge."""
-        if not self.grid_push_enabled:
-            return
-        self._start_provider_push(
-            "grid",
-            (
-                self.grid_power_entity,
-                self.grid_feed_in_energy_entity,
-                self.grid_consumption_energy_entity,
-            ),
-            self.async_push_grid_data,
-        )
+        self._provider_manager.async_start_grid_push()
 
     @property
     def pv_push_enabled(self) -> bool:
         """Return True when a PV power sensor is mapped to the VAPD provider."""
-        return bool(self.pv_power_entity)
+        return self._provider_manager.pv_push_enabled
 
     async def async_push_pv_data(self) -> None:
-        """Push the mapped PV sensors to the bridge VAPD (display) provider.
-
-        PV power is required; yield energy and nominal peak power are optional.
-        No-op when no PV power sensor is mapped or its value is unavailable.
-        """
-        if not self.pv_power_entity:
-            return
-        power_w = self._read_sensor_value(
-            self.pv_power_entity, POWER_UNIT_TO_W, "PV power", minimum=0
-        )
-        if power_w is None:
-            return
-        yield_wh = self._read_sensor_value(
-            self.pv_yield_energy_entity, ENERGY_UNIT_TO_WH, "PV yield", minimum=0
-        )
-        peak_power_w = self._read_sensor_value(
-            self.pv_peak_power_entity, POWER_UNIT_TO_W, "PV peak power", minimum=0
-        )
-
-        from . import proto_stubs
-
-        request = proto_stubs.PVData(power_w=power_w)
-        if yield_wh is not None:
-            request.yield_wh = yield_wh
-        if peak_power_w is not None:
-            request.peak_power_w = peak_power_w
-        await self._async_publish_provider(
-            "PV", "visualization_service_stub", "PublishPVData", request
-        )
+        """Push mapped PV sensor values to the bridge."""
+        await self._provider_manager.async_push_pv_data()
 
     def async_start_pv_push(self) -> None:
         """Track mapped PV sensors and push their values to the bridge."""
-        if not self.pv_push_enabled:
-            return
-        self._start_provider_push(
-            "pv",
-            (
-                self.pv_power_entity,
-                self.pv_yield_energy_entity,
-                self.pv_peak_power_entity,
-            ),
-            self.async_push_pv_data,
-        )
+        self._provider_manager.async_start_pv_push()
 
     @property
     def battery_push_enabled(self) -> bool:
         """Return True when a battery power sensor is mapped to the VABD provider."""
-        return bool(self.battery_power_entity)
+        return self._provider_manager.battery_push_enabled
 
     async def async_push_battery_data(self) -> None:
-        """Push the mapped battery sensors to the bridge VABD (display) provider.
-
-        Battery power is required; charged/discharged energy and state of charge
-        are optional. No-op when no battery power sensor is mapped or its value is
-        unavailable.
-        """
-        if not self.battery_power_entity:
-            return
-        power_w = self._read_sensor_value(self.battery_power_entity, POWER_UNIT_TO_W, "battery power")
-        if power_w is None:
-            return
-        charged_wh = self._read_sensor_value(
-            self.battery_charged_energy_entity, ENERGY_UNIT_TO_WH, "battery charged", minimum=0
-        )
-        discharged_wh = self._read_sensor_value(
-            self.battery_discharged_energy_entity, ENERGY_UNIT_TO_WH, "battery discharged", minimum=0
-        )
-        soc_pct = self._read_sensor_value(
-            self.battery_soc_entity, SOC_UNIT_TO_PCT, "battery SoC", minimum=0, maximum=100
-        )
-
-        from . import proto_stubs
-
-        request = proto_stubs.BatteryData(power_w=power_w)
-        if charged_wh is not None:
-            request.charged_wh = charged_wh
-        if discharged_wh is not None:
-            request.discharged_wh = discharged_wh
-        if soc_pct is not None:
-            request.state_of_charge_pct = soc_pct
-        await self._async_publish_provider(
-            "battery", "visualization_service_stub", "PublishBatteryData", request
-        )
+        """Push mapped battery sensor values to the bridge."""
+        await self._provider_manager.async_push_battery_data()
 
     def async_start_battery_push(self) -> None:
         """Track mapped battery sensors and push their values to the bridge."""
-        if not self.battery_push_enabled:
-            return
-        self._start_provider_push(
-            "battery",
-            (
-                self.battery_power_entity,
-                self.battery_charged_energy_entity,
-                self.battery_discharged_energy_entity,
-                self.battery_soc_entity,
-            ),
-            self.async_push_battery_data,
-        )
+        self._provider_manager.async_start_battery_push()
 
     def async_start_streams(self) -> None:
         """Start background tasks consuming bridge event streams."""
@@ -996,8 +675,6 @@ class EebusCoordinator(DataUpdateCoordinator[CoordinatorSnapshot]):
 
     async def async_shutdown(self) -> None:
         """Close gRPC channel and cancel stream tasks."""
-        for pusher in self._provider_pushers:
-            await pusher.stop()
-        self._provider_pushers.clear()
+        await self._provider_manager.async_stop()
         await self._stream_manager.stop()
         await self._channel_manager.close()

--- a/custom_components/eebus/providers.py
+++ b/custom_components/eebus/providers.py
@@ -1,0 +1,468 @@
+"""Home Assistant sensor-backed EEBUS provider publishers."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import math
+from collections.abc import Awaitable, Callable
+from contextlib import suppress
+from typing import Any
+
+import grpc
+import grpc.aio
+
+from homeassistant.const import (
+    ATTR_UNIT_OF_MEASUREMENT,
+    PERCENTAGE,
+    STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
+    UnitOfEnergy,
+    UnitOfPower,
+)
+from homeassistant.core import Event, HomeAssistant
+from homeassistant.helpers.event import (
+    EventStateChangedData,
+    async_track_state_change_event,
+)
+
+from .grpc_client import (
+    RPC_TIMEOUT,
+    is_unimplemented as _is_unimplemented,
+    rpc_error_text as _rpc_error_text,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+# Convert a Home Assistant sensor's value to the unit the providers expect
+# (power in W, energy in Wh) using its unit_of_measurement attribute.
+POWER_UNIT_TO_W: dict[str, float] = {
+    UnitOfPower.WATT: 1.0,
+    UnitOfPower.KILO_WATT: 1000.0,
+    UnitOfPower.MEGA_WATT: 1_000_000.0,
+}
+ENERGY_UNIT_TO_WH: dict[str, float] = {
+    UnitOfEnergy.WATT_HOUR: 1.0,
+    UnitOfEnergy.KILO_WATT_HOUR: 1000.0,
+    UnitOfEnergy.MEGA_WATT_HOUR: 1_000_000.0,
+}
+# State of charge is a plain percentage (0-100); no conversion needed.
+SOC_UNIT_TO_PCT: dict[str, float] = {PERCENTAGE: 1.0}
+
+ChannelGetter = Callable[[], Awaitable[grpc.aio.Channel]]
+
+
+class _ProviderPusher:
+    """Serialize and coalesce state-triggered pushes for one provider."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        label: str,
+        ski: str,
+        tracked: tuple[str | None, ...],
+        push: Callable[[], Awaitable[None]],
+    ) -> None:
+        self._hass = hass
+        self._label = label
+        self._ski = ski
+        self._entity_ids = [entity_id for entity_id in tracked if entity_id]
+        self._push = push
+        self._dirty = asyncio.Event()
+        self._task: asyncio.Task[None] | None = None
+        self._unsub: Callable[[], None] | None = None
+
+    def start(self) -> None:
+        """Subscribe to state changes and schedule the initial push."""
+        if self._task is not None:
+            return
+
+        def _on_change(_event: Event[EventStateChangedData]) -> None:
+            self.signal()
+
+        self._unsub = async_track_state_change_event(
+            self._hass, self._entity_ids, _on_change
+        )
+        self.signal()
+        self._task = self._hass.async_create_background_task(
+            self._run(), name=f"eebus_{self._label}_provider_push_{self._ski}"
+        )
+
+    def signal(self) -> None:
+        """Mark provider data dirty, coalescing repeated signals."""
+        self._dirty.set()
+
+    async def stop(self) -> None:
+        """Unsubscribe, then cancel and await the worker task."""
+        unsub = self._unsub
+        self._unsub = None
+        task = self._task
+        if task is None:
+            if unsub is not None:
+                unsub()
+            return
+        try:
+            if unsub is not None:
+                unsub()
+        finally:
+            task.cancel()
+            with suppress(asyncio.CancelledError):
+                await task
+            self._task = None
+
+    async def _run(self) -> None:
+        """Push the freshest state once per coalesced dirty signal."""
+        while True:
+            await self._dirty.wait()
+            self._dirty.clear()
+            try:
+                await self._push()
+            except asyncio.CancelledError:
+                raise
+            except Exception:  # noqa: BLE001
+                _LOGGER.exception(
+                    "Unexpected failure pushing %s provider data", self._label
+                )
+
+
+class ProviderManager:
+    """Manage sensor-backed provider publishing and worker lifecycles."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        ski: str,
+        channel_getter: ChannelGetter,
+        *,
+        grid_power_entity: str | None = None,
+        grid_feed_in_energy_entity: str | None = None,
+        grid_consumption_energy_entity: str | None = None,
+        pv_power_entity: str | None = None,
+        pv_yield_energy_entity: str | None = None,
+        pv_peak_power_entity: str | None = None,
+        battery_power_entity: str | None = None,
+        battery_charged_energy_entity: str | None = None,
+        battery_discharged_energy_entity: str | None = None,
+        battery_soc_entity: str | None = None,
+    ) -> None:
+        """Initialize provider configuration and lifecycle state."""
+        self._hass = hass
+        self._ski = ski
+        self._channel_getter = channel_getter
+        self._grid_power_entity = grid_power_entity
+        self._grid_feed_in_energy_entity = grid_feed_in_energy_entity
+        self._grid_consumption_energy_entity = grid_consumption_energy_entity
+        self._pv_power_entity = pv_power_entity
+        self._pv_yield_energy_entity = pv_yield_energy_entity
+        self._pv_peak_power_entity = pv_peak_power_entity
+        self._battery_power_entity = battery_power_entity
+        self._battery_charged_energy_entity = battery_charged_energy_entity
+        self._battery_discharged_energy_entity = battery_discharged_energy_entity
+        self._battery_soc_entity = battery_soc_entity
+        self._provider_pushers: list[_ProviderPusher] = []
+        self._provider_push_failing: dict[str, bool] = {}
+
+    @property
+    def grid_push_enabled(self) -> bool:
+        """Return True when a grid power sensor is mapped to the MGCP provider."""
+        return bool(self._grid_power_entity)
+
+    @property
+    def pv_push_enabled(self) -> bool:
+        """Return True when a PV power sensor is mapped to the VAPD provider."""
+        return bool(self._pv_power_entity)
+
+    @property
+    def battery_push_enabled(self) -> bool:
+        """Return True when a battery power sensor is mapped to the VABD provider."""
+        return bool(self._battery_power_entity)
+
+    def _read_sensor_value(
+        self,
+        entity_id: str | None,
+        unit_map: dict[str, float],
+        kind: str,
+        *,
+        minimum: float | None = None,
+        maximum: float | None = None,
+    ) -> float | None:
+        """Read an HA sensor and normalize it via unit_map (W / Wh / %).
+
+        Returns None when the entity is unset, missing, unavailable,
+        non-numeric, non-finite (NaN/Inf), or outside ``[minimum, maximum]`` so
+        the caller can omit it from the push instead of advertising a bogus
+        reading to downstream equipment. ``kind`` is a short descriptor (e.g.
+        "grid power", "PV yield") used only for debug logging.
+        """
+        if not entity_id:
+            return None
+        state = self._hass.states.get(entity_id)
+        if state is None or state.state in (
+            STATE_UNKNOWN,
+            STATE_UNAVAILABLE,
+            "",
+            None,
+        ):
+            return None
+        try:
+            value = float(state.state)
+        except (TypeError, ValueError):
+            _LOGGER.debug(
+                "%s sensor %s has non-numeric state %r",
+                kind,
+                entity_id,
+                state.state,
+            )
+            return None
+        unit = state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
+        factor = unit_map.get(unit) if isinstance(unit, str) else None
+        if factor is None:
+            _LOGGER.debug(
+                "%s sensor %s has unknown unit %r; assuming base unit",
+                kind,
+                entity_id,
+                unit,
+            )
+            factor = 1.0
+        result = value * factor
+        if not math.isfinite(result):
+            _LOGGER.debug(
+                "%s sensor %s produced non-finite value %r", kind, entity_id, result
+            )
+            return None
+        if (minimum is not None and result < minimum) or (
+            maximum is not None and result > maximum
+        ):
+            _LOGGER.debug(
+                "%s sensor %s value %r out of range [%s, %s]; omitting",
+                kind,
+                entity_id,
+                result,
+                minimum,
+                maximum,
+            )
+            return None
+        return result
+
+    async def _async_publish_provider(
+        self, label: str, stub_factory: str, publish_method: str, request: Any
+    ) -> None:
+        """Publish a provider reading to the bridge, quiet when the provider is off.
+
+        UNIMPLEMENTED/UNAVAILABLE mean the provider is disabled or the bridge is
+        down; skip quietly so a missing provider never spams or fails HA.
+        """
+        channel = await self._channel_getter()
+        from . import proto_stubs
+
+        stub = getattr(proto_stubs, stub_factory)(channel)
+        try:
+            await getattr(stub, publish_method)(request, timeout=RPC_TIMEOUT)
+            if self._provider_push_failing.pop(label, False):
+                _LOGGER.info("%s provider push recovered", label)
+            _LOGGER.debug("Pushed %s data: %s", label, request)
+        except grpc.aio.AioRpcError as err:
+            if _is_unimplemented(err) or err.code() == grpc.StatusCode.UNAVAILABLE:
+                _LOGGER.debug(
+                    "%s provider not ready; skipping push: %s",
+                    label,
+                    _rpc_error_text(err),
+                )
+                return
+            if self._provider_push_failing.get(label, False):
+                _LOGGER.debug(
+                    "Failed to push %s data: %s", label, _rpc_error_text(err)
+                )
+            else:
+                _LOGGER.warning(
+                    "Failed to push %s data: %s", label, _rpc_error_text(err)
+                )
+                self._provider_push_failing[label] = True
+
+    def _start_provider_push(
+        self,
+        label: str,
+        tracked: tuple[str | None, ...],
+        push: Callable[[], Awaitable[None]],
+    ) -> None:
+        """Start one lifecycle-owning provider push worker."""
+        pusher = _ProviderPusher(
+            self._hass,
+            label,
+            self._ski,
+            tracked,
+            push,
+        )
+        self._provider_pushers.append(pusher)
+        pusher.start()
+
+    async def async_push_grid_data(self) -> None:
+        """Push the mapped grid sensors to the bridge MGCP provider.
+
+        Grid power is the surplus signal (negative = export); the energy totals
+        are optional. No-op when no grid power sensor is mapped or its value is
+        currently unavailable.
+        """
+        if not self._grid_power_entity:
+            return
+        power_w = self._read_sensor_value(
+            self._grid_power_entity, POWER_UNIT_TO_W, "grid power"
+        )
+        if power_w is None:
+            return
+        feed_in_wh = self._read_sensor_value(
+            self._grid_feed_in_energy_entity,
+            ENERGY_UNIT_TO_WH,
+            "grid feed-in",
+            minimum=0,
+        )
+        consumed_wh = self._read_sensor_value(
+            self._grid_consumption_energy_entity,
+            ENERGY_UNIT_TO_WH,
+            "grid consumption",
+            minimum=0,
+        )
+
+        from . import proto_stubs
+
+        request = proto_stubs.GridData(power_w=power_w)
+        if feed_in_wh is not None:
+            request.feed_in_wh = feed_in_wh
+        if consumed_wh is not None:
+            request.consumed_wh = consumed_wh
+        await self._async_publish_provider(
+            "grid", "grid_service_stub", "PublishGridData", request
+        )
+
+    async def async_push_pv_data(self) -> None:
+        """Push the mapped PV sensors to the bridge VAPD (display) provider.
+
+        PV power is required; yield energy and nominal peak power are optional.
+        No-op when no PV power sensor is mapped or its value is unavailable.
+        """
+        if not self._pv_power_entity:
+            return
+        power_w = self._read_sensor_value(
+            self._pv_power_entity, POWER_UNIT_TO_W, "PV power", minimum=0
+        )
+        if power_w is None:
+            return
+        yield_wh = self._read_sensor_value(
+            self._pv_yield_energy_entity,
+            ENERGY_UNIT_TO_WH,
+            "PV yield",
+            minimum=0,
+        )
+        peak_power_w = self._read_sensor_value(
+            self._pv_peak_power_entity,
+            POWER_UNIT_TO_W,
+            "PV peak power",
+            minimum=0,
+        )
+
+        from . import proto_stubs
+
+        request = proto_stubs.PVData(power_w=power_w)
+        if yield_wh is not None:
+            request.yield_wh = yield_wh
+        if peak_power_w is not None:
+            request.peak_power_w = peak_power_w
+        await self._async_publish_provider(
+            "PV", "visualization_service_stub", "PublishPVData", request
+        )
+
+    async def async_push_battery_data(self) -> None:
+        """Push the mapped battery sensors to the bridge VABD (display) provider.
+
+        Battery power is required; charged/discharged energy and state of charge
+        are optional. No-op when no battery power sensor is mapped or its value is
+        unavailable.
+        """
+        if not self._battery_power_entity:
+            return
+        power_w = self._read_sensor_value(
+            self._battery_power_entity, POWER_UNIT_TO_W, "battery power"
+        )
+        if power_w is None:
+            return
+        charged_wh = self._read_sensor_value(
+            self._battery_charged_energy_entity,
+            ENERGY_UNIT_TO_WH,
+            "battery charged",
+            minimum=0,
+        )
+        discharged_wh = self._read_sensor_value(
+            self._battery_discharged_energy_entity,
+            ENERGY_UNIT_TO_WH,
+            "battery discharged",
+            minimum=0,
+        )
+        soc_pct = self._read_sensor_value(
+            self._battery_soc_entity,
+            SOC_UNIT_TO_PCT,
+            "battery SoC",
+            minimum=0,
+            maximum=100,
+        )
+
+        from . import proto_stubs
+
+        request = proto_stubs.BatteryData(power_w=power_w)
+        if charged_wh is not None:
+            request.charged_wh = charged_wh
+        if discharged_wh is not None:
+            request.discharged_wh = discharged_wh
+        if soc_pct is not None:
+            request.state_of_charge_pct = soc_pct
+        await self._async_publish_provider(
+            "battery", "visualization_service_stub", "PublishBatteryData", request
+        )
+
+    def async_start_grid_push(self) -> None:
+        """Track mapped grid sensors and push their values to the bridge."""
+        if not self.grid_push_enabled:
+            return
+        self._start_provider_push(
+            "grid",
+            (
+                self._grid_power_entity,
+                self._grid_feed_in_energy_entity,
+                self._grid_consumption_energy_entity,
+            ),
+            self.async_push_grid_data,
+        )
+
+    def async_start_pv_push(self) -> None:
+        """Track mapped PV sensors and push their values to the bridge."""
+        if not self.pv_push_enabled:
+            return
+        self._start_provider_push(
+            "pv",
+            (
+                self._pv_power_entity,
+                self._pv_yield_energy_entity,
+                self._pv_peak_power_entity,
+            ),
+            self.async_push_pv_data,
+        )
+
+    def async_start_battery_push(self) -> None:
+        """Track mapped battery sensors and push their values to the bridge."""
+        if not self.battery_push_enabled:
+            return
+        self._start_provider_push(
+            "battery",
+            (
+                self._battery_power_entity,
+                self._battery_charged_energy_entity,
+                self._battery_discharged_energy_entity,
+                self._battery_soc_entity,
+            ),
+            self.async_push_battery_data,
+        )
+
+    async def async_stop(self) -> None:
+        """Stop all provider push workers."""
+        for pusher in self._provider_pushers:
+            await pusher.stop()
+        self._provider_pushers.clear()

--- a/custom_components/eebus/tests/test_coordinator.py
+++ b/custom_components/eebus/tests/test_coordinator.py
@@ -298,18 +298,21 @@ def test_start_streams_delegates_all_consumers_to_stream_manager():
 async def test_shutdown_stops_streams_before_closing_channel():
     """Shutdown fully stops stream tasks before closing the shared channel."""
     coordinator = EebusCoordinator.__new__(EebusCoordinator)
-    coordinator._provider_pushers = []
     lifecycle = MagicMock()
+    coordinator._provider_manager = MagicMock()
+    coordinator._provider_manager.async_stop = AsyncMock()
     coordinator._stream_manager = MagicMock()
     coordinator._stream_manager.stop = AsyncMock()
     coordinator._channel_manager = MagicMock()
     coordinator._channel_manager.close = AsyncMock()
+    lifecycle.attach_mock(coordinator._provider_manager.async_stop, "stop_providers")
     lifecycle.attach_mock(coordinator._stream_manager.stop, "stop_streams")
     lifecycle.attach_mock(coordinator._channel_manager.close, "close_channel")
 
     await coordinator.async_shutdown()
 
     assert lifecycle.mock_calls == [
+        call.stop_providers(),
         call.stop_streams(),
         call.close_channel(),
     ]

--- a/custom_components/eebus/tests/test_grid_push.py
+++ b/custom_components/eebus/tests/test_grid_push.py
@@ -4,10 +4,11 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 from custom_components.eebus import proto_stubs
-from custom_components.eebus.coordinator import (
+from custom_components.eebus.coordinator import EebusCoordinator
+from custom_components.eebus.providers import (
     ENERGY_UNIT_TO_WH,
     POWER_UNIT_TO_W,
-    EebusCoordinator,
+    ProviderManager,
 )
 
 
@@ -20,32 +21,52 @@ def _make_grid_coordinator(states, power=None, feed_in=None, consumed=None):
     """Build a coordinator skeleton wired for grid-push tests."""
     coordinator = EebusCoordinator.__new__(EebusCoordinator)
     coordinator.ski = "test-ski"
-    coordinator.grid_power_entity = power
-    coordinator.grid_feed_in_energy_entity = feed_in
-    coordinator.grid_consumption_energy_entity = consumed
     hass = MagicMock()
     hass.states.get = lambda entity_id: states.get(entity_id)
     coordinator.hass = hass
     coordinator._ensure_channel = AsyncMock(return_value=object())
+    coordinator._provider_manager = ProviderManager(
+        hass,
+        coordinator.ski,
+        lambda: coordinator._ensure_channel(),
+        grid_power_entity=power,
+        grid_feed_in_energy_entity=feed_in,
+        grid_consumption_energy_entity=consumed,
+    )
     return coordinator
 
 
 def test_read_sensor_value_normalizes_power_units():
     """kW is scaled to W; W passes through; export stays negative."""
     coordinator = _make_grid_coordinator({"sensor.p": _state("-1.5", "kW")}, power="sensor.p")
-    assert coordinator._read_sensor_value("sensor.p", POWER_UNIT_TO_W, "power") == -1500.0
+    assert (
+        coordinator._provider_manager._read_sensor_value(
+            "sensor.p", POWER_UNIT_TO_W, "power"
+        )
+        == -1500.0
+    )
 
 
 def test_read_sensor_value_normalizes_energy_units():
     """kWh is scaled to Wh."""
     coordinator = _make_grid_coordinator({"sensor.e": _state("12.34", "kWh")})
-    assert coordinator._read_sensor_value("sensor.e", ENERGY_UNIT_TO_WH, "energy") == 12340.0
+    assert (
+        coordinator._provider_manager._read_sensor_value(
+            "sensor.e", ENERGY_UNIT_TO_WH, "energy"
+        )
+        == 12340.0
+    )
 
 
 def test_read_sensor_value_unknown_unit_assumes_base():
     """Unknown unit falls back to the base unit (factor 1)."""
     coordinator = _make_grid_coordinator({"sensor.p": _state("42", None)})
-    assert coordinator._read_sensor_value("sensor.p", POWER_UNIT_TO_W, "power") == 42.0
+    assert (
+        coordinator._provider_manager._read_sensor_value(
+            "sensor.p", POWER_UNIT_TO_W, "power"
+        )
+        == 42.0
+    )
 
 
 def test_read_sensor_value_unavailable_returns_none():
@@ -53,9 +74,10 @@ def test_read_sensor_value_unavailable_returns_none():
     coordinator = _make_grid_coordinator(
         {"sensor.u": _state("unavailable", "W"), "sensor.x": _state("foo", "W")}
     )
-    assert coordinator._read_sensor_value("sensor.u", POWER_UNIT_TO_W, "power") is None
-    assert coordinator._read_sensor_value("sensor.x", POWER_UNIT_TO_W, "power") is None
-    assert coordinator._read_sensor_value(None, POWER_UNIT_TO_W, "power") is None
+    manager = coordinator._provider_manager
+    assert manager._read_sensor_value("sensor.u", POWER_UNIT_TO_W, "power") is None
+    assert manager._read_sensor_value("sensor.x", POWER_UNIT_TO_W, "power") is None
+    assert manager._read_sensor_value(None, POWER_UNIT_TO_W, "power") is None
 
 
 async def test_push_skips_without_power_entity():

--- a/custom_components/eebus/tests/test_provider_push.py
+++ b/custom_components/eebus/tests/test_provider_push.py
@@ -8,9 +8,9 @@ from unittest.mock import AsyncMock, MagicMock
 import grpc
 from grpc.aio import AioRpcError, Metadata
 
-from custom_components.eebus import coordinator as coordinator_module
+from custom_components.eebus import providers as providers_module
 from custom_components.eebus import proto_stubs
-from custom_components.eebus.coordinator import EebusCoordinator, _ProviderPusher
+from custom_components.eebus.providers import ProviderManager, _ProviderPusher
 
 
 def _fake_hass():
@@ -33,7 +33,7 @@ async def test_provider_pusher_coalesces_burst_and_publishes_latest(monkeypatch)
         return unsub
 
     monkeypatch.setattr(
-        coordinator_module, "async_track_state_change_event", _track_state_changes
+        providers_module, "async_track_state_change_event", _track_state_changes
     )
 
     current_value = 0
@@ -86,7 +86,7 @@ async def test_provider_pusher_stop_cancels_in_flight_push(monkeypatch):
     """Stopping during a blocked RPC awaits cancellation and leaks no task."""
     unsub = MagicMock()
     monkeypatch.setattr(
-        coordinator_module,
+        providers_module,
         "async_track_state_change_event",
         lambda *_args: unsub,
     )
@@ -130,25 +130,25 @@ async def test_provider_push_failure_warning_is_rate_limited(monkeypatch, caplog
             if outcome is not None:
                 raise outcome
 
-    coordinator = EebusCoordinator.__new__(EebusCoordinator)
-    coordinator._ensure_channel = AsyncMock(return_value=object())
-    coordinator._provider_push_failing = {}
+    manager = ProviderManager(
+        _fake_hass(), "test-ski", AsyncMock(return_value=object())
+    )
     monkeypatch.setattr(
         proto_stubs,
         "test_provider_stub",
         lambda _channel: _FakeStub(),
         raising=False,
     )
-    caplog.set_level(logging.DEBUG, logger=coordinator_module.__name__)
+    caplog.set_level(logging.DEBUG, logger=providers_module.__name__)
 
     for _ in range(3):
-        await coordinator._async_publish_provider(
+        await manager._async_publish_provider(
             "test", "test_provider_stub", "Publish", object()
         )
-    await coordinator._async_publish_provider(
+    await manager._async_publish_provider(
         "test", "test_provider_stub", "Publish", object()
     )
-    await coordinator._async_publish_provider(
+    await manager._async_publish_provider(
         "test", "test_provider_stub", "Publish", object()
     )
 

--- a/custom_components/eebus/tests/test_visualization_push.py
+++ b/custom_components/eebus/tests/test_visualization_push.py
@@ -4,10 +4,8 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 from custom_components.eebus import proto_stubs
-from custom_components.eebus.coordinator import (
-    SOC_UNIT_TO_PCT,
-    EebusCoordinator,
-)
+from custom_components.eebus.coordinator import EebusCoordinator
+from custom_components.eebus.providers import SOC_UNIT_TO_PCT, ProviderManager
 
 
 def _state(value, unit):
@@ -15,29 +13,48 @@ def _state(value, unit):
     return SimpleNamespace(state=value, attributes={"unit_of_measurement": unit})
 
 
-def _make_coordinator(states):
+def _make_coordinator(
+    states,
+    *,
+    pv_power=None,
+    pv_yield=None,
+    pv_peak=None,
+    battery_power=None,
+    battery_charged=None,
+    battery_discharged=None,
+    battery_soc=None,
+):
     """Build a coordinator skeleton wired for visualization-push tests."""
     coordinator = EebusCoordinator.__new__(EebusCoordinator)
     coordinator.ski = "test-ski"
-    # PV + battery entities default to unmapped; tests set what they need.
-    coordinator.pv_power_entity = None
-    coordinator.pv_yield_energy_entity = None
-    coordinator.pv_peak_power_entity = None
-    coordinator.battery_power_entity = None
-    coordinator.battery_charged_energy_entity = None
-    coordinator.battery_discharged_energy_entity = None
-    coordinator.battery_soc_entity = None
     hass = MagicMock()
     hass.states.get = lambda entity_id: states.get(entity_id)
     coordinator.hass = hass
     coordinator._ensure_channel = AsyncMock(return_value=object())
+    coordinator._provider_manager = ProviderManager(
+        hass,
+        coordinator.ski,
+        lambda: coordinator._ensure_channel(),
+        pv_power_entity=pv_power,
+        pv_yield_energy_entity=pv_yield,
+        pv_peak_power_entity=pv_peak,
+        battery_power_entity=battery_power,
+        battery_charged_energy_entity=battery_charged,
+        battery_discharged_energy_entity=battery_discharged,
+        battery_soc_entity=battery_soc,
+    )
     return coordinator
 
 
 def test_read_sensor_value_normalizes_soc_percentage():
     """State of charge passes through as a plain percentage."""
     coordinator = _make_coordinator({"sensor.soc": _state("73", "%")})
-    assert coordinator._read_sensor_value("sensor.soc", SOC_UNIT_TO_PCT, "battery SoC") == 73.0
+    assert (
+        coordinator._provider_manager._read_sensor_value(
+            "sensor.soc", SOC_UNIT_TO_PCT, "battery SoC"
+        )
+        == 73.0
+    )
 
 
 def test_read_sensor_value_rejects_non_finite():
@@ -45,8 +62,9 @@ def test_read_sensor_value_rejects_non_finite():
     coordinator = _make_coordinator(
         {"sensor.bad": _state("nan", "%"), "sensor.inf": _state("inf", "%")}
     )
-    assert coordinator._read_sensor_value("sensor.bad", SOC_UNIT_TO_PCT, "battery SoC") is None
-    assert coordinator._read_sensor_value("sensor.inf", SOC_UNIT_TO_PCT, "battery SoC") is None
+    manager = coordinator._provider_manager
+    assert manager._read_sensor_value("sensor.bad", SOC_UNIT_TO_PCT, "battery SoC") is None
+    assert manager._read_sensor_value("sensor.inf", SOC_UNIT_TO_PCT, "battery SoC") is None
 
 
 def test_read_sensor_value_enforces_range():
@@ -56,20 +74,20 @@ def test_read_sensor_value_enforces_range():
     )
     # SoC capped at 100; negative energy/power rejected by minimum=0.
     assert (
-        coordinator._read_sensor_value(
+        coordinator._provider_manager._read_sensor_value(
             "sensor.soc", SOC_UNIT_TO_PCT, "battery SoC", minimum=0, maximum=100
         )
         is None
     )
     assert (
-        coordinator._read_sensor_value(
+        coordinator._provider_manager._read_sensor_value(
             "sensor.neg", SOC_UNIT_TO_PCT, "PV power", minimum=0
         )
         is None
     )
     # In-range value still passes.
     assert (
-        coordinator._read_sensor_value(
+        coordinator._provider_manager._read_sensor_value(
             "sensor.soc", SOC_UNIT_TO_PCT, "battery SoC", minimum=0, maximum=100
         )
         is None
@@ -89,10 +107,12 @@ async def test_pv_push_publishes_power_and_optional_fields(monkeypatch):
         "sensor.pv_power": _state("3.2", "kW"),
         "sensor.pv_yield": _state("18", "kWh"),
     }
-    coordinator = _make_coordinator(states)
-    coordinator.pv_power_entity = "sensor.pv_power"
-    coordinator.pv_yield_energy_entity = "sensor.pv_yield"
-    coordinator.pv_peak_power_entity = "sensor.missing"
+    coordinator = _make_coordinator(
+        states,
+        pv_power="sensor.pv_power",
+        pv_yield="sensor.pv_yield",
+        pv_peak="sensor.missing",
+    )
 
     captured = {}
 
@@ -129,10 +149,12 @@ async def test_battery_push_publishes_power_and_optional_fields(monkeypatch):
         "sensor.bat_power": _state("-1.5", "kW"),  # negative = charging
         "sensor.bat_soc": _state("64", "%"),
     }
-    coordinator = _make_coordinator(states)
-    coordinator.battery_power_entity = "sensor.bat_power"
-    coordinator.battery_soc_entity = "sensor.bat_soc"
-    coordinator.battery_charged_energy_entity = "sensor.missing"
+    coordinator = _make_coordinator(
+        states,
+        battery_power="sensor.bat_power",
+        battery_soc="sensor.bat_soc",
+        battery_charged="sensor.missing",
+    )
 
     captured = {}
 


### PR DESCRIPTION
## Summary
- New `providers.py`: `ProviderManager` owns `_ProviderPusher`, unit-conversion tables (`POWER_UNIT_TO_W`/`ENERGY_UNIT_TO_WH`/`SOC_UNIT_TO_PCT`), `_read_sensor_value`, `_async_publish_provider`, `_start_provider_push`, and the grid/PV/battery push-builders + starters + enabled properties.
- `coordinator.py` keeps the same public surface (`async_start_grid_push`, `async_push_pv_data`, `battery_push_enabled`, etc.) as one-line delegations to a `ProviderManager` instance it owns — `__init__.py`'s setup calls and existing tests call through unchanged.
- `async_shutdown` now delegates provider-pusher cleanup to `ProviderManager.async_stop()`.
- Last of the RF-05 module splits (`grpc_client.py` → `streams.py` → `models.py`/`snapshot.py` → `providers.py`), see `docs/refactoring-optimization-spec.md`.

## Test plan
- [x] `pytest` — 114 passed, no regressions (test_provider_push.py/test_grid_push.py/test_visualization_push.py moved to test `ProviderManager` directly; shutdown-ordering test updated to assert provider stop → stream stop → channel close)
- [x] `ruff check custom_components/` — clean
- [x] `mypy custom_components/eebus` — strict, no issues