### PR TITLE
SPEC2-09 slice 1: reject NaN/Inf in LPC numeric writes

### DIFF
--- a/docs/spec2-09-lpc-numeric-validation.md
+++ b/docs/spec2-09-lpc-numeric-validation.md
@@ -1,0 +1,69 @@
+# SPEC2-09 Slice 1 — reject NaN/Inf in LPC numeric writes
+
+Source: `docs/refactoring-optimization-spec-v2.md` SPEC2-09 (P1). This slice covers
+only the first Abnahme bullet: `NaN/Inf werden in allen numerischen Write- und
+Publish-RPCs als INVALID_ARGUMENT abgewiesen.` The remaining Soll bullets (central
+error-mapping policy adoption elsewhere, unified entity-resolution flow, uniform
+stream validation, deadline propagation) are separate follow-up slices — see
+"Deliberately out of scope" below for why they don't belong in this slice.
+
+## Problem
+
+`eebus-bridge/internal/grpc/errors.go` already has `finite`/`nonNegative`/`percent`
+helpers, and `grid_service.go`/`visualization_service.go` (provider push RPCs)
+already use them. But `lpc_service.go`'s four numeric write RPCs never adopted
+them — they still use a raw `req.ValueWatts < 0` / `req.DurationSeconds < 0`
+comparison. In Go, `NaN < 0` is `false`, so a NaN payload sails past this check,
+gets forwarded into `s.lpc.WriteConsumptionLimit`/`WriteFailsafeConsumptionActivePowerLimit`,
+and is serialized into a spine-go scaled number advertised to the heat pump as a
+real load-limit reading — silent bad data, exactly the failure mode `finite`'s doc
+comment in errors.go already describes for the provider RPCs.
+
+Affected in `eebus-bridge/internal/grpc/lpc_service.go`:
+- `WriteConsumptionLimit`: `req.ValueWatts < 0` (line 52), `req.DurationSeconds < 0` (line 55)
+- `WriteFailsafeLimit`: `req.ValueWatts < 0` (line 108), `req.DurationMinimumSeconds < 0` (line 111)
+
+(Line numbers from the current `main` tip; re-check before editing.)
+
+## What to build
+
+Replace each of the four raw `< 0` comparisons with a call to the existing
+`nonNegative(name, v)` helper from `errors.go` (same helper `grid_service.go`
+already uses), converting `int64` duration fields to `float64` for the check
+(`nonNegative("duration_seconds", float64(req.DurationSeconds))`). Keep the
+field names in error messages consistent with the current ones (`value_watts`,
+`duration_seconds`, `duration_minimum_seconds`) so behavior for legitimately
+negative input is unchanged — only NaN/Inf becomes newly rejected.
+
+Do not touch the SKI/nil/init checks in these four methods, and don't restructure
+the methods otherwise — this is a single-line-per-check swap.
+
+## Deliberately out of scope
+
+- **Error-policy migration for LPC/OHPCF/monitoring/device services** (Soll
+  bullet 2, `mapUsecaseError`): DHW and HVAC already adopted this because
+  `internal/usecases/dhw.go`/`hvac.go` define their own sentinel errors
+  (`ErrDHWOutOfRange`, etc.) to classify. LPC/OHPCF/monitoring's use-case calls
+  return raw errors straight from the vendored `enbility/eebus-go` library with
+  no sentinel taxonomy of our own — `codes.Internal` is the honest mapping today,
+  not a shortcut. Introducing sentinels there is real design work (what error
+  classes does eebus-go actually surface?), not a mechanical migration — separate
+  slice.
+- Shared range/enum/timestamp boundary helpers, unified entity-resolution flow,
+  uniform stream validation, context/deadline propagation into the use-case layer
+  (remaining Soll bullets) — each is its own slice.
+
+## Acceptance
+
+- Table-driven test in `eebus-bridge/internal/grpc/lpc_service_test.go` proving
+  `WriteConsumptionLimit` and `WriteFailsafeLimit` reject `math.NaN()`,
+  `math.Inf(1)`, and `math.Inf(-1)` for both `ValueWatts` and the duration field
+  with `codes.InvalidArgument`, while legitimate non-negative values still pass
+  (regression check against the existing negative-value tests, if any).
+- No other file changes; no Python-side changes.
+
+## Verification
+
+- `go vet ./...`
+- `go test -race ./internal/grpc/...` (full `make test` optional but not required
+  for this narrowly-scoped change)

