### PR TITLE
SPEC2-07 slice 1: consume OHPCF event stream

### DIFF
--- a/custom_components/eebus/coordinator.py
+++ b/custom_components/eebus/coordinator.py
@@ -23,6 +23,7 @@ from .grpc_client import (
     is_unimplemented as _is_unimplemented,
 )
 from .models import (
+    CompressorFlexibilityState,
     CoordinatorSnapshot,
     _dhw_system_function_to_dict,
     _setpoint_to_dict,
@@ -478,6 +479,15 @@ class EebusCoordinator(DataUpdateCoordinator[CoordinatorSnapshot]):
             ):
                 self._handle_measurement_event(event)
 
+        async def consume_ohpcf(channel: grpc.aio.Channel) -> None:
+            from . import proto_stubs
+
+            stub = proto_stubs.ohpcf_service_stub(channel)
+            async for event in stub.SubscribeOHPCFEvents(
+                proto_stubs.DeviceRequest(ski=self.ski)
+            ):
+                self._handle_ohpcf_event(event)
+
         async def consume_dhw(channel: grpc.aio.Channel) -> None:
             from . import proto_stubs
 
@@ -509,6 +519,7 @@ class EebusCoordinator(DataUpdateCoordinator[CoordinatorSnapshot]):
             "device_events": consume,
             "lpc_events": consume_lpc,
             "measurements": consume_measurements,
+            "ohpcf_events": consume_ohpcf,
             "dhw_events": consume_dhw,
             "dhw_sysfn_events": consume_dhw_sysfn,
             "room_heating_events": consume_room_heating,
@@ -598,6 +609,58 @@ class EebusCoordinator(DataUpdateCoordinator[CoordinatorSnapshot]):
             self._push_domain_fields("failsafe_limit", "failsafe_supported")
         elif event_type == proto_stubs.LPCEventType.LPC_EVENT_HEARTBEAT_TIMEOUT:
             self.hass.async_create_task(self.async_request_refresh())
+
+    def _handle_ohpcf_event(self, event: Any) -> None:
+        from . import proto_stubs
+
+        if not self._event_matches(event.ski):
+            return
+        event_type = event.event_type
+        if event_type == proto_stubs.OHPCFEventType.OHPCF_EVENT_SUPPORT_UPDATED:
+            self.hass.async_create_task(self.async_request_refresh())
+            return
+        if event_type not in (
+            proto_stubs.OHPCFEventType.OHPCF_EVENT_STATE_UPDATED,
+            proto_stubs.OHPCFEventType.OHPCF_EVENT_DATA_UPDATED,
+        ):
+            return
+        if not event.HasField("flexibility"):
+            # Bridge signalled a change but sent no payload; reconcile via poll.
+            self.hass.async_create_task(self.async_request_refresh())
+            return
+        flexibility = event.flexibility
+        value: CompressorFlexibilityState = {
+            "available": flexibility.available,
+            "state": proto_stubs.CompressorPowerConsumptionState.Name(
+                flexibility.state
+            ),
+            "requested_power_estimate_w": (
+                flexibility.requested_power_estimate_w
+                if flexibility.HasField("requested_power_estimate_w")
+                else None
+            ),
+            "requested_power_max_w": (
+                flexibility.requested_power_max_w
+                if flexibility.HasField("requested_power_max_w")
+                else None
+            ),
+            "is_pausable": flexibility.is_pausable,
+            "is_stoppable": flexibility.is_stoppable,
+            "minimal_run_seconds": flexibility.minimal_run_seconds,
+            "minimal_pause_seconds": flexibility.minimal_pause_seconds,
+        }
+        ohpcf, capabilities = apply_reading(
+            self._domain_state.ohpcf,
+            "compressor_flexibility",
+            value,
+            self._domain_state.capabilities,
+            "ohpcf",
+            None,
+        )
+        self._domain_state = replace(
+            self._domain_state, ohpcf=ohpcf, capabilities=capabilities
+        )
+        self._push_domain_fields("compressor_flexibility", "ohpcf_supported")
 
     def _handle_measurement_event(self, event: Any) -> None:
         if not self._event_matches(event.ski):

--- a/custom_components/eebus/tests/test_coordinator.py
+++ b/custom_components/eebus/tests/test_coordinator.py
@@ -27,6 +27,7 @@ from custom_components.eebus.generated.eebus.v1 import (
     hvac_service_pb2,
     lpc_service_pb2,
     monitoring_service_pb2,
+    ohpcf_service_pb2,
 )
 
 
@@ -319,7 +320,7 @@ async def test_ensure_channel_delegates_to_channel_manager():
 
 
 def test_start_streams_delegates_all_consumers_to_stream_manager():
-    """The coordinator supplies all six event consumers to StreamManager."""
+    """The coordinator supplies all seven event consumers to StreamManager."""
     coordinator = EebusCoordinator.__new__(EebusCoordinator)
     coordinator.ski = "test-ski"
     coordinator._stream_manager = MagicMock()
