### PR TITLE
SPEC2-04: canonical SKI normalization

### DIFF
--- a/custom_components/eebus/__init__.py
+++ b/custom_components/eebus/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING
 
 from homeassistant.config_entries import ConfigEntry
@@ -30,11 +31,57 @@ from .const import (
     SECURITY_MODE_LOOPBACK,
 )
 from .coordinator import EebusCoordinator
+from .ski import normalize_ski
+
+_LOGGER = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     EebusConfigEntry = ConfigEntry[EebusCoordinator]
 else:
     EebusConfigEntry = ConfigEntry
+
+
+async def async_migrate_entry(
+    hass: HomeAssistant, config_entry: ConfigEntry
+) -> bool:
+    """Migrate an EEBUS config entry to canonical SKI storage."""
+    if config_entry.version >= 2:
+        return True
+
+    canonical_ski = normalize_ski(config_entry.data[CONF_DEVICE_SKI])
+    for other_entry in hass.config_entries.async_entries(DOMAIN):
+        if other_entry.entry_id == config_entry.entry_id:
+            continue
+        other_ski = other_entry.unique_id
+        if other_ski is None or normalize_ski(other_ski) != canonical_ski:
+            continue
+        if other_entry.entry_id < config_entry.entry_id:
+            _LOGGER.warning(
+                "Cannot migrate duplicate EEBUS config entry %s (%s): canonical "
+                "SKI %s conflicts with older entry %s (%s)",
+                config_entry.entry_id,
+                config_entry.title,
+                canonical_ski,
+                other_entry.entry_id,
+                other_entry.title,
+            )
+            return False
+
+    if (
+        config_entry.data[CONF_DEVICE_SKI] == canonical_ski
+        and config_entry.unique_id == canonical_ski
+    ):
+        hass.config_entries.async_update_entry(config_entry, version=2)
+        return True
+
+    data = {**config_entry.data, CONF_DEVICE_SKI: canonical_ski}
+    hass.config_entries.async_update_entry(
+        config_entry,
+        data=data,
+        unique_id=canonical_ski,
+        version=2,
+    )
+    return True
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: EebusConfigEntry) -> bool:

--- a/custom_components/eebus/__init__.py
+++ b/custom_components/eebus/__init__.py
@@ -31,7 +31,7 @@ from .const import (
     SECURITY_MODE_LOOPBACK,
 )
 from .coordinator import EebusCoordinator
