### PR TITLE
fix: migrate device registry SKI identifier, fix heartbeat sensor availability

### DIFF
--- a/custom_components/eebus/__init__.py
+++ b/custom_components/eebus/__init__.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import entity_registry as er
 
 from .const import (
@@ -84,6 +85,10 @@ async def async_migrate_entry(
         hass.config_entries.async_update_entry(config_entry, version=2)
         return True
 
+    raw_ski = config_entry.data[CONF_DEVICE_SKI]
+    if raw_ski != canonical_ski:
+        _migrate_device_registry_identifier(hass, raw_ski, canonical_ski)
+
     data = {**config_entry.data, CONF_DEVICE_SKI: canonical_ski}
     hass.config_entries.async_update_entry(
         config_entry,
@@ -92,6 +97,24 @@ async def async_migrate_entry(
         version=2,
     )
     return True
+
+
+def _migrate_device_registry_identifier(
+    hass: HomeAssistant, raw_ski: str, canonical_ski: str
+) -> None:
+    """Rename a device registry entry's identifier from raw to canonical SKI.
+
+    EebusEntity keys device identifiers off the stored SKI. Without this, a
+    canonicalized config entry re-registers under a new identifier and HA
+    creates a second device, orphaning the original's area/history/automation
+    references instead of reusing it.
+    """
+    device_registry = dr.async_get(hass)
+    device = device_registry.async_get_device(identifiers={(DOMAIN, raw_ski)})
+    if device is not None:
+        device_registry.async_update_device(
+            device.id, new_identifiers={(DOMAIN, canonical_ski)}
+        )
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: EebusConfigEntry) -> bool:

--- a/custom_components/eebus/binary_sensor.py
+++ b/custom_components/eebus/binary_sensor.py
@@ -80,6 +80,16 @@ class EebusHeartbeatOkSensor(EebusEntity, BinarySensorEntity):
         self._attr_unique_id = f"{coordinator.ski}_heartbeat_ok"
 
     @property
+    def available(self) -> bool:
+        """Stay available on a successful poll regardless of connected state.
+
+        EebusEntity.available gates on device connection, which would flip
+        this sensor to "unavailable" (grey, no history) on every transient
+        per-device disconnect instead of a stable on/off a dashboard can plot.
+        """
+        return self.coordinator.last_update_success
+
+    @property
     def is_on(self) -> bool | None:
         """Return True if heartbeat has a problem (inverted for PROBLEM class)."""
         if self.coordinator.data is None:

--- a/custom_components/eebus/tests/test_binary_sensor.py
+++ b/custom_components/eebus/tests/test_binary_sensor.py
@@ -2,7 +2,10 @@
 
 from unittest.mock import MagicMock
 
-from custom_components.eebus.binary_sensor import EebusConnectedSensor
+from custom_components.eebus.binary_sensor import (
+    EebusConnectedSensor,
+    EebusHeartbeatOkSensor,
+)
 
 
 def _sensor(*, connected: bool | None, poll_ok: bool) -> EebusConnectedSensor:
@@ -11,6 +14,20 @@ def _sensor(*, connected: bool | None, poll_ok: bool) -> EebusConnectedSensor:
     coordinator.ski = "test-ski"
     coordinator.last_update_success = poll_ok
     return EebusConnectedSensor(coordinator)
+
+
+def _heartbeat_sensor(
+    *, within_duration: bool | None, poll_ok: bool
+) -> EebusHeartbeatOkSensor:
+    coordinator = MagicMock()
+    coordinator.data = {
+        "heartbeat_status": (
+            None if within_duration is None else {"within_duration": within_duration}
+        )
+    }
+    coordinator.ski = "test-ski"
+    coordinator.last_update_success = poll_ok
+    return EebusHeartbeatOkSensor(coordinator)
 
 
 def test_available_when_device_disconnected_but_poll_succeeded() -> None:
@@ -30,3 +47,14 @@ def test_is_on_true_when_connected() -> None:
 
 def test_is_on_none_when_no_data_yet() -> None:
     assert _sensor(connected=None, poll_ok=True).is_on is None
+
+
+def test_heartbeat_available_when_device_disconnected_but_poll_succeeded() -> None:
+    sensor = _heartbeat_sensor(within_duration=True, poll_ok=True)
+    assert sensor.available is True
+    assert sensor.is_on is False
+
+
+def test_heartbeat_unavailable_when_poll_failed() -> None:
+    sensor = _heartbeat_sensor(within_duration=True, poll_ok=False)
+    assert sensor.available is False

--- a/custom_components/eebus/tests/test_init.py
+++ b/custom_components/eebus/tests/test_init.py
@@ -155,13 +155,50 @@ async def test_migrate_entry_canonicalizes_data_and_unique_id():
     )
     hass.config_entries.async_entries.return_value = [entry]
 
-    assert await async_migrate_entry(hass, entry)
+    with patch("custom_components.eebus.dr.async_get") as async_get_device_registry:
+        device_registry = MagicMock()
+        async_get_device_registry.return_value = device_registry
+
+        assert await async_migrate_entry(hass, entry)
+
+        device_registry.async_get_device.assert_called_once_with(
+            identifiers={("eebus", raw)}
+        )
+        device_registry.async_update_device.assert_called_once_with(
+            device_registry.async_get_device.return_value.id,
+            new_identifiers={("eebus", canonical)},
+        )
     hass.config_entries.async_update_entry.assert_called_once_with(
         entry,
         data={CONF_DEVICE_SKI: canonical, "grpc_host": "bridge"},
         unique_id=canonical,
         version=2,
     )
+
+
+async def test_migrate_entry_skips_device_rename_when_device_not_found():
+    """No matching device registry entry means nothing to rename."""
+    from custom_components.eebus import async_migrate_entry
+
+    raw = "68:2f:70:8C:EB:A5:DF:9A:DC:B9:E6:78:7E:A9:11:D9:FC:3A:C4:90"
+    hass = MagicMock()
+    entry = MagicMock(
+        version=1,
+        data={CONF_DEVICE_SKI: raw},
+        unique_id=raw,
+        entry_id="01",
+        title="Heat pump",
+    )
+    hass.config_entries.async_entries.return_value = [entry]
+
+    with patch("custom_components.eebus.dr.async_get") as async_get_device_registry:
+        device_registry = MagicMock()
+        device_registry.async_get_device.return_value = None
+        async_get_device_registry.return_value = device_registry
+
+        assert await async_migrate_entry(hass, entry)
+
+        device_registry.async_update_device.assert_not_called()
 
 
 async def test_migrate_entry_rejects_newer_duplicate(caplog: pytest.LogCaptureFixture):


### PR DESCRIPTION
## Summary
- Device registry entries stayed keyed under the raw SKI after SPEC2-04's config-entry canonicalization, orphaning the device (area/history/automation references lost) on next setup. `async_migrate_entry` now renames the device registry identifier to the canonical SKI in place.
- `EebusHeartbeatOkSensor` was missing the `available` override `EebusConnectedSensor` already got for the SPEC2-01 regression — transient per-device disconnects flipped it fully "unavailable" instead of a stable on/off, breaking dashboard history graphs.

## Test plan
- [x] `PYTHONPATH=. pytest` — 171 passed
- [x] `ruff check custom_components/` — clean
- [x] `mypy custom_components/eebus` — clean