@@ -332,6 +333,7 @@ def test_start_streams_delegates_all_consumers_to_stream_manager():
         "device_events",
         "lpc_events",
         "measurements",
+        "ohpcf_events",
         "dhw_events",
         "dhw_sysfn_events",
         "room_heating_events",
@@ -548,6 +550,62 @@ def test_lpc_limit_event_without_payload_refreshes():
     )
     coordinator._handle_lpc_event(event)
     assert not pushed  # no zeroing push
+    coordinator.hass.async_create_task.assert_called_once()
+
+
+def test_ohpcf_state_event_pushes_compressor_flexibility():
+    """OHPCF state events update compressor flexibility without polling."""
+    coordinator, pushed = _make_coordinator(data={"compressor_flexibility": None})
+    coordinator.hass = MagicMock()
+    coordinator.async_request_refresh = MagicMock(return_value=None)
+    event = ohpcf_service_pb2.OHPCFEvent(
+        ski="test-ski",
+        event_type=ohpcf_service_pb2.OHPCF_EVENT_STATE_UPDATED,
+        flexibility=ohpcf_service_pb2.CompressorFlexibility(
+            available=True,
+            requested_power_estimate_w=1500.0,
+            is_pausable=True,
+            is_stoppable=False,
+            state=ohpcf_service_pb2.COMPRESSOR_STATE_RUNNING,
+            minimal_run_seconds=600,
+            minimal_pause_seconds=120,
+        ),
+    )
+
+    coordinator._handle_ohpcf_event(event)
+
+    assert pushed["compressor_flexibility"] == {
+        "available": True,
+        "state": "COMPRESSOR_STATE_RUNNING",
+        "requested_power_estimate_w": 1500.0,
+        "requested_power_max_w": None,
+        "is_pausable": True,
+        "is_stoppable": False,
+        "minimal_run_seconds": 600,
+        "minimal_pause_seconds": 120,
+    }
+    assert pushed["ohpcf_supported"] == CapabilityState.AVAILABLE
+    coordinator.hass.async_create_task.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "event_type",
+    [
+        ohpcf_service_pb2.OHPCF_EVENT_SUPPORT_UPDATED,
+        ohpcf_service_pb2.OHPCF_EVENT_STATE_UPDATED,
+        ohpcf_service_pb2.OHPCF_EVENT_DATA_UPDATED,
+    ],
+)
+def test_ohpcf_event_without_payload_refreshes(event_type):
+    """OHPCF support or payload-free data changes reconcile through polling."""
+    coordinator, pushed = _make_coordinator(data={"compressor_flexibility": None})
+    coordinator.hass = MagicMock()
+    coordinator.async_request_refresh = MagicMock(return_value=None)
+    event = ohpcf_service_pb2.OHPCFEvent(ski="test-ski", event_type=event_type)
+
+    coordinator._handle_ohpcf_event(event)
+
+    assert not pushed
     coordinator.hass.async_create_task.assert_called_once()
 
 

