### PR TITLE
SPEC2-01: separate bridge and device connection state

### DIFF
--- a/custom_components/eebus/binary_sensor.py
+++ b/custom_components/eebus/binary_sensor.py
@@ -46,6 +46,16 @@ class EebusConnectedSensor(EebusEntity, BinarySensorEntity):
         self._attr_unique_id = f"{coordinator.ski}_connected"
 
     @property
+    def available(self) -> bool:
+        """Stay available on a successful poll regardless of connected state.
+
+        EebusEntity.available gates on the device being connected, which would
+        make this exact sensor disappear as "unavailable" instead of showing
+        "off" the moment it has something to report.
+        """
+        return self.coordinator.last_update_success
+
+    @property
     def is_on(self) -> bool | None:
         """Return True if connected."""
         if self.coordinator.data is None:

--- a/custom_components/eebus/entity.py
+++ b/custom_components/eebus/entity.py
@@ -25,3 +25,10 @@ class EebusEntity(CoordinatorEntity[EebusCoordinator]):
             model=info.get("model"),
             serial_number=info.get("serial"),
         )
+
+    @property
+    def available(self) -> bool:
+        """Unavailable whenever the coordinator poll failed or the remote device is disconnected."""
+        if not super().available:
+            return False
+        return bool((self.coordinator.data or {}).get("connected"))

--- a/custom_components/eebus/generated/eebus/v1/device_service_pb2.py
+++ b/custom_components/eebus/generated/eebus/v1/device_service_pb2.py
@@ -23,9 +23,10 @@ _sym_db = _symbol_database.Default()
 
 
 from . import common_pb2 as eebus_dot_v1_dot_common__pb2