--- a/eebus-bridge/internal/grpc/lpc_service.go
+++ b/eebus-bridge/internal/grpc/lpc_service.go
@@ -49,11 +49,11 @@ func (s *LPCService) WriteConsumptionLimit(_ context.Context, req *pb.WriteLoadL
 	if req.Ski == "" {
 		return nil, status.Error(codes.InvalidArgument, "ski is required for write operations")
 	}
-	if req.ValueWatts < 0 {
-		return nil, status.Error(codes.InvalidArgument, "value_watts must be non-negative")
+	if err := nonNegative("value_watts", req.ValueWatts); err != nil {
+		return nil, err
 	}
-	if req.DurationSeconds < 0 {
-		return nil, status.Error(codes.InvalidArgument, "duration_seconds must be non-negative")
+	if err := nonNegative("duration_seconds", float64(req.DurationSeconds)); err != nil {
+		return nil, err
 	}
 	if s.lpc == nil {
 		return nil, status.Error(codes.Unavailable, "LPC use case not initialized")
@@ -106,11 +106,11 @@ func (s *LPCService) WriteFailsafeLimit(_ context.Context, req *pb.WriteFailsafe
 	if req.Ski == "" {
 		return nil, status.Error(codes.InvalidArgument, "ski is required for write operations")
 	}
-	if req.ValueWatts < 0 {
-		return nil, status.Error(codes.InvalidArgument, "value_watts must be non-negative")
+	if err := nonNegative("value_watts", req.ValueWatts); err != nil {
+		return nil, err
 	}
-	if req.DurationMinimumSeconds < 0 {
-		return nil, status.Error(codes.InvalidArgument, "duration_minimum_seconds must be non-negative")
+	if err := nonNegative("duration_minimum_seconds", float64(req.DurationMinimumSeconds)); err != nil {
+		return nil, err
 	}
 	if s.lpc == nil {
 		return nil, status.Error(codes.Unavailable, "LPC use case not initialized")

--- a/eebus-bridge/internal/grpc/lpc_service_test.go
+++ b/eebus-bridge/internal/grpc/lpc_service_test.go
@@ -2,6 +2,7 @@ package grpc_test
 
 import (
 	"context"
+	"math"
 	"testing"
 	"time"
 
@@ -9,8 +10,126 @@ import (
 	"github.com/volschin/eebus-bridge/internal/eebus"
 	bridgegrpc "github.com/volschin/eebus-bridge/internal/grpc"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
 )
+
+func TestLPCNumericWriteValidation(t *testing.T) {
+	svc := bridgegrpc.NewLPCService(nil, eebus.NewEventBus(), eebus.NewDeviceRegistry())
+	ctx := context.Background()
+
+	tests := []struct {
+		name     string
+		write    func() error
+		wantCode codes.Code
+	}{
+		{
+			name: "consumption limit NaN watts",
+			write: func() error {
+				_, err := svc.WriteConsumptionLimit(ctx, &pb.WriteLoadLimitRequest{Ski: "test-ski", ValueWatts: math.NaN()})
+				return err
+			},
+			wantCode: codes.InvalidArgument,
+		},
+		{
+			name: "consumption limit positive infinity watts",
+			write: func() error {
+				_, err := svc.WriteConsumptionLimit(ctx, &pb.WriteLoadLimitRequest{Ski: "test-ski", ValueWatts: math.Inf(1)})
+				return err
+			},
+			wantCode: codes.InvalidArgument,
+		},
+		{
+			name: "consumption limit negative infinity watts",
+			write: func() error {
+				_, err := svc.WriteConsumptionLimit(ctx, &pb.WriteLoadLimitRequest{Ski: "test-ski", ValueWatts: math.Inf(-1)})
+				return err
+			},
+			wantCode: codes.InvalidArgument,
+		},
+		{
+			name: "consumption limit negative watts",
+			write: func() error {
+				_, err := svc.WriteConsumptionLimit(ctx, &pb.WriteLoadLimitRequest{Ski: "test-ski", ValueWatts: -1})
+				return err
+			},
+			wantCode: codes.InvalidArgument,
+		},
+		{
+			name: "consumption limit negative duration",
+			write: func() error {
+				_, err := svc.WriteConsumptionLimit(ctx, &pb.WriteLoadLimitRequest{Ski: "test-ski", DurationSeconds: -1})
+				return err
+			},
+			wantCode: codes.InvalidArgument,
+		},
+		{
+			name: "consumption limit non-negative values",
+			write: func() error {
+				_, err := svc.WriteConsumptionLimit(ctx, &pb.WriteLoadLimitRequest{Ski: "test-ski", ValueWatts: 1, DurationSeconds: 1})
+				return err
+			},
+			wantCode: codes.Unavailable,
+		},
+		{
+			name: "failsafe limit NaN watts",
+			write: func() error {
+				_, err := svc.WriteFailsafeLimit(ctx, &pb.WriteFailsafeLimitRequest{Ski: "test-ski", ValueWatts: math.NaN()})
+				return err
+			},
+			wantCode: codes.InvalidArgument,
+		},
+		{
+			name: "failsafe limit positive infinity watts",
+			write: func() error {
+				_, err := svc.WriteFailsafeLimit(ctx, &pb.WriteFailsafeLimitRequest{Ski: "test-ski", ValueWatts: math.Inf(1)})
+				return err
+			},
+			wantCode: codes.InvalidArgument,
+		},
+		{
+			name: "failsafe limit negative infinity watts",
+			write: func() error {
+				_, err := svc.WriteFailsafeLimit(ctx, &pb.WriteFailsafeLimitRequest{Ski: "test-ski", ValueWatts: math.Inf(-1)})
+				return err
+			},
+			wantCode: codes.InvalidArgument,
+		},
+		{
+			name: "failsafe limit negative watts",
+			write: func() error {
+				_, err := svc.WriteFailsafeLimit(ctx, &pb.WriteFailsafeLimitRequest{Ski: "test-ski", ValueWatts: -1})
+				return err
+			},
+			wantCode: codes.InvalidArgument,
+		},
+		{
+			name: "failsafe limit negative duration",
+			write: func() error {
+				_, err := svc.WriteFailsafeLimit(ctx, &pb.WriteFailsafeLimitRequest{Ski: "test-ski", DurationMinimumSeconds: -1})
+				return err
+			},
+			wantCode: codes.InvalidArgument,
+		},
+		{
+			name: "failsafe limit non-negative values",
+			write: func() error {
+				_, err := svc.WriteFailsafeLimit(ctx, &pb.WriteFailsafeLimitRequest{Ski: "test-ski", ValueWatts: 1, DurationMinimumSeconds: 1})
+				return err
+			},
+			wantCode: codes.Unavailable,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.write(); status.Code(err) != tt.wantCode {
+				t.Fatalf("status code = %v, want %v (error: %v)", status.Code(err), tt.wantCode, err)
+			}
+		})
+	}
+}
 
 func TestSubscribeLPCEvents(t *testing.T) {
 	bus := eebus.NewEventBus()


### PR DESCRIPTION
## Summary
- `WriteConsumptionLimit`/`WriteFailsafeLimit` validated numeric fields with a raw `< 0` comparison; `NaN < 0` is `false` in Go, so a NaN payload passed straight through to eebus-go and would be serialized into a spine-go scaled number advertised to the heat pump as a real load-limit reading — silent bad data.
- Swaps all four checks to the existing `nonNegative` helper (`errors.go`), the same one `grid_service.go`/`visualization_service.go` already use for provider push RPCs. Single-line-per-check swap, no other behavior change — legitimate negative-value rejection unchanged, only NaN/±Inf newly rejected.
- Scope is slice 1 of SPEC2-09 (docs/spec2-09-lpc-numeric-validation.md) — migrating LPC/OHPCF/monitoring/device to the shared `mapUsecaseError` policy is deliberately deferred: unlike DHW/HVAC, those use cases wrap raw `enbility/eebus-go` errors with no sentinel taxonomy of our own, so `codes.Internal` is the honest mapping today, not a shortcut. Range/enum/timestamp helpers, unified entity resolution, stream validation, and deadline propagation are further follow-up slices.

Implemented via Codex delegation; independently verified (diff review, go vet, go test -race).

## Test plan
- [x] `go vet ./...` — pass
- [x] `go test -race ./internal/grpc/...` — pass (new `TestLPCNumericWriteValidation` table test: NaN/±Inf/negative rejected with `InvalidArgument`, non-negative values pass through to the `Unavailable` initialization check)
- [x] No Python-side changes