-from .ski import normalize_ski
+from .ski import is_valid_ski, normalize_ski
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -49,6 +49,16 @@ async def async_migrate_entry(
         return True
 
     canonical_ski = normalize_ski(config_entry.data[CONF_DEVICE_SKI])
+    if not is_valid_ski(canonical_ski):
+        _LOGGER.warning(
+            "Cannot migrate EEBUS config entry %s (%s): stored SKI %r is not a "
+            "valid 40-character hexadecimal fingerprint",
+            config_entry.entry_id,
+            config_entry.title,
+            config_entry.data[CONF_DEVICE_SKI],
+        )
+        return False
+
     for other_entry in hass.config_entries.async_entries(DOMAIN):
         if other_entry.entry_id == config_entry.entry_id:
             continue

--- a/custom_components/eebus/config_flow.py
+++ b/custom_components/eebus/config_flow.py
@@ -51,19 +51,12 @@ from .const import (
     SECURITY_MODE_TLS_TOKEN,
 )
 from .security import create_grpc_channel
+from .ski import is_valid_ski, normalize_ski
 
 _LOGGER = logging.getLogger(__name__)
 
 CONFIG_RPC_TIMEOUT = 8
 
-
-def _normalize_ski(ski: str) -> str:
-    """Normalize a SKI for comparison (strip colons/whitespace, lowercase).
-
-    Mirrors the bridge's SKI normalization so a hand-typed value with colons or
-    different casing still matches the bridge's reported local SKI.
-    """
-    return ski.replace(":", "").replace(" ", "").strip().lower()
 
 STEP_USER_DATA_SCHEMA = vol.Schema(
     {
@@ -116,7 +109,7 @@ def _reauth_schema(tls_ca_certificate: str) -> vol.Schema:
 class EebusConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for EEBUS."""
 
-    VERSION = 1
+    VERSION = 2
     DOMAIN = DOMAIN
 
     @staticmethod
@@ -305,13 +298,15 @@ class EebusConfigFlow(ConfigFlow, domain=DOMAIN):
         errors: dict[str, str] = {}
 
         if user_input is not None:
-            ski = user_input[CONF_DEVICE_SKI].strip()
+            ski = normalize_ski(user_input[CONF_DEVICE_SKI])
 
             # The picker hides the bridge's own SKI, but custom_value=True lets a
             # user paste it by hand (e.g. the "Local SKI" line from the bridge
             # log). That SKI never resolves to a remote entity, so reject it
             # rather than create a permanently broken entry.
-            if _normalize_ski(ski) == _normalize_ski(self._local_ski):
+            if not is_valid_ski(ski):
+                errors[CONF_DEVICE_SKI] = "invalid_ski"
+            elif ski == normalize_ski(self._local_ski):
                 errors[CONF_DEVICE_SKI] = "ski_is_local"
             else:
                 await self.async_set_unique_id(ski)

--- a/custom_components/eebus/coordinator.py
+++ b/custom_components/eebus/coordinator.py
@@ -29,6 +29,7 @@ from .models import (
 )
 from .providers import ProviderManager
 from .snapshot import SnapshotSupport, async_build_snapshot
+from .ski import normalize_ski
 from .streams import ConsumeFn, StreamManager
 
 if TYPE_CHECKING:
@@ -40,10 +41,6 @@ _LOGGER = logging.getLogger(__name__)
 # streams cannot carry (scoped energy, heartbeat, support flags).
 POLL_INTERVAL = timedelta(minutes=5)
 
-
-def _normalize_ski(ski: str) -> str:
-    """Normalize an SKI for comparisons without changing its stored form."""
-    return ski.replace(":", "").replace("-", "").replace(" ", "").casefold()
 
 @lru_cache(maxsize=1)
 def _measurement_event_map() -> tuple[dict[int, tuple[str, str, str]], frozenset[int]]:
@@ -522,7 +519,7 @@ class EebusCoordinator(DataUpdateCoordinator[CoordinatorSnapshot]):
 
     def _event_matches(self, event_ski: str) -> bool:
         """Return True when an event applies to the configured device."""
-        return _normalize_ski(event_ski) == _normalize_ski(self.ski)
+        return normalize_ski(event_ski) == normalize_ski(self.ski)
 
     def _push_data(self, updates: dict[str, Any]) -> None:
         """Merge stream updates into coordinator data and notify listeners."""

--- a/custom_components/eebus/ski.py
+++ b/custom_components/eebus/ski.py
@@ -1,0 +1,17 @@
+"""EEBUS Subject Key Identifier helpers."""
+
+from __future__ import annotations
+
+import string
+
+
+def normalize_ski(ski: str) -> str:
+    """Return an SKI in uppercase hexadecimal form without separators."""
+    for separator in (" ", "\t", "\n", "\r", ":", "-"):
+        ski = ski.replace(separator, "")
+    return ski.strip().upper()
+
+
+def is_valid_ski(ski: str) -> bool:
+    """Return whether an SKI is a 40-character hexadecimal fingerprint."""
+    return len(ski) == 40 and all(character in string.hexdigits for character in ski)

--- a/custom_components/eebus/ski.py
+++ b/custom_components/eebus/ski.py
@@ -4,12 +4,22 @@ from __future__ import annotations
 
 import string
 
+_ASCII_UPPER_HEX = str.maketrans("abcdef", "ABCDEF")
+
 
 def normalize_ski(ski: str) -> str:
-    """Return an SKI in uppercase hexadecimal form without separators."""
+    """Return an SKI in uppercase hexadecimal form without separators.
+
+    Uses an ASCII-only case translation rather than str.upper(): the latter
+    performs full Unicode case folding, which expands ligatures like 'ﬀ'
+    (U+FB00) into two-character sequences ("FF") that Go's rune-wise
+    strings.ToUpper never produces — letting non-hex input normalize into a
+    string that looks like a valid 40-character SKI. Restricting to a-f/A-F
+    keeps normalize_ski's output space identical to the Go implementation.
+    """
     for separator in (" ", "\t", "\n", "\r", ":", "-"):
         ski = ski.replace(separator, "")
-    return ski.strip().upper()
+    return ski.translate(_ASCII_UPPER_HEX)
 
 
 def is_valid_ski(ski: str) -> bool:

--- a/custom_components/eebus/strings.json
+++ b/custom_components/eebus/strings.json
@@ -54,6 +54,7 @@
     },
     "error": {
       "cannot_connect": "Cannot connect to EEBUS bridge. Check the address, certificate, and token.",
+      "invalid_ski": "Enter a valid 40-character hexadecimal SKI.",
       "required": "This field is required for TLS + token mode.",
       "ski_is_local": "That is the bridge's own SKI. Enter the heat pump's SKI instead."
     },

--- a/custom_components/eebus/tests/test_config_flow.py
+++ b/custom_components/eebus/tests/test_config_flow.py
@@ -9,7 +9,6 @@ from homeassistant.data_entry_flow import FlowResultType
 from custom_components.eebus.config_flow import (
     EebusConfigFlow,
     EebusOptionsFlow,
-    _normalize_ski,
 )
 from custom_components.eebus.const import (
     CONF_AUTH_TOKEN,
@@ -35,12 +34,6 @@ def test_config_flow_supports_zeroconf():
     assert hasattr(EebusConfigFlow, "async_step_zeroconf")
 
 
-def test_normalize_ski_strips_colons_and_case():
-    """SKI normalization ignores colons, spaces, and casing."""
-    assert _normalize_ski("96:81:87:DB ") == "968187db"
-    assert _normalize_ski("ABCD") == "abcd"
-
-
 async def test_device_step_rejects_local_ski():
     """Entering the bridge's own SKI is rejected, even with colons/casing."""
     flow = EebusConfigFlow()
@@ -56,6 +49,41 @@ async def test_device_step_rejects_local_ski():
 
     assert result["type"] == FlowResultType.FORM
     assert result["errors"][CONF_DEVICE_SKI] == "ski_is_local"
+
+
+async def test_device_step_rejects_invalid_ski():
+    """Malformed SKIs are rejected before a config entry is created."""
+    flow = EebusConfigFlow()
+    flow._local_ski = "968187db034cad41dab545c32a174ed7cc2fd8a5"
+    flow._host = "localhost"
+    flow._port = 50051
+
+    with patch.object(
+        flow, "_async_list_discovered_skis", AsyncMock(return_value=[])
+    ):
+        result = await flow.async_step_device({CONF_DEVICE_SKI: "not-a-ski"})
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["errors"][CONF_DEVICE_SKI] == "invalid_ski"
+
+
+async def test_device_step_stores_canonical_ski():
+    """New entries use the canonical SKI for data and unique ID."""
+    flow = EebusConfigFlow()
+    flow._host = "localhost"
+    flow._port = 50051
+    typed = "68:2f:70:8C:EB:A5:DF:9A:DC:B9:E6:78:7E:A9:11:D9:FC:3A:C4:90"
+    canonical = "682F708CEBA5DF9ADCB9E6787EA911D9FC3AC490"
+
+    with (
+        patch.object(flow, "async_set_unique_id", AsyncMock()) as set_unique_id,
+        patch.object(flow, "_abort_if_unique_id_configured"),
+    ):
+        result = await flow.async_step_device({CONF_DEVICE_SKI: typed})
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["data"][CONF_DEVICE_SKI] == canonical
+    set_unique_id.assert_awaited_once_with(canonical)
 
 
 def test_config_flow_exposes_options_flow():

--- a/custom_components/eebus/tests/test_init.py
+++ b/custom_components/eebus/tests/test_init.py
@@ -1,8 +1,11 @@
 """Tests for EEBUS integration setup and unload."""
 
+import logging
 from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
+
+from custom_components.eebus.const import CONF_DEVICE_SKI
 
 
 @pytest.mark.asyncio
@@ -76,3 +79,77 @@ async def test_unload_entry():
 
     assert result is True
     coordinator.async_shutdown.assert_awaited_once()
+
+
+async def test_migrate_entry_only_bumps_version_when_ski_is_canonical():
+    """A canonical v1 entry needs only a version update."""
+    from custom_components.eebus import async_migrate_entry
+
+    canonical = "682F708CEBA5DF9ADCB9E6787EA911D9FC3AC490"
+    hass = MagicMock()
+    entry = MagicMock(
+        version=1,
+        data={CONF_DEVICE_SKI: canonical},
+        unique_id=canonical,
+        entry_id="01",
+        title="Older entry",
+    )
+    hass.config_entries.async_entries.return_value = [entry]
+
+    assert await async_migrate_entry(hass, entry)
+    hass.config_entries.async_update_entry.assert_called_once_with(entry, version=2)
+
+
+async def test_migrate_entry_canonicalizes_data_and_unique_id():
+    """A formatted mixed-case v1 SKI migrates to canonical storage."""
+    from custom_components.eebus import async_migrate_entry
+
+    raw = "68:2f:70:8C:EB:A5:DF:9A:DC:B9:E6:78:7E:A9:11:D9:FC:3A:C4:90"
+    canonical = "682F708CEBA5DF9ADCB9E6787EA911D9FC3AC490"
+    hass = MagicMock()
+    entry = MagicMock(
+        version=1,
+        data={CONF_DEVICE_SKI: raw, "grpc_host": "bridge"},
+        unique_id=raw,
+        entry_id="01",
+        title="Heat pump",
+    )
+    hass.config_entries.async_entries.return_value = [entry]
+
+    assert await async_migrate_entry(hass, entry)
+    hass.config_entries.async_update_entry.assert_called_once_with(
+        entry,
+        data={CONF_DEVICE_SKI: canonical, "grpc_host": "bridge"},
+        unique_id=canonical,
+        version=2,
+    )
+
+
+async def test_migrate_entry_rejects_newer_duplicate(caplog: pytest.LogCaptureFixture):
+    """The newer of two entries for one canonical SKI fails with a warning."""
+    from custom_components.eebus import async_migrate_entry
+
+    canonical = "682F708CEBA5DF9ADCB9E6787EA911D9FC3AC490"
+    older = MagicMock(
+        version=2,
+        data={CONF_DEVICE_SKI: canonical},
+        unique_id=canonical,
+        entry_id="01",
+        title="Older entry",
+    )
+    newer = MagicMock(
+        version=1,
+        data={CONF_DEVICE_SKI: canonical.lower()},
+        unique_id=canonical.lower(),
+        entry_id="02",
+        title="Newer entry",
+    )
+    hass = MagicMock()
+    hass.config_entries.async_entries.return_value = [older, newer]
+
+    with caplog.at_level(logging.WARNING, logger="custom_components.eebus"):
+        assert not await async_migrate_entry(hass, newer)
+
+    hass.config_entries.async_update_entry.assert_not_called()
+    assert "02 (Newer entry)" in caplog.text
+    assert "01 (Older entry)" in caplog.text

--- a/custom_components/eebus/tests/test_init.py
+++ b/custom_components/eebus/tests/test_init.py
@@ -81,6 +81,24 @@ async def test_unload_entry():
     coordinator.async_shutdown.assert_awaited_once()
 
 
+async def test_migrate_entry_rejects_malformed_legacy_ski():
+    """A pre-existing entry with a non-hex/wrong-length SKI fails migration."""
+    from custom_components.eebus import async_migrate_entry
+
+    hass = MagicMock()
+    entry = MagicMock(
+        version=1,
+        data={CONF_DEVICE_SKI: "not-an-ski"},
+        unique_id="not-an-ski",
+        entry_id="01",
+        title="Broken entry",
+    )
+    hass.config_entries.async_entries.return_value = [entry]
+
+    assert not await async_migrate_entry(hass, entry)
+    hass.config_entries.async_update_entry.assert_not_called()
+
+
 async def test_migrate_entry_only_bumps_version_when_ski_is_canonical():
     """A canonical v1 entry needs only a version update."""
     from custom_components.eebus import async_migrate_entry

--- a/custom_components/eebus/tests/test_ski.py
+++ b/custom_components/eebus/tests/test_ski.py
@@ -1,0 +1,50 @@
+"""Tests for canonical EEBUS SKI handling."""
+
+import pytest
+
+from custom_components.eebus.ski import is_valid_ski, normalize_ski
+
+
+@pytest.mark.parametrize(
+    ("ski", "expected"),
+    [
+        ("abcdef", "ABCDEF"),
+        ("  ab cd ef  ", "ABCDEF"),
+        ("ab:cd-ef", "ABCDEF"),
+        ("ab\tcd\nef", "ABCDEF"),
+        ("AbCdEf", "ABCDEF"),
+        ("\t ab:CD-ef \r\n", "ABCDEF"),
+        (" aB:cD-ef\t12:34 ", "ABCDEF1234"),
+        ("", ""),
+    ],
+)
+def test_normalize_ski(ski: str, expected: str) -> None:
+    """Normalization matches the bridge's canonical test vectors."""
+    assert normalize_ski(ski) == expected
+
+
+@pytest.mark.parametrize(
+    "ski",
+    [
+        "682f708ceba5df9adcb9e6787ea911d9fc3ac490",
+        "682F708CEBA5DF9ADCB9E6787EA911D9FC3AC490",
+    ],
+)
+def test_is_valid_ski_accepts_40_hex_characters(ski: str) -> None:
+    """Both hexadecimal cases are valid."""
+    assert is_valid_ski(ski)
+
+
+@pytest.mark.parametrize(
+    "ski",
+    [
+        "",
+        "682F708CEBA5DF9ADCB9E6787EA911D9FC3AC49",
+        "682F708CEBA5DF9ADCB9E6787EA911D9FC3AC4900",
+        "682F708CEBA5DF9ADCB9E6787EA911D9FC3AC49Z",
+        "68:2F:70:8C:EB:A5:DF:9A:DC:B9:E6:78:7E:A9:11:D9:FC:3A:C4:90",
+    ],
+)
+def test_is_valid_ski_rejects_malformed_values(ski: str) -> None:
+    """Non-canonical lengths, separators, and non-hex characters are invalid."""
+    assert not is_valid_ski(ski)

--- a/custom_components/eebus/tests/test_ski.py
+++ b/custom_components/eebus/tests/test_ski.py
@@ -16,11 +16,24 @@ from custom_components.eebus.ski import is_valid_ski, normalize_ski
         ("\t ab:CD-ef \r\n", "ABCDEF"),
         (" aB:cD-ef\t12:34 ", "ABCDEF1234"),
         ("", ""),
+        ("\x1c", "\x1c"),
     ],
 )
 def test_normalize_ski(ski: str, expected: str) -> None:
     """Normalization matches the bridge's canonical test vectors."""
     assert normalize_ski(ski) == expected
+
+
+def test_normalize_ski_does_not_expand_unicode_ligatures() -> None:
+    """str.upper() would fold 'ﬀ' into 'FF', forging a fake valid SKI.
+
+    Go's rune-wise strings.ToUpper never does this; normalize_ski must not
+    diverge from that by using Python's full Unicode case folding.
+    """
+    ligature_ski = "ﬀ" * 20
+    normalized = normalize_ski(ligature_ski)
+    assert normalized != "F" * 40
+    assert not is_valid_ski(normalized)
 
 
 @pytest.mark.parametrize(

--- a/custom_components/eebus/translations/de.json
+++ b/custom_components/eebus/translations/de.json
@@ -54,6 +54,7 @@
     },
     "error": {
       "cannot_connect": "Verbindung zur EEBUS Bridge fehlgeschlagen. Bitte Adresse, Zertifikat und Token prüfen.",
+      "invalid_ski": "Bitte eine gültige hexadezimale SKI mit 40 Zeichen eingeben.",
       "required": "Dieses Feld ist für den Modus TLS + Token erforderlich.",
       "ski_is_local": "Das ist die eigene SKI der Bridge. Bitte die SKI der Wärmepumpe eingeben."
     },

--- a/custom_components/eebus/translations/en.json
+++ b/custom_components/eebus/translations/en.json
@@ -54,6 +54,7 @@
     },
     "error": {
       "cannot_connect": "Cannot connect to EEBUS bridge. Check the address, certificate, and token.",
+      "invalid_ski": "Enter a valid 40-character hexadecimal SKI.",
       "required": "This field is required for TLS + token mode.",
       "ski_is_local": "That is the bridge's own SKI. Enter the heat pump's SKI instead."
     },