--- a/docs/spec2-07-ohpcf-stream-consume.md
+++ b/docs/spec2-07-ohpcf-stream-consume.md
@@ -1,0 +1,90 @@
+# SPEC2-07 Slice 1 — consume the OHPCF event stream
+
+Source: `docs/refactoring-optimization-spec-v2.md` SPEC2-07 (P1). This slice covers the
+first bullet of its Ist-Befund only — full revision/gap-counter machinery (later
+bullets) is a separate follow-up slice, same incremental pattern as SPEC2-08.
+
+## Problem
+
+The bridge implements `OHPCFService.SubscribeOHPCFEvents` (streams `OHPCFEvent`,
+see `eebus-bridge/proto/eebus/v1/ohpcf_service.proto`), but
+`EebusCoordinator.async_start_streams` (`custom_components/eebus/coordinator.py`)
+never starts it. External OHPCF state changes (compressor offer appears, process
+gets scheduled/paused/resumed by another CEM, etc.) are invisible in HA until the
+next 5-minute poll.
+
+Every other push-capable use case (LPC, DHW, DHW-sysfn, room-heating, measurements)
+already has this wiring. OHPCF is the one gap.
+
+## What to build
+
+Add OHPCF stream consumption in `custom_components/eebus/coordinator.py`, mirroring
+the existing `consume_dhw` / `_handle_dhw_event` pair exactly (see
+`async_start_streams` and `_handle_dhw_event` as the reference implementation):
+
+1. `consume_ohpcf(channel)` — subscribes via
+   `proto_stubs.ohpcf_service_stub(channel).SubscribeOHPCFEvents(DeviceRequest(ski=self.ski))`,
+   dispatches each event to a new `_handle_ohpcf_event(event)`. Register it in the
+   `streams` dict passed to `self._stream_manager.start(...)` under key
+   `"ohpcf_events"`.
+
+2. `_handle_ohpcf_event(event)`:
+   - Skip if `not self._event_matches(event.ski)`.
+   - `OHPCF_EVENT_SUPPORT_UPDATED` → no reliable payload semantics, reconcile via
+     `self.hass.async_create_task(self.async_request_refresh())` (same as the
+     `LPC_EVENT_HEARTBEAT_TIMEOUT` / measurement "support" branch).
+   - `OHPCF_EVENT_STATE_UPDATED` and `OHPCF_EVENT_DATA_UPDATED` → both carry the
+     current `flexibility` payload (`CompressorFlexibility`, proto3 message field,
+     so `event.HasField("flexibility")` is valid). If unset, reconcile via poll
+     (same "signalled without payload" fallback used everywhere else). If set,
+     build a `CompressorFlexibilityState` dict with the same field mapping
+     `_async_read_compressor_flexibility` uses in `snapshot.py` (`available`,
+     `state` via `CompressorPowerConsumptionState.Name(...)`,
+     `requested_power_estimate_w`/`requested_power_max_w` via `HasField` on the
+     optional scalar fields, `is_pausable`, `is_stoppable`,
+     `minimal_run_seconds`, `minimal_pause_seconds`), then route it through the
+     shared reducer:
+     ```python
+     ohpcf, capabilities = apply_reading(
+         self._domain_state.ohpcf,
+         "compressor_flexibility",
+         value,
+         self._domain_state.capabilities,
+         "ohpcf",
+         None,
+     )
+     self._domain_state = replace(self._domain_state, ohpcf=ohpcf, capabilities=capabilities)
+     self._push_domain_fields("compressor_flexibility", "ohpcf_supported")
+     ```
+   - Any other/unknown event type: ignore.
+
+3. If the bridge doesn't implement the RPC (older bridge version), the existing
+   `StreamManager._run_stream` UNIMPLEMENTED handling already degrades to
+   polling-only for that one stream — no special-casing needed here.
+
+## Out of scope for this slice
+
+- Monotone per-SKI stream revisions and coalesced gap-reconcile (SPEC2-07 Soll
+  bullets 2–3).
+- Go eventbus per-subscriber/per-stream-family drop counters (bullet 4).
+- Cross-stream/poll "newer wins" ordering guarantee via a single publish point
+  (bullet 5) — today's pattern (last write wins via `_push_domain_fields`) is
+  unchanged, consistent with how LPC/DHW/room-heating already behave.
+- Backoff/last-received/last-error/reconnect-count observability (bullet 6).
+
+## Acceptance
+
+- New/updated unit test(s) in `custom_components/eebus/tests/test_coordinator.py`
+  (or `test_ohpcf.py`) proving: a `OHPCF_EVENT_STATE_UPDATED` event with a
+  `flexibility` payload updates `compressor_flexibility` in the coordinator
+  snapshot without a poll; a `OHPCF_EVENT_SUPPORT_UPDATED` event or a
+  state/data event with no payload triggers `async_request_refresh`.
+- `ohpcf_events` appears in `async_start_streams`'s `streams` dict.
+- No changes to `eebus-bridge/` (Go side already implements the RPC).
+- No changes to `models.py` or any platform file — same flatten shape as today.
+
+## Verification
+
+- `ruff check custom_components/`
+- `mypy custom_components/eebus`
+- `PYTHONPATH=. pytest`


### PR DESCRIPTION
## Summary
- Bridge implements `OHPCFService.SubscribeOHPCFEvents`; HA never started it, so external OHPCF changes (offer appears, scheduled/paused/resumed by another CEM) stayed invisible until the next 5-minute poll — the one push-capable use case missing this wiring.
- Adds `consume_ohpcf`/`_handle_ohpcf_event` to `coordinator.py`, mirroring the existing DHW handler exactly: `STATE_UPDATED`/`DATA_UPDATED` with a payload route through the shared `StateReducer` (`apply_reading`) same as the poll path; `SUPPORT_UPDATED` or a payload-free state/data event falls back to a poll reconcile.
- Scope is slice 1 of SPEC2-07 (docs/spec2-07-ohpcf-stream-consume.md) — monotone per-SKI revisions, Go eventbus drop counters, and stream/poll ordering guarantees are follow-up slices, same incremental pattern as SPEC2-08.

Implemented via Codex delegation; independently verified (diff review, tests, lint/type checks).

## Test plan
- [x] `ruff check custom_components/` — pass
- [x] `mypy custom_components/eebus` — pass
- [x] `PYTHONPATH=. pytest` — 168 passed (incl. new OHPCF stream tests: payload push, no-payload-refresh for all 3 event types)
- [x] No changes to `eebus-bridge/`, `models.py`, or any platform file