+from google.protobuf import timestamp_pb2 as google_dot_protobuf_dot_timestamp__pb2
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x1d\x65\x65\x62us/v1/device_service.proto\x12\x08\x65\x65\x62us.v1\x1a\x15\x65\x65\x62us/v1/common.proto\"3\n\rServiceStatus\x12\x0f\n\x07running\x18\x01 \x01(\x08\x12\x11\n\tlocal_ski\x18\x02 \x01(\t\"p\n\x10\x44iscoveredDevice\x12\x0b\n\x03ski\x18\x01 \x01(\t\x12\r\n\x05\x62rand\x18\x02 \x01(\t\x12\r\n\x05model\x18\x03 \x01(\t\x12\x0e\n\x06serial\x18\x04 \x01(\t\x12\x13\n\x0b\x64\x65vice_type\x18\x05 \x01(\t\x12\x0c\n\x04host\x18\x06 \x01(\t\"B\n\x13ListDevicesResponse\x12+\n\x07\x64\x65vices\x18\x01 \x03(\x0b\x32\x1a.eebus.v1.DiscoveredDevice\"!\n\x12RegisterSKIRequest\x12\x0b\n\x03ski\x18\x01 \x01(\t\"{\n\x0cPairedDevice\x12\x0b\n\x03ski\x18\x01 \x01(\t\x12\r\n\x05\x62rand\x18\x02 \x01(\t\x12\r\n\x05model\x18\x03 \x01(\t\x12\x0e\n\x06serial\x18\x04 \x01(\t\x12\x13\n\x0b\x64\x65vice_type\x18\x05 \x01(\t\x12\x1b\n\x13supported_use_cases\x18\x06 \x03(\t\"D\n\x19ListPairedDevicesResponse\x12\'\n\x07\x64\x65vices\x18\x01 \x03(\x0b\x32\x16.eebus.v1.PairedDevice\"I\n\x0b\x44\x65viceEvent\x12\x0b\n\x03ski\x18\x01 \x01(\t\x12-\n\nevent_type\x18\x02 \x01(\x0e\x32\x19.eebus.v1.DeviceEventType*\x8a\x01\n\x0f\x44\x65viceEventType\x12\x1c\n\x18\x44\x45VICE_EVENT_UNSPECIFIED\x10\x00\x12\x1a\n\x16\x44\x45VICE_EVENT_CONNECTED\x10\x01\x12\x1d\n\x19\x44\x45VICE_EVENT_DISCONNECTED\x10\x02\x12\x1e\n\x1a\x44\x45VICE_EVENT_TRUST_REMOVED\x10\x03\x32\xa7\x03\n\rDeviceService\x12\x35\n\tGetStatus\x12\x0f.eebus.v1.Empty\x1a\x17.eebus.v1.ServiceStatus\x12G\n\x15ListDiscoveredDevices\x12\x0f.eebus.v1.Empty\x1a\x1d.eebus.v1.ListDevicesResponse\x12\x42\n\x11RegisterRemoteSKI\x12\x1c.eebus.v1.RegisterSKIRequest\x1a\x0f.eebus.v1.Empty\x12\x44\n\x13UnregisterRemoteSKI\x12\x1c.eebus.v1.RegisterSKIRequest\x1a\x0f.eebus.v1.Empty\x12I\n\x11ListPairedDevices\x12\x0f.eebus.v1.Empty\x1a#.eebus.v1.ListPairedDevicesResponse\x12\x41\n\x15SubscribeDeviceEvents\x12\x0f.eebus.v1.Empty\x1a\x15.eebus.v1.DeviceEvent0\x01\x42=Z;github.com/volschin/eebus-bridge/gen/proto/eebus/v1;eebusv1b\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x1d\x65\x65\x62us/v1/device_service.proto\x12\x08\x65\x65\x62us.v1\x1a\x15\x65\x65\x62us/v1/common.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"3\n\rServiceStatus\x12\x0f\n\x07running\x18\x01 \x01(\x08\x12\x11\n\tlocal_ski\x18\x02 \x01(\t\"V\n\x0c\x44\x65viceStatus\x12\x11\n\tconnected\x18\x01 \x01(\x08\x12\x33\n\x0flast_transition\x18\x02 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\"p\n\x10\x44iscoveredDevice\x12\x0b\n\x03ski\x18\x01 \x01(\t\x12\r\n\x05\x62rand\x18\x02 \x01(\t\x12\r\n\x05model\x18\x03 \x01(\t\x12\x0e\n\x06serial\x18\x04 \x01(\t\x12\x13\n\x0b\x64\x65vice_type\x18\x05 \x01(\t\x12\x0c\n\x04host\x18\x06 \x01(\t\"B\n\x13ListDevicesResponse\x12+\n\x07\x64\x65vices\x18\x01 \x03(\x0b\x32\x1a.eebus.v1.DiscoveredDevice\"!\n\x12RegisterSKIRequest\x12\x0b\n\x03ski\x18\x01 \x01(\t\"{\n\x0cPairedDevice\x12\x0b\n\x03ski\x18\x01 \x01(\t\x12\r\n\x05\x62rand\x18\x02 \x01(\t\x12\r\n\x05model\x18\x03 \x01(\t\x12\x0e\n\x06serial\x18\x04 \x01(\t\x12\x13\n\x0b\x64\x65vice_type\x18\x05 \x01(\t\x12\x1b\n\x13supported_use_cases\x18\x06 \x03(\t\"D\n\x19ListPairedDevicesResponse\x12\'\n\x07\x64\x65vices\x18\x01 \x03(\x0b\x32\x16.eebus.v1.PairedDevice\"I\n\x0b\x44\x65viceEvent\x12\x0b\n\x03ski\x18\x01 \x01(\t\x12-\n\nevent_type\x18\x02 \x01(\x0e\x32\x19.eebus.v1.DeviceEventType*\x8a\x01\n\x0f\x44\x65viceEventType\x12\x1c\n\x18\x44\x45VICE_EVENT_UNSPECIFIED\x10\x00\x12\x1a\n\x16\x44\x45VICE_EVENT_CONNECTED\x10\x01\x12\x1d\n\x19\x44\x45VICE_EVENT_DISCONNECTED\x10\x02\x12\x1e\n\x1a\x44\x45VICE_EVENT_TRUST_REMOVED\x10\x03\x32\xeb\x03\n\rDeviceService\x12\x35\n\tGetStatus\x12\x0f.eebus.v1.Empty\x1a\x17.eebus.v1.ServiceStatus\x12\x42\n\x0fGetDeviceStatus\x12\x17.eebus.v1.DeviceRequest\x1a\x16.eebus.v1.DeviceStatus\x12G\n\x15ListDiscoveredDevices\x12\x0f.eebus.v1.Empty\x1a\x1d.eebus.v1.ListDevicesResponse\x12\x42\n\x11RegisterRemoteSKI\x12\x1c.eebus.v1.RegisterSKIRequest\x1a\x0f.eebus.v1.Empty\x12\x44\n\x13UnregisterRemoteSKI\x12\x1c.eebus.v1.RegisterSKIRequest\x1a\x0f.eebus.v1.Empty\x12I\n\x11ListPairedDevices\x12\x0f.eebus.v1.Empty\x1a#.eebus.v1.ListPairedDevicesResponse\x12\x41\n\x15SubscribeDeviceEvents\x12\x0f.eebus.v1.Empty\x1a\x15.eebus.v1.DeviceEvent0\x01\x42=Z;github.com/volschin/eebus-bridge/gen/proto/eebus/v1;eebusv1b\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -33,22 +34,24 @@ _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'eebus.v1.device_service_pb2
 if not _descriptor._USE_C_DESCRIPTORS:
   _globals['DESCRIPTOR']._loaded_options = None
   _globals['DESCRIPTOR']._serialized_options = b'Z;github.com/volschin/eebus-bridge/gen/proto/eebus/v1;eebusv1'
-  _globals['_DEVICEEVENTTYPE']._serialized_start=607
-  _globals['_DEVICEEVENTTYPE']._serialized_end=745
-  _globals['_SERVICESTATUS']._serialized_start=66
-  _globals['_SERVICESTATUS']._serialized_end=117
-  _globals['_DISCOVEREDDEVICE']._serialized_start=119
-  _globals['_DISCOVEREDDEVICE']._serialized_end=231
-  _globals['_LISTDEVICESRESPONSE']._serialized_start=233
-  _globals['_LISTDEVICESRESPONSE']._serialized_end=299
-  _globals['_REGISTERSKIREQUEST']._serialized_start=301
-  _globals['_REGISTERSKIREQUEST']._serialized_end=334
-  _globals['_PAIREDDEVICE']._serialized_start=336
-  _globals['_PAIREDDEVICE']._serialized_end=459
-  _globals['_LISTPAIREDDEVICESRESPONSE']._serialized_start=461
-  _globals['_LISTPAIREDDEVICESRESPONSE']._serialized_end=529
-  _globals['_DEVICEEVENT']._serialized_start=531
-  _globals['_DEVICEEVENT']._serialized_end=604
-  _globals['_DEVICESERVICE']._serialized_start=748
-  _globals['_DEVICESERVICE']._serialized_end=1171
+  _globals['_DEVICEEVENTTYPE']._serialized_start=728
+  _globals['_DEVICEEVENTTYPE']._serialized_end=866
+  _globals['_SERVICESTATUS']._serialized_start=99
+  _globals['_SERVICESTATUS']._serialized_end=150
+  _globals['_DEVICESTATUS']._serialized_start=152
+  _globals['_DEVICESTATUS']._serialized_end=238
+  _globals['_DISCOVEREDDEVICE']._serialized_start=240
+  _globals['_DISCOVEREDDEVICE']._serialized_end=352
+  _globals['_LISTDEVICESRESPONSE']._serialized_start=354
+  _globals['_LISTDEVICESRESPONSE']._serialized_end=420
+  _globals['_REGISTERSKIREQUEST']._serialized_start=422
+  _globals['_REGISTERSKIREQUEST']._serialized_end=455
+  _globals['_PAIREDDEVICE']._serialized_start=457
+  _globals['_PAIREDDEVICE']._serialized_end=580
+  _globals['_LISTPAIREDDEVICESRESPONSE']._serialized_start=582
+  _globals['_LISTPAIREDDEVICESRESPONSE']._serialized_end=650
+  _globals['_DEVICEEVENT']._serialized_start=652
+  _globals['_DEVICEEVENT']._serialized_end=725
+  _globals['_DEVICESERVICE']._serialized_start=869
+  _globals['_DEVICESERVICE']._serialized_end=1360
 # @@protoc_insertion_point(module_scope)

--- a/custom_components/eebus/generated/eebus/v1/device_service_pb2.pyi
+++ b/custom_components/eebus/generated/eebus/v1/device_service_pb2.pyi
@@ -1,4 +1,7 @@
+import datetime
+
 from . import common_pb2 as _common_pb2
+from google.protobuf import timestamp_pb2 as _timestamp_pb2
 from google.protobuf.internal import containers as _containers
 from google.protobuf.internal import enum_type_wrapper as _enum_type_wrapper
 from google.protobuf import descriptor as _descriptor
@@ -26,6 +29,14 @@ class ServiceStatus(_message.Message):
     running: bool
     local_ski: str
     def __init__(self, running: bool = ..., local_ski: _Optional[str] = ...) -> None: ...
+
+class DeviceStatus(_message.Message):
+    __slots__ = ("connected", "last_transition")
+    CONNECTED_FIELD_NUMBER: _ClassVar[int]
+    LAST_TRANSITION_FIELD_NUMBER: _ClassVar[int]
+    connected: bool
+    last_transition: _timestamp_pb2.Timestamp
+    def __init__(self, connected: bool = ..., last_transition: _Optional[_Union[datetime.datetime, _timestamp_pb2.Timestamp, _Mapping]] = ...) -> None: ...
 
 class DiscoveredDevice(_message.Message):
     __slots__ = ("ski", "brand", "model", "serial", "device_type", "host")

--- a/custom_components/eebus/generated/eebus/v1/device_service_pb2_grpc.py
+++ b/custom_components/eebus/generated/eebus/v1/device_service_pb2_grpc.py
@@ -40,6 +40,11 @@ class DeviceServiceStub(object):
                 request_serializer=eebus_dot_v1_dot_common__pb2.Empty.SerializeToString,
                 response_deserializer=eebus_dot_v1_dot_device__service__pb2.ServiceStatus.FromString,
                 _registered_method=True)
+        self.GetDeviceStatus = channel.unary_unary(
+                '/eebus.v1.DeviceService/GetDeviceStatus',
+                request_serializer=eebus_dot_v1_dot_common__pb2.DeviceRequest.SerializeToString,
+                response_deserializer=eebus_dot_v1_dot_device__service__pb2.DeviceStatus.FromString,
+                _registered_method=True)
         self.ListDiscoveredDevices = channel.unary_unary(
                 '/eebus.v1.DeviceService/ListDiscoveredDevices',
                 request_serializer=eebus_dot_v1_dot_common__pb2.Empty.SerializeToString,
@@ -71,6 +76,12 @@ class DeviceServiceServicer(object):
     """Missing associated documentation comment in .proto file."""
 
     def GetStatus(self, request, context):
+        """Missing associated documentation comment in .proto file."""
+        context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+        context.set_details('Method not implemented!')
+        raise NotImplementedError('Method not implemented!')
+
+    def GetDeviceStatus(self, request, context):
         """Missing associated documentation comment in .proto file."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details('Method not implemented!')
@@ -113,6 +124,11 @@ def add_DeviceServiceServicer_to_server(servicer, server):
                     servicer.GetStatus,
                     request_deserializer=eebus_dot_v1_dot_common__pb2.Empty.FromString,
                     response_serializer=eebus_dot_v1_dot_device__service__pb2.ServiceStatus.SerializeToString,
+            ),
+            'GetDeviceStatus': grpc.unary_unary_rpc_method_handler(
+                    servicer.GetDeviceStatus,
+                    request_deserializer=eebus_dot_v1_dot_common__pb2.DeviceRequest.FromString,
+                    response_serializer=eebus_dot_v1_dot_device__service__pb2.DeviceStatus.SerializeToString,
             ),
             'ListDiscoveredDevices': grpc.unary_unary_rpc_method_handler(
                     servicer.ListDiscoveredDevices,
@@ -167,6 +183,33 @@ class DeviceService(object):
             '/eebus.v1.DeviceService/GetStatus',
             eebus_dot_v1_dot_common__pb2.Empty.SerializeToString,
             eebus_dot_v1_dot_device__service__pb2.ServiceStatus.FromString,
+            options,
+            channel_credentials,
+            insecure,
+            call_credentials,
+            compression,
+            wait_for_ready,
+            timeout,
+            metadata,
+            _registered_method=True)
+
+    @staticmethod
+    def GetDeviceStatus(request,
+            target,
+            options=(),
+            channel_credentials=None,
+            call_credentials=None,
+            insecure=False,
+            compression=None,
+            wait_for_ready=None,
+            timeout=None,
+            metadata=None):
+        return grpc.experimental.unary_unary(
+            request,
+            target,
+            '/eebus.v1.DeviceService/GetDeviceStatus',
+            eebus_dot_v1_dot_common__pb2.DeviceRequest.SerializeToString,
+            eebus_dot_v1_dot_device__service__pb2.DeviceStatus.FromString,
             options,
             channel_credentials,
             insecure,

--- a/custom_components/eebus/proto_stubs.py
+++ b/custom_components/eebus/proto_stubs.py
@@ -19,6 +19,7 @@ from .generated.eebus.v1.common_pb2 import (  # noqa: F401
 )
 from .generated.eebus.v1.device_service_pb2 import (  # noqa: F401
     DeviceEventType,
+    DeviceStatus,
     RegisterSKIRequest,
     ServiceStatus,
 )
@@ -124,6 +125,7 @@ __all__ = [
     "CompressorPowerConsumptionState",
     "ControlCompressorRequest",
     "DeviceEventType",
+    "DeviceStatus",
     "DeviceDiagnosticsData",
     "DeviceRequest",
     "DeviceServiceStub",

--- a/custom_components/eebus/quality_scale.yaml
+++ b/custom_components/eebus/quality_scale.yaml
@@ -29,7 +29,9 @@ rules:
   config-entry-unloading: done
   docs-configuration-parameters: done
   docs-installation-parameters: done
-  entity-unavailable: done
+  entity-unavailable:
+    status: done
+    comment: EebusEntity.available requires both a successful coordinator poll and the device-level connected state from GetDeviceStatus (registry-backed, not bridge liveness) — every platform's own available override chains through it via super().available.
   integration-owner: done
   log-when-unavailable: done
   parallel-updates: done

--- a/custom_components/eebus/snapshot.py
+++ b/custom_components/eebus/snapshot.py
@@ -410,13 +410,38 @@ async def async_build_snapshot(
         ),
     )
 
-    device_info, compressor, dhw_setpoint, dhw_system_function, room_heating, diagnostics = await asyncio.gather(
-        _async_fetch_device_info(device_stub, ski),
-        _async_read_compressor_flexibility(channel, request, ski, support.ohpcf),
-        _async_read_dhw_setpoint(channel, request, ski, support.dhw),
-        _async_read_dhw_system_function(channel, request, ski, support.dhw_system_function),
-        _async_read_room_heating(channel, request, support.room_heating),
-        _async_read_device_diagnostics(channel, request, ski),
+    (
+        device_status,
+        device_info,
+        compressor,
+        dhw_setpoint,
+        dhw_system_function,
+        room_heating,
+        diagnostics,
+    ) = cast(
+        tuple[
+            proto_stubs.DeviceStatus,
+            DeviceInfo | None,
+            _ReadResult[CompressorFlexibilityState],
+            _ReadResult[SetpointState],
+            _ReadResult[DHWSystemFunctionState],
+            _ReadResult[_RoomHeatingRead],
+            str | None,
+        ],
+        await asyncio.gather(
+            cast(
+                Awaitable[proto_stubs.DeviceStatus],
+                device_stub.GetDeviceStatus(request, timeout=RPC_TIMEOUT),
+            ),
+            _async_fetch_device_info(device_stub, ski),
+            _async_read_compressor_flexibility(channel, request, ski, support.ohpcf),
+            _async_read_dhw_setpoint(channel, request, ski, support.dhw),
+            _async_read_dhw_system_function(
+                channel, request, ski, support.dhw_system_function
+            ),
+            _async_read_room_heating(channel, request, support.room_heating),
+            _async_read_device_diagnostics(channel, request, ski),
+        ),
     )
 
     updated_support = SnapshotSupport(
@@ -463,7 +488,7 @@ async def async_build_snapshot(
         room_temperature_c = room_heating_value.current_temperature_celsius
 
     snapshot = CoordinatorSnapshot(
-        connected=status.running,
+        connected=device_status.connected,
         local_ski=status.local_ski,
         ski_registered=registered,
         power_l1_w=flat_measurements.get("power_l1_w"),

--- a/custom_components/eebus/tests/test_binary_sensor.py
+++ b/custom_components/eebus/tests/test_binary_sensor.py
@@ -1,0 +1,32 @@
+"""Tests for EEBUS binary sensor entities."""
+
+from unittest.mock import MagicMock
+
+from custom_components.eebus.binary_sensor import EebusConnectedSensor
+
+
+def _sensor(*, connected: bool | None, poll_ok: bool) -> EebusConnectedSensor:
+    coordinator = MagicMock()
+    coordinator.data = None if connected is None else {"connected": connected}
+    coordinator.ski = "test-ski"
+    coordinator.last_update_success = poll_ok
+    return EebusConnectedSensor(coordinator)
+
+
+def test_available_when_device_disconnected_but_poll_succeeded() -> None:
+    sensor = _sensor(connected=False, poll_ok=True)
+    assert sensor.available is True
+    assert sensor.is_on is False
+
+
+def test_unavailable_when_poll_failed() -> None:
+    sensor = _sensor(connected=True, poll_ok=False)
+    assert sensor.available is False
+
+
+def test_is_on_true_when_connected() -> None:
+    assert _sensor(connected=True, poll_ok=True).is_on is True
+
+
+def test_is_on_none_when_no_data_yet() -> None:
+    assert _sensor(connected=None, poll_ok=True).is_on is None

--- a/custom_components/eebus/tests/test_coordinator.py
+++ b/custom_components/eebus/tests/test_coordinator.py
@@ -54,6 +54,9 @@ def _poll_stubs(room_heating_read):
                 running=True, local_ski="bridge-ski"
             )
         ),
+        GetDeviceStatus=AsyncMock(
+            return_value=device_service_pb2.DeviceStatus(connected=True)
+        ),
         ListPairedDevices=AsyncMock(
             return_value=device_service_pb2.ListPairedDevicesResponse()
         ),
@@ -224,6 +227,24 @@ async def test_poll_returns_room_temperature_without_mid_poll_push():
     assert snapshot["room_temperature_c"] == room_temperature
     assert coordinator.data == {"room_temperature_c": 18.0}
     coordinator._push_data.assert_not_called()
+
+
+async def test_poll_connected_uses_device_status_independent_of_bridge_status():
+    """Snapshot connectivity comes from the remote device, not bridge liveness."""
+    stubs = _poll_stubs(AsyncMock(return_value=hvac_service_pb2.RoomHeatingState()))
+    stubs["device_service_stub"].GetStatus.return_value = device_service_pb2.ServiceStatus(
+        running=False, local_ski="bridge-ski"
+    )
+    stubs["device_service_stub"].GetDeviceStatus.return_value = (
+        device_service_pb2.DeviceStatus(connected=True)
+    )
+    coordinator = _poll_coordinator()
+
+    with _patch_poll_stubs(stubs):
+        snapshot = await coordinator._async_update_data()
+
+    assert snapshot["connected"] is True
+    stubs["device_service_stub"].GetDeviceStatus.assert_awaited_once()
 
 
 async def test_poll_applies_support_flags_only_after_all_reads_complete():
@@ -610,17 +631,36 @@ async def test_poll_read_not_found_does_not_retry_with_empty_ski():
     call.assert_awaited_once_with(request, timeout=10)
 
 
-def test_device_event_triggers_refresh():
-    """Connection state events trigger a reconciliation poll."""
-    coordinator, _ = _make_coordinator(data={"connected": True})
-    coordinator.hass = MagicMock()
-    coordinator.async_request_refresh = MagicMock(return_value=None)
+async def test_device_disconnect_event_refreshes_disconnected_state():
+    """A disconnect event reconciles to the registry-backed disconnected state."""
+    stubs = _poll_stubs(AsyncMock(return_value=hvac_service_pb2.RoomHeatingState()))
+    stubs["device_service_stub"].GetDeviceStatus.return_value = (
+        device_service_pb2.DeviceStatus(connected=False)
+    )
+    coordinator = _poll_coordinator()
+    coordinator.data = {"connected": True}
+    tasks: list[asyncio.Task] = []
+
+    async def request_refresh():
+        coordinator.data = await coordinator._async_update_data()
+
+    def create_task(coro):
+        task = asyncio.create_task(coro)
+        tasks.append(task)
+        return task
+
+    coordinator.async_request_refresh = request_refresh
+    coordinator.hass = SimpleNamespace(async_create_task=create_task)
     event = device_service_pb2.DeviceEvent(
-        ski="test-ski",
+        ski="device-ski",
         event_type=device_service_pb2.DEVICE_EVENT_DISCONNECTED,
     )
-    coordinator._handle_device_event(event)
-    coordinator.hass.async_create_task.assert_called_once()
+
+    with _patch_poll_stubs(stubs):
+        coordinator._handle_device_event(event)
+        await tasks[0]
+
+    assert coordinator.data["connected"] is False
 
 
 def _entry(measurement_type, value):

--- a/custom_components/eebus/tests/test_entity.py
+++ b/custom_components/eebus/tests/test_entity.py
@@ -1,0 +1,25 @@
+"""Tests for the EEBUS base entity."""
+
+from unittest.mock import MagicMock
+
+from custom_components.eebus.entity import EebusEntity
+
+
+def _entity(*, connected: bool, poll_ok: bool) -> EebusEntity:
+    coordinator = MagicMock()
+    coordinator.data = {"connected": connected}
+    coordinator.ski = "test-ski"
+    coordinator.last_update_success = poll_ok
+    return EebusEntity(coordinator)
+
+
+def test_available_when_connected_and_poll_succeeded() -> None:
+    assert _entity(connected=True, poll_ok=True).available is True
+
+
+def test_unavailable_when_device_disconnected() -> None:
+    assert _entity(connected=False, poll_ok=True).available is False
+
+
+def test_unavailable_when_poll_failed_even_if_device_was_connected() -> None:
+    assert _entity(connected=True, poll_ok=False).available is False

--- a/custom_components/eebus/tests/test_sensor.py
+++ b/custom_components/eebus/tests/test_sensor.py
@@ -43,6 +43,7 @@ def test_failsafe_limit_sensor_value():
     """Test failsafe limit sensor returns correct value from coordinator data."""
     coordinator = MagicMock()
     coordinator.data = {
+        "connected": True,
         "failsafe_limit": {"value_watts": 4200.0, "duration_minimum_seconds": 7200},
         "failsafe_supported": True,
     }

--- a/docs/refactoring-optimization-spec-v2.md
+++ b/docs/refactoring-optimization-spec-v2.md
@@ -122,6 +122,10 @@ Prioritäten:
 - Eine weiterhin erreichbare Bridge darf den Remote-Zustand nicht wieder auf `connected` setzen.
 - Tests decken `bridge up/device down`, `bridge up/device up`, Trust-Removal und Reconnect ab.
 
+**Bekannte Lücke**
+
+`device_ready` ist noch nicht implementiert: `DeviceStatus` liefert aktuell nur `connected`/`last_transition`, kein aggregiertes Freshness-Signal über SPINE/Use-Case-Bindings. Umsetzung gehört inhaltlich zu SPEC2-12 (Diagnose/Degradation) und ist dort nachzuziehen, statt sie als Scope-Erweiterung in dieses P0-Ticket zu ziehen.
+
 ### SPEC2-02 – Heartbeat-Eigentümerschaft korrigieren (P0)
 
 **Ist-Befund**

--- a/eebus-bridge/gen/proto/eebus/v1/device_service.pb.go
+++ b/eebus-bridge/gen/proto/eebus/v1/device_service.pb.go
@@ -9,6 +9,7 @@ package eebusv1
 import (
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
 	reflect "reflect"
 	sync "sync"
 	unsafe "unsafe"
@@ -125,6 +126,58 @@ func (x *ServiceStatus) GetLocalSki() string {
 	return ""
 }
 
+type DeviceStatus struct {
+	state          protoimpl.MessageState `protogen:"open.v1"`
+	Connected      bool                   `protobuf:"varint,1,opt,name=connected,proto3" json:"connected,omitempty"`
+	LastTransition *timestamppb.Timestamp `protobuf:"bytes,2,opt,name=last_transition,json=lastTransition,proto3" json:"last_transition,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *DeviceStatus) Reset() {
+	*x = DeviceStatus{}
+	mi := &file_eebus_v1_device_service_proto_msgTypes[1]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DeviceStatus) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DeviceStatus) ProtoMessage() {}
+
+func (x *DeviceStatus) ProtoReflect() protoreflect.Message {
+	mi := &file_eebus_v1_device_service_proto_msgTypes[1]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DeviceStatus.ProtoReflect.Descriptor instead.
+func (*DeviceStatus) Descriptor() ([]byte, []int) {
+	return file_eebus_v1_device_service_proto_rawDescGZIP(), []int{1}
+}
+
+func (x *DeviceStatus) GetConnected() bool {
+	if x != nil {
+		return x.Connected
+	}
+	return false
+}
+
+func (x *DeviceStatus) GetLastTransition() *timestamppb.Timestamp {
+	if x != nil {
+		return x.LastTransition
+	}
+	return nil
+}
+
 type DiscoveredDevice struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Ski           string                 `protobuf:"bytes,1,opt,name=ski,proto3" json:"ski,omitempty"`
@@ -139,7 +192,7 @@ type DiscoveredDevice struct {
 
 func (x *DiscoveredDevice) Reset() {
 	*x = DiscoveredDevice{}
-	mi := &file_eebus_v1_device_service_proto_msgTypes[1]
+	mi := &file_eebus_v1_device_service_proto_msgTypes[2]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -151,7 +204,7 @@ func (x *DiscoveredDevice) String() string {
 func (*DiscoveredDevice) ProtoMessage() {}
 
 func (x *DiscoveredDevice) ProtoReflect() protoreflect.Message {
-	mi := &file_eebus_v1_device_service_proto_msgTypes[1]
+	mi := &file_eebus_v1_device_service_proto_msgTypes[2]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -164,7 +217,7 @@ func (x *DiscoveredDevice) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DiscoveredDevice.ProtoReflect.Descriptor instead.
 func (*DiscoveredDevice) Descriptor() ([]byte, []int) {
-	return file_eebus_v1_device_service_proto_rawDescGZIP(), []int{1}
+	return file_eebus_v1_device_service_proto_rawDescGZIP(), []int{2}
 }
 
 func (x *DiscoveredDevice) GetSki() string {
@@ -218,7 +271,7 @@ type ListDevicesResponse struct {
 
 func (x *ListDevicesResponse) Reset() {
 	*x = ListDevicesResponse{}
-	mi := &file_eebus_v1_device_service_proto_msgTypes[2]
+	mi := &file_eebus_v1_device_service_proto_msgTypes[3]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -230,7 +283,7 @@ func (x *ListDevicesResponse) String() string {
 func (*ListDevicesResponse) ProtoMessage() {}
 
 func (x *ListDevicesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_eebus_v1_device_service_proto_msgTypes[2]
+	mi := &file_eebus_v1_device_service_proto_msgTypes[3]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -243,7 +296,7 @@ func (x *ListDevicesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListDevicesResponse.ProtoReflect.Descriptor instead.
 func (*ListDevicesResponse) Descriptor() ([]byte, []int) {
-	return file_eebus_v1_device_service_proto_rawDescGZIP(), []int{2}
+	return file_eebus_v1_device_service_proto_rawDescGZIP(), []int{3}
 }
 
 func (x *ListDevicesResponse) GetDevices() []*DiscoveredDevice {
@@ -262,7 +315,7 @@ type RegisterSKIRequest struct {
 
 func (x *RegisterSKIRequest) Reset() {
 	*x = RegisterSKIRequest{}
-	mi := &file_eebus_v1_device_service_proto_msgTypes[3]
+	mi := &file_eebus_v1_device_service_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -274,7 +327,7 @@ func (x *RegisterSKIRequest) String() string {
 func (*RegisterSKIRequest) ProtoMessage() {}
 
 func (x *RegisterSKIRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_eebus_v1_device_service_proto_msgTypes[3]
+	mi := &file_eebus_v1_device_service_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -287,7 +340,7 @@ func (x *RegisterSKIRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RegisterSKIRequest.ProtoReflect.Descriptor instead.
 func (*RegisterSKIRequest) Descriptor() ([]byte, []int) {
-	return file_eebus_v1_device_service_proto_rawDescGZIP(), []int{3}
+	return file_eebus_v1_device_service_proto_rawDescGZIP(), []int{4}
 }
 
 func (x *RegisterSKIRequest) GetSki() string {
@@ -311,7 +364,7 @@ type PairedDevice struct {
 
 func (x *PairedDevice) Reset() {
 	*x = PairedDevice{}
-	mi := &file_eebus_v1_device_service_proto_msgTypes[4]
+	mi := &file_eebus_v1_device_service_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -323,7 +376,7 @@ func (x *PairedDevice) String() string {
 func (*PairedDevice) ProtoMessage() {}
 
 func (x *PairedDevice) ProtoReflect() protoreflect.Message {
-	mi := &file_eebus_v1_device_service_proto_msgTypes[4]
+	mi := &file_eebus_v1_device_service_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -336,7 +389,7 @@ func (x *PairedDevice) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PairedDevice.ProtoReflect.Descriptor instead.
 func (*PairedDevice) Descriptor() ([]byte, []int) {
-	return file_eebus_v1_device_service_proto_rawDescGZIP(), []int{4}
+	return file_eebus_v1_device_service_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *PairedDevice) GetSki() string {
@@ -390,7 +443,7 @@ type ListPairedDevicesResponse struct {
 
 func (x *ListPairedDevicesResponse) Reset() {
 	*x = ListPairedDevicesResponse{}
-	mi := &file_eebus_v1_device_service_proto_msgTypes[5]
+	mi := &file_eebus_v1_device_service_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -402,7 +455,7 @@ func (x *ListPairedDevicesResponse) String() string {
 func (*ListPairedDevicesResponse) ProtoMessage() {}
 
 func (x *ListPairedDevicesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_eebus_v1_device_service_proto_msgTypes[5]
+	mi := &file_eebus_v1_device_service_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -415,7 +468,7 @@ func (x *ListPairedDevicesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListPairedDevicesResponse.ProtoReflect.Descriptor instead.
 func (*ListPairedDevicesResponse) Descriptor() ([]byte, []int) {
-	return file_eebus_v1_device_service_proto_rawDescGZIP(), []int{5}
+	return file_eebus_v1_device_service_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *ListPairedDevicesResponse) GetDevices() []*PairedDevice {
@@ -435,7 +488,7 @@ type DeviceEvent struct {
 
 func (x *DeviceEvent) Reset() {
 	*x = DeviceEvent{}
-	mi := &file_eebus_v1_device_service_proto_msgTypes[6]
+	mi := &file_eebus_v1_device_service_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -447,7 +500,7 @@ func (x *DeviceEvent) String() string {
 func (*DeviceEvent) ProtoMessage() {}
 
 func (x *DeviceEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_eebus_v1_device_service_proto_msgTypes[6]
+	mi := &file_eebus_v1_device_service_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -460,7 +513,7 @@ func (x *DeviceEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeviceEvent.ProtoReflect.Descriptor instead.
 func (*DeviceEvent) Descriptor() ([]byte, []int) {
-	return file_eebus_v1_device_service_proto_rawDescGZIP(), []int{6}
+	return file_eebus_v1_device_service_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *DeviceEvent) GetSki() string {
@@ -481,10 +534,13 @@ var File_eebus_v1_device_service_proto protoreflect.FileDescriptor
 
 const file_eebus_v1_device_service_proto_rawDesc = "" +
 	"\n" +
-	"\x1deebus/v1/device_service.proto\x12\beebus.v1\x1a\x15eebus/v1/common.proto\"F\n" +
+	"\x1deebus/v1/device_service.proto\x12\beebus.v1\x1a\x15eebus/v1/common.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"F\n" +
 	"\rServiceStatus\x12\x18\n" +
 	"\arunning\x18\x01 \x01(\bR\arunning\x12\x1b\n" +
-	"\tlocal_ski\x18\x02 \x01(\tR\blocalSki\"\x9d\x01\n" +
+	"\tlocal_ski\x18\x02 \x01(\tR\blocalSki\"q\n" +
+	"\fDeviceStatus\x12\x1c\n" +
+	"\tconnected\x18\x01 \x01(\bR\tconnected\x12C\n" +
+	"\x0flast_transition\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\x0elastTransition\"\x9d\x01\n" +
 	"\x10DiscoveredDevice\x12\x10\n" +
 	"\x03ski\x18\x01 \x01(\tR\x03ski\x12\x14\n" +
 	"\x05brand\x18\x02 \x01(\tR\x05brand\x12\x14\n" +
@@ -515,9 +571,10 @@ const file_eebus_v1_device_service_proto_rawDesc = "" +
 	"\x18DEVICE_EVENT_UNSPECIFIED\x10\x00\x12\x1a\n" +
 	"\x16DEVICE_EVENT_CONNECTED\x10\x01\x12\x1d\n" +
 	"\x19DEVICE_EVENT_DISCONNECTED\x10\x02\x12\x1e\n" +
-	"\x1aDEVICE_EVENT_TRUST_REMOVED\x10\x032\xa7\x03\n" +
+	"\x1aDEVICE_EVENT_TRUST_REMOVED\x10\x032\xeb\x03\n" +
 	"\rDeviceService\x125\n" +
-	"\tGetStatus\x12\x0f.eebus.v1.Empty\x1a\x17.eebus.v1.ServiceStatus\x12G\n" +
+	"\tGetStatus\x12\x0f.eebus.v1.Empty\x1a\x17.eebus.v1.ServiceStatus\x12B\n" +
+	"\x0fGetDeviceStatus\x12\x17.eebus.v1.DeviceRequest\x1a\x16.eebus.v1.DeviceStatus\x12G\n" +
 	"\x15ListDiscoveredDevices\x12\x0f.eebus.v1.Empty\x1a\x1d.eebus.v1.ListDevicesResponse\x12B\n" +
 	"\x11RegisterRemoteSKI\x12\x1c.eebus.v1.RegisterSKIRequest\x1a\x0f.eebus.v1.Empty\x12D\n" +
 	"\x13UnregisterRemoteSKI\x12\x1c.eebus.v1.RegisterSKIRequest\x1a\x0f.eebus.v1.Empty\x12I\n" +
@@ -537,39 +594,45 @@ func file_eebus_v1_device_service_proto_rawDescGZIP() []byte {
 }
 
 var file_eebus_v1_device_service_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_eebus_v1_device_service_proto_msgTypes = make([]protoimpl.MessageInfo, 7)
+var file_eebus_v1_device_service_proto_msgTypes = make([]protoimpl.MessageInfo, 8)
 var file_eebus_v1_device_service_proto_goTypes = []any{
 	(DeviceEventType)(0),              // 0: eebus.v1.DeviceEventType
 	(*ServiceStatus)(nil),             // 1: eebus.v1.ServiceStatus
-	(*DiscoveredDevice)(nil),          // 2: eebus.v1.DiscoveredDevice
-	(*ListDevicesResponse)(nil),       // 3: eebus.v1.ListDevicesResponse
-	(*RegisterSKIRequest)(nil),        // 4: eebus.v1.RegisterSKIRequest
-	(*PairedDevice)(nil),              // 5: eebus.v1.PairedDevice
-	(*ListPairedDevicesResponse)(nil), // 6: eebus.v1.ListPairedDevicesResponse
-	(*DeviceEvent)(nil),               // 7: eebus.v1.DeviceEvent
-	(*Empty)(nil),                     // 8: eebus.v1.Empty
+	(*DeviceStatus)(nil),              // 2: eebus.v1.DeviceStatus
+	(*DiscoveredDevice)(nil),          // 3: eebus.v1.DiscoveredDevice
+	(*ListDevicesResponse)(nil),       // 4: eebus.v1.ListDevicesResponse
+	(*RegisterSKIRequest)(nil),        // 5: eebus.v1.RegisterSKIRequest
+	(*PairedDevice)(nil),              // 6: eebus.v1.PairedDevice
+	(*ListPairedDevicesResponse)(nil), // 7: eebus.v1.ListPairedDevicesResponse
+	(*DeviceEvent)(nil),               // 8: eebus.v1.DeviceEvent
+	(*timestamppb.Timestamp)(nil),     // 9: google.protobuf.Timestamp
+	(*Empty)(nil),                     // 10: eebus.v1.Empty
+	(*DeviceRequest)(nil),             // 11: eebus.v1.DeviceRequest
 }
 var file_eebus_v1_device_service_proto_depIdxs = []int32{
-	2, // 0: eebus.v1.ListDevicesResponse.devices:type_name -> eebus.v1.DiscoveredDevice
-	5, // 1: eebus.v1.ListPairedDevicesResponse.devices:type_name -> eebus.v1.PairedDevice
-	0, // 2: eebus.v1.DeviceEvent.event_type:type_name -> eebus.v1.DeviceEventType
-	8, // 3: eebus.v1.DeviceService.GetStatus:input_type -> eebus.v1.Empty
-	8, // 4: eebus.v1.DeviceService.ListDiscoveredDevices:input_type -> eebus.v1.Empty
-	4, // 5: eebus.v1.DeviceService.RegisterRemoteSKI:input_type -> eebus.v1.RegisterSKIRequest
-	4, // 6: eebus.v1.DeviceService.UnregisterRemoteSKI:input_type -> eebus.v1.RegisterSKIRequest
-	8, // 7: eebus.v1.DeviceService.ListPairedDevices:input_type -> eebus.v1.Empty
-	8, // 8: eebus.v1.DeviceService.SubscribeDeviceEvents:input_type -> eebus.v1.Empty
-	1, // 9: eebus.v1.DeviceService.GetStatus:output_type -> eebus.v1.ServiceStatus
-	3, // 10: eebus.v1.DeviceService.ListDiscoveredDevices:output_type -> eebus.v1.ListDevicesResponse
-	8, // 11: eebus.v1.DeviceService.RegisterRemoteSKI:output_type -> eebus.v1.Empty
-	8, // 12: eebus.v1.DeviceService.UnregisterRemoteSKI:output_type -> eebus.v1.Empty
-	6, // 13: eebus.v1.DeviceService.ListPairedDevices:output_type -> eebus.v1.ListPairedDevicesResponse
-	7, // 14: eebus.v1.DeviceService.SubscribeDeviceEvents:output_type -> eebus.v1.DeviceEvent
-	9, // [9:15] is the sub-list for method output_type
-	3, // [3:9] is the sub-list for method input_type
-	3, // [3:3] is the sub-list for extension type_name
-	3, // [3:3] is the sub-list for extension extendee
-	0, // [0:3] is the sub-list for field type_name
+	9,  // 0: eebus.v1.DeviceStatus.last_transition:type_name -> google.protobuf.Timestamp
+	3,  // 1: eebus.v1.ListDevicesResponse.devices:type_name -> eebus.v1.DiscoveredDevice
+	6,  // 2: eebus.v1.ListPairedDevicesResponse.devices:type_name -> eebus.v1.PairedDevice
+	0,  // 3: eebus.v1.DeviceEvent.event_type:type_name -> eebus.v1.DeviceEventType
+	10, // 4: eebus.v1.DeviceService.GetStatus:input_type -> eebus.v1.Empty
+	11, // 5: eebus.v1.DeviceService.GetDeviceStatus:input_type -> eebus.v1.DeviceRequest
+	10, // 6: eebus.v1.DeviceService.ListDiscoveredDevices:input_type -> eebus.v1.Empty
+	5,  // 7: eebus.v1.DeviceService.RegisterRemoteSKI:input_type -> eebus.v1.RegisterSKIRequest
+	5,  // 8: eebus.v1.DeviceService.UnregisterRemoteSKI:input_type -> eebus.v1.RegisterSKIRequest
+	10, // 9: eebus.v1.DeviceService.ListPairedDevices:input_type -> eebus.v1.Empty
+	10, // 10: eebus.v1.DeviceService.SubscribeDeviceEvents:input_type -> eebus.v1.Empty
+	1,  // 11: eebus.v1.DeviceService.GetStatus:output_type -> eebus.v1.ServiceStatus
+	2,  // 12: eebus.v1.DeviceService.GetDeviceStatus:output_type -> eebus.v1.DeviceStatus
+	4,  // 13: eebus.v1.DeviceService.ListDiscoveredDevices:output_type -> eebus.v1.ListDevicesResponse
+	10, // 14: eebus.v1.DeviceService.RegisterRemoteSKI:output_type -> eebus.v1.Empty
+	10, // 15: eebus.v1.DeviceService.UnregisterRemoteSKI:output_type -> eebus.v1.Empty
+	7,  // 16: eebus.v1.DeviceService.ListPairedDevices:output_type -> eebus.v1.ListPairedDevicesResponse
+	8,  // 17: eebus.v1.DeviceService.SubscribeDeviceEvents:output_type -> eebus.v1.DeviceEvent
+	11, // [11:18] is the sub-list for method output_type
+	4,  // [4:11] is the sub-list for method input_type
+	4,  // [4:4] is the sub-list for extension type_name
+	4,  // [4:4] is the sub-list for extension extendee
+	0,  // [0:4] is the sub-list for field type_name
 }
 
 func init() { file_eebus_v1_device_service_proto_init() }
@@ -584,7 +647,7 @@ func file_eebus_v1_device_service_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_eebus_v1_device_service_proto_rawDesc), len(file_eebus_v1_device_service_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   7,
+			NumMessages:   8,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/eebus-bridge/gen/proto/eebus/v1/device_service_grpc.pb.go
+++ b/eebus-bridge/gen/proto/eebus/v1/device_service_grpc.pb.go
@@ -20,6 +20,7 @@ const _ = grpc.SupportPackageIsVersion9
 
 const (
 	DeviceService_GetStatus_FullMethodName             = "/eebus.v1.DeviceService/GetStatus"
+	DeviceService_GetDeviceStatus_FullMethodName       = "/eebus.v1.DeviceService/GetDeviceStatus"
 	DeviceService_ListDiscoveredDevices_FullMethodName = "/eebus.v1.DeviceService/ListDiscoveredDevices"
 	DeviceService_RegisterRemoteSKI_FullMethodName     = "/eebus.v1.DeviceService/RegisterRemoteSKI"
 	DeviceService_UnregisterRemoteSKI_FullMethodName   = "/eebus.v1.DeviceService/UnregisterRemoteSKI"
@@ -32,6 +33,7 @@ const (
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
 type DeviceServiceClient interface {
 	GetStatus(ctx context.Context, in *Empty, opts ...grpc.CallOption) (*ServiceStatus, error)
+	GetDeviceStatus(ctx context.Context, in *DeviceRequest, opts ...grpc.CallOption) (*DeviceStatus, error)
 	ListDiscoveredDevices(ctx context.Context, in *Empty, opts ...grpc.CallOption) (*ListDevicesResponse, error)
 	RegisterRemoteSKI(ctx context.Context, in *RegisterSKIRequest, opts ...grpc.CallOption) (*Empty, error)
 	UnregisterRemoteSKI(ctx context.Context, in *RegisterSKIRequest, opts ...grpc.CallOption) (*Empty, error)
@@ -51,6 +53,16 @@ func (c *deviceServiceClient) GetStatus(ctx context.Context, in *Empty, opts ...
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(ServiceStatus)
 	err := c.cc.Invoke(ctx, DeviceService_GetStatus_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *deviceServiceClient) GetDeviceStatus(ctx context.Context, in *DeviceRequest, opts ...grpc.CallOption) (*DeviceStatus, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(DeviceStatus)
+	err := c.cc.Invoke(ctx, DeviceService_GetDeviceStatus_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -121,6 +133,7 @@ type DeviceService_SubscribeDeviceEventsClient = grpc.ServerStreamingClient[Devi
 // for forward compatibility.
 type DeviceServiceServer interface {
 	GetStatus(context.Context, *Empty) (*ServiceStatus, error)
+	GetDeviceStatus(context.Context, *DeviceRequest) (*DeviceStatus, error)
 	ListDiscoveredDevices(context.Context, *Empty) (*ListDevicesResponse, error)
 	RegisterRemoteSKI(context.Context, *RegisterSKIRequest) (*Empty, error)
 	UnregisterRemoteSKI(context.Context, *RegisterSKIRequest) (*Empty, error)
@@ -138,6 +151,9 @@ type UnimplementedDeviceServiceServer struct{}
 
 func (UnimplementedDeviceServiceServer) GetStatus(context.Context, *Empty) (*ServiceStatus, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetStatus not implemented")
+}
+func (UnimplementedDeviceServiceServer) GetDeviceStatus(context.Context, *DeviceRequest) (*DeviceStatus, error) {
+	return nil, status.Error(codes.Unimplemented, "method GetDeviceStatus not implemented")
 }
 func (UnimplementedDeviceServiceServer) ListDiscoveredDevices(context.Context, *Empty) (*ListDevicesResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ListDiscoveredDevices not implemented")
@@ -189,6 +205,24 @@ func _DeviceService_GetStatus_Handler(srv interface{}, ctx context.Context, dec 
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(DeviceServiceServer).GetStatus(ctx, req.(*Empty))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _DeviceService_GetDeviceStatus_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(DeviceRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(DeviceServiceServer).GetDeviceStatus(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: DeviceService_GetDeviceStatus_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(DeviceServiceServer).GetDeviceStatus(ctx, req.(*DeviceRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -286,6 +320,10 @@ var DeviceService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "GetStatus",
 			Handler:    _DeviceService_GetStatus_Handler,
+		},
+		{
+			MethodName: "GetDeviceStatus",
+			Handler:    _DeviceService_GetDeviceStatus_Handler,
 		},
 		{
 			MethodName: "ListDiscoveredDevices",

--- a/eebus-bridge/internal/eebus/registry.go
+++ b/eebus-bridge/internal/eebus/registry.go
@@ -52,6 +52,7 @@ type DeviceRegistry struct {
 type deviceMonitoringState struct {
 	connected                  bool
 	connectedAt                time.Time
+	lastTransitionAt           time.Time
 	lastMonitoringSuccess      time.Time
 	monitoringSuccessOnConnect bool
 }
@@ -95,8 +96,10 @@ func (r *DeviceRegistry) MarkConnected(ski string) {
 	if state.connected {
 		return
 	}
+	now := r.clock.Now()
 	state.connected = true
-	state.connectedAt = r.clock.Now()
+	state.connectedAt = now
+	state.lastTransitionAt = now
 	state.monitoringSuccessOnConnect = false
 	r.monitoring[ski] = state
 }
@@ -109,11 +112,26 @@ func (r *DeviceRegistry) MarkDisconnected(ski string) {
 
 	ski = NormalizeSKI(ski)
 	state, ok := r.monitoring[ski]
-	if !ok {
+	if !ok || !state.connected {
 		return
 	}
 	state.connected = false
+	state.lastTransitionAt = r.clock.Now()
 	r.monitoring[ski] = state
+}
+
+// DeviceConnection returns the current connection state and the time it last
+// changed. A device with no monitoring state is unknown and reads as
+// disconnected.
+func (r *DeviceRegistry) DeviceConnection(ski string) (connected bool, lastTransition time.Time, known bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	state, ok := r.monitoring[NormalizeSKI(ski)]
+	if !ok {
+		return false, time.Time{}, false
+	}
+	return state.connected, state.lastTransitionAt, true
 }
 
 // RecordMonitoringSuccess marks that a remote entity was just successfully

--- a/eebus-bridge/internal/eebus/registry_test.go
+++ b/eebus-bridge/internal/eebus/registry_test.go
@@ -214,6 +214,59 @@ func TestRegistryEntityHelpersEmpty(t *testing.T) {
 	}
 }
 
+func TestDeviceConnectionTracksRealTransitionsOnly(t *testing.T) {
+	connectedAt := time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)
+	clock := &fakeClock{now: connectedAt}
+	reg := eebus.NewDeviceRegistryWithClock(clock)
+
+	if connected, transition, known := reg.DeviceConnection("unknown"); connected || !transition.IsZero() || known {
+		t.Fatalf("DeviceConnection(unknown) = (%t, %s, %t), want (false, zero, false)", connected, transition, known)
+	}
+	reg.MarkDisconnected("unknown")
+	if _, _, known := reg.DeviceConnection("unknown"); known {
+		t.Fatal("MarkDisconnected created monitoring state for an unknown SKI")
+	}
+
+	reg.MarkConnected("ab:cd-ef")
+	connected, transition, known := reg.DeviceConnection("AB-CD-EF")
+	if !connected || transition != connectedAt || !known {
+		t.Fatalf("DeviceConnection(connected) = (%t, %s, %t), want (true, %s, true)", connected, transition, known, connectedAt)
+	}
+
+	clock.Advance(time.Minute)
+	reg.MarkConnected("a b c d e f")
+	_, transition, _ = reg.DeviceConnection("ABCDEF")
+	if transition != connectedAt {
+		t.Errorf("redundant MarkConnected changed transition to %s, want %s", transition, connectedAt)
+	}
+
+	disconnectedAt := clock.now.Add(time.Minute)
+	clock.Advance(time.Minute)
+	reg.MarkDisconnected("ABCDEF")
+	connected, transition, known = reg.DeviceConnection("ab:cd:ef")
+	if connected || transition != disconnectedAt || !known {
+		t.Fatalf("DeviceConnection(disconnected) = (%t, %s, %t), want (false, %s, true)", connected, transition, known, disconnectedAt)
+	}
+
+	clock.Advance(time.Minute)
+	reg.MarkDisconnected("ABCDEF")
+	_, transition, _ = reg.DeviceConnection("ABCDEF")
+	if transition != disconnectedAt {
+		t.Errorf("redundant MarkDisconnected changed transition to %s, want %s", transition, disconnectedAt)
+	}
+}
+
+func TestDeviceConnectionUnknownAfterDeviceRemoval(t *testing.T) {
+	reg := eebus.NewDeviceRegistry()
+	reg.MarkConnected("ski-1")
+	reg.RemoveDevice("ski-1")
+
+	connected, transition, known := reg.DeviceConnection("ski-1")
+	if connected || !transition.IsZero() || known {
+		t.Errorf("DeviceConnection(removed) = (%t, %s, %t), want (false, zero, false)", connected, transition, known)
+	}
+}
+
 func TestStaleDevicesNoConnectedDevice(t *testing.T) {
 	clock := &fakeClock{now: time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)}
 	reg := eebus.NewDeviceRegistryWithClock(clock)

--- a/eebus-bridge/internal/grpc/device_service.go
+++ b/eebus-bridge/internal/grpc/device_service.go
@@ -8,6 +8,7 @@ import (
 	"github.com/volschin/eebus-bridge/internal/eebus"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 type TrustController interface {
@@ -39,6 +40,20 @@ func (s *DeviceService) GetStatus(_ context.Context, _ *pb.Empty) (*pb.ServiceSt
 		Running:  true,
 		LocalSki: s.localSKI,
 	}, nil
+}
+
+func (s *DeviceService) GetDeviceStatus(_ context.Context, req *pb.DeviceRequest) (*pb.DeviceStatus, error) {
+	ski := eebus.NormalizeSKI(req.Ski)
+	if !validSKI(ski) {
+		return nil, status.Errorf(codes.InvalidArgument, "ski must be 40 hex characters, got %q", req.Ski)
+	}
+
+	connected, lastTransition, known := s.registry.DeviceConnection(ski)
+	result := &pb.DeviceStatus{Connected: connected}
+	if known && !lastTransition.IsZero() {
+		result.LastTransition = timestamppb.New(lastTransition)
+	}
+	return result, nil
 }
 
 func (s *DeviceService) ListDiscoveredDevices(_ context.Context, _ *pb.Empty) (*pb.ListDevicesResponse, error) {

--- a/eebus-bridge/internal/grpc/device_service_test.go
+++ b/eebus-bridge/internal/grpc/device_service_test.go
@@ -72,6 +72,64 @@ func TestGetStatus(t *testing.T) {
 	}
 }
 
+func TestGetDeviceStatus(t *testing.T) {
+	bus := eebus.NewEventBus()
+	registry := eebus.NewDeviceRegistry()
+	svc := bridgegrpc.NewDeviceService(
+		eebus.NewCallbacks(bus, false),
+		bus,
+		"test-local-ski",
+		registry,
+		&recordingTrustController{},
+	)
+
+	registry.MarkConnected(testValidSKI)
+	connected, err := svc.GetDeviceStatus(context.Background(), &pb.DeviceRequest{Ski: testValidSKI})
+	if err != nil {
+		t.Fatalf("GetDeviceStatus(connected): %v", err)
+	}
+	if !connected.Connected || connected.LastTransition == nil {
+		t.Errorf("GetDeviceStatus(connected) = %+v, want connected with transition timestamp", connected)
+	}
+
+	registry.MarkDisconnected(testValidSKI)
+	disconnected, err := svc.GetDeviceStatus(context.Background(), &pb.DeviceRequest{Ski: testValidSKI})
+	if err != nil {
+		t.Fatalf("GetDeviceStatus(disconnected): %v", err)
+	}
+	if disconnected.Connected || disconnected.LastTransition == nil {
+		t.Errorf("GetDeviceStatus(disconnected) = %+v, want disconnected with transition timestamp", disconnected)
+	}
+
+	unknownSKI := "782f708ceba5df9adcb9e6787ea911d9fc3ac490"
+	unknown, err := svc.GetDeviceStatus(context.Background(), &pb.DeviceRequest{Ski: unknownSKI})
+	if err != nil {
+		t.Fatalf("GetDeviceStatus(unknown): %v", err)
+	}
+	if unknown.Connected || unknown.LastTransition != nil {
+		t.Errorf("GetDeviceStatus(unknown) = %+v, want disconnected without transition timestamp", unknown)
+	}
+}
+
+func TestGetDeviceStatusRejectsMalformedSKI(t *testing.T) {
+	bus := eebus.NewEventBus()
+	svc := bridgegrpc.NewDeviceService(
+		eebus.NewCallbacks(bus, false),
+		bus,
+		"test-local-ski",
+		eebus.NewDeviceRegistry(),
+		&recordingTrustController{},
+	)
+
+	response, err := svc.GetDeviceStatus(context.Background(), &pb.DeviceRequest{Ski: "not-a-ski"})
+	if response != nil {
+		t.Errorf("GetDeviceStatus(malformed) response = %+v, want nil", response)
+	}
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("GetDeviceStatus(malformed) code = %v, want InvalidArgument", status.Code(err))
+	}
+}
+
 func TestListDevicesResponsesAreSortedByNormalizedSKI(t *testing.T) {
 	bus := eebus.NewEventBus()
 	callbacks := eebus.NewCallbacks(bus, false)

--- a/eebus-bridge/proto/eebus/v1/device_service.proto
+++ b/eebus-bridge/proto/eebus/v1/device_service.proto
@@ -5,9 +5,11 @@ package eebus.v1;
 option go_package = "github.com/volschin/eebus-bridge/gen/proto/eebus/v1;eebusv1";
 
 import "eebus/v1/common.proto";
+import "google/protobuf/timestamp.proto";
 
 service DeviceService {
   rpc GetStatus(Empty) returns (ServiceStatus);
+  rpc GetDeviceStatus(DeviceRequest) returns (DeviceStatus);
   rpc ListDiscoveredDevices(Empty) returns (ListDevicesResponse);
   rpc RegisterRemoteSKI(RegisterSKIRequest) returns (Empty);
   rpc UnregisterRemoteSKI(RegisterSKIRequest) returns (Empty);
@@ -18,6 +20,11 @@ service DeviceService {
 message ServiceStatus {
   bool running = 1;
   string local_ski = 2;
+}
+
+message DeviceStatus {
+  bool connected = 1;
+  google.protobuf.Timestamp last_transition = 2;
 }
 
 message DiscoveredDevice {


### PR DESCRIPTION
## Summary
- New `GetDeviceStatus(DeviceRequest) returns (DeviceStatus{connected, last_transition})` RPC, distinct from the existing bridge-level `GetStatus`.
- Backed by the `DeviceRegistry`'s per-SKI connected state (already tracked correctly by the RF-06 watchdog's `MarkConnected`/`MarkDisconnected`, just never exposed over gRPC). Registry now also tracks a last-transition timestamp, updated only on real state changes (not redundant Mark calls).
- `snapshot.py` sources `CoordinatorSnapshot.connected` from this new RPC instead of `GetStatus.running` (which is always `true` whenever the bridge process is reachable — the actual bug: a device disconnect already triggered a reconciliation poll via `SubscribeDeviceEvents`, but that poll re-read the wrong signal and reported `connected=True` again).
- `EebusEntity.available` now requires both a successful coordinator poll and this device-level connected state — every platform entity (climate, sensor, number, switch, select, water_heater) goes unavailable on a real disconnect, not just the connectivity `binary_sensor`. No platform file needed to change since each already chains through `super().available`.
- `device_ready` (spec's third tier) deliberately **not** implemented — deferred to SPEC2-06 (per-use-case capability state machine), which is the correct home for it.

Implements SPEC2-01 from `docs/refactoring-optimization-spec-v2.md`.

## Test plan
- [x] `go vet ./...`
- [x] `make test` (`-race`) — all packages green
- [x] Proto regenerated both sides (`make proto`, `generate_proto.sh`) — reproducible, zero further drift on re-run
- [x] `ruff check custom_components/`
- [x] `mypy custom_components/eebus` (strict) — clean
- [x] `PYTHONPATH=. pytest` — 140 passed, including a regression test proving a `DEVICE_EVENT_DISCONNECTED` event now resolves to `connected: False` (the exact bug being fixed) and new `EebusEntity.available` coverage
- [x] Manually confirmed `MarkDisconnected` runs before `bus.Publish` in `callbacks.go`, so no race between the registry write and the Python-side event handler