--- a/eebus-bridge/internal/eebus/registry_test.go
+++ b/eebus-bridge/internal/eebus/registry_test.go
@@ -115,12 +115,14 @@ func TestRegistryUpsertDeviceClassification(t *testing.T) {
 
 func TestNormalizeSKI(t *testing.T) {
 	cases := map[string]string{
-		"abcdef":       "ABCDEF",
-		"  ab cd ef  ": "ABCDEF",
-		"ab:cd-ef":     "ABCDEF",
-		"ab\tcd\nef":   "ABCDEF",
-		"AbCdEf":       "ABCDEF",
-		"":             "",
+		"abcdef":            "ABCDEF",
+		"  ab cd ef  ":      "ABCDEF",
+		"ab:cd-ef":          "ABCDEF",
+		"ab\tcd\nef":        "ABCDEF",
+		"AbCdEf":            "ABCDEF",
+		"\t ab:CD-ef \r\n":  "ABCDEF",
+		" aB:cD-ef\t12:34 ": "ABCDEF1234",
+		"":                  "",
 	}
 	for in, want := range cases {
 		if got := eebus.NormalizeSKI(in); got != want {

--- a/eebus-bridge/internal/grpc/device_service.go
+++ b/eebus-bridge/internal/grpc/device_service.go
@@ -56,7 +56,7 @@ func (s *DeviceService) ListDiscoveredDevices(_ context.Context, _ *pb.Empty) (*
 }
 
 func (s *DeviceService) RegisterRemoteSKI(_ context.Context, req *pb.RegisterSKIRequest) (*pb.Empty, error) {
-	ski := normalizeSKIInput(req.Ski)
+	ski := eebus.NormalizeSKI(req.Ski)
 	if !validSKI(ski) {
 		return nil, status.Errorf(codes.InvalidArgument, "ski must be 40 hex characters, got %q", req.Ski)
 	}
@@ -71,7 +71,7 @@ func (s *DeviceService) RegisterRemoteSKI(_ context.Context, req *pb.RegisterSKI
 // be dropped without deleting internal/certs/ (which would rotate the local
 // SKI and force every other paired device to re-pair too).
 func (s *DeviceService) UnregisterRemoteSKI(_ context.Context, req *pb.RegisterSKIRequest) (*pb.Empty, error) {
-	ski := normalizeSKIInput(req.Ski)
+	ski := eebus.NormalizeSKI(req.Ski)
 	if !validSKI(ski) {
 		return nil, status.Errorf(codes.InvalidArgument, "ski must be 40 hex characters, got %q", req.Ski)
 	}

--- a/eebus-bridge/internal/grpc/device_service_test.go
+++ b/eebus-bridge/internal/grpc/device_service_test.go
@@ -137,7 +137,7 @@ func TestRegisterRemoteSKINormalizesColonSeparatedSKI(t *testing.T) {
 		t.Fatalf("RegisterRemoteSKI(colon-separated): %v", err)
 	}
 
-	want := testValidSKI
+	want := "682F708CEBA5DF9ADCB9E6787EA911D9FC3AC490"
 	if len(trust.registerCalls) != 1 || trust.registerCalls[0] != want {
 		t.Fatalf("RegisterSKI calls = %v, want [%s]", trust.registerCalls, want)
 	}
@@ -174,7 +174,7 @@ func TestPairingCommandsBypassCongestedEventBus(t *testing.T) {
 		t.Fatalf("UnregisterRemoteSKI: %v", err)
 	}
 
-	want := testValidSKI
+	want := "682F708CEBA5DF9ADCB9E6787EA911D9FC3AC490"
 	if len(trust.registerCalls) != 1 || trust.registerCalls[0] != want {
 		t.Errorf("RegisterSKI calls = %v, want [%s]", trust.registerCalls, want)
 	}

--- a/eebus-bridge/internal/grpc/validate.go
+++ b/eebus-bridge/internal/grpc/validate.go
@@ -2,25 +2,14 @@ package grpc
 
 import (
 	"math"
-	"strings"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
 
-// normalizeSKIInput strips separators a user may have typed or pasted a SKI
-// with (colons, dashes, spaces) and lower-cases it, mirroring the HA config
-// flow's own _normalize_ski. Without this, a colon-separated or spaced SKI
-// that HA's config flow already accepts would be rejected here before
-// BridgeService.RegisterRemoteSKI gets a chance to canonicalize it.
-func normalizeSKIInput(ski string) string {
-	replacer := strings.NewReplacer(":", "", "-", "", " ", "")
-	return strings.ToLower(replacer.Replace(strings.TrimSpace(ski)))
-}
-
 // validSKI reports whether ski is a well-formed EEBUS SKI: the SHA-1
 // fingerprint of a device certificate, 40 hex characters. Callers must
-// normalize with normalizeSKIInput first. Accepting malformed input here
+// normalize with eebus.NormalizeSKI first. Accepting malformed input here
 // would forward it straight to eebus-go's SHIP trust registration, which
 // fails silently downstream instead of with a clear rejection at the RPC
 // boundary.

--- a/eebus-bridge/internal/grpc/validate_test.go
+++ b/eebus-bridge/internal/grpc/validate_test.go
@@ -57,23 +57,6 @@ func TestValidSKI(t *testing.T) {
 	}
 }
 
-func TestNormalizeSKIInput(t *testing.T) {
-	valid := "682f708ceba5df9adcb9e6787ea911d9fc3ac490"
-
-	cases := map[string]string{
-		valid: valid,
-		"682F708CEBA5DF9ADCB9E6787EA911D9FC3AC490":                    valid,
-		"68:2f:70:8c:eb:a5:df:9a:dc:b9:e6:78:7e:a9:11:d9:fc:3a:c4:90": valid,
-		"68-2f-70-8c-eb-a5-df-9a-dc-b9-e6-78-7e-a9-11-d9-fc-3a-c4-90": valid,
-		"  " + valid + "  ": valid,
-	}
-	for in, want := range cases {
-		if got := normalizeSKIInput(in); got != want {
-			t.Errorf("normalizeSKIInput(%q) = %q, want %q", in, got, want)
-		}
-	}
-}
-
 // Validation runs before the provider-nil check, so a nil provider still yields
 // InvalidArgument for bad input (rather than Unavailable).
 func TestPublishRPCsRejectInvalidValues(t *testing.T) {


### PR DESCRIPTION
## Summary
- One production SKI normalizer per language: `eebus.NormalizeSKI` (Go, unchanged) and new `custom_components/eebus/ski.py` (Python), replacing four independently-drifted implementations (`internal/grpc/validate.go`'s `normalizeSKIInput`, `coordinator.py`'s and `config_flow.py`'s `_normalize_ski` — the latter didn't even strip dashes).
- Canonical form: uppercase, 40 hex chars, no separators.
- Config flow validates SKI format before creating an entry (`invalid_ski` error, en+de translations) and stores the canonical form as both `unique_id` and `CONF_DEVICE_SKI`.
- Config entry `VERSION` bumped to 2 with `async_migrate_entry`: canonicalizes existing entries, deterministically rejects a newer duplicate (by `entry_id`) if two entries collide on the same canonical SKI, logging a warning instead of silently dropping data.

Implements SPEC2-04 from `docs/refactoring-optimization-spec-v2.md`.

## Test plan
- [x] `go vet ./...`
- [x] `make test` (`-race`) — all packages green
- [x] `ruff check custom_components/`
- [x] `mypy custom_components/eebus` (strict) — clean
- [x] `PYTHONPATH=. pytest` — 133 passed
- [x] Manually traced migrated `CONF_DEVICE_SKI` flows into `coordinator.ski`; no stray raw `entry.unique_id` comparisons elsewhere