### PR TITLE
fix: allow removing stale devices left behind by SKI canonicalization

### DIFF
--- a/custom_components/eebus/__init__.py
+++ b/custom_components/eebus/__init__.py
@@ -183,6 +183,22 @@ async def async_unload_entry(hass: HomeAssistant, entry: EebusConfigEntry) -> bo
     return unload_ok
 
 
+async def async_remove_config_entry_device(
+    hass: HomeAssistant, config_entry: ConfigEntry, device_entry: dr.DeviceEntry
+) -> bool:
+    """Allow removing a stale device left behind by a SKI canonicalization.
+
+    A device is only removable if none of its identifiers match the entry's
+    current canonical SKI — i.e. it's an orphan from before the identifier
+    was renamed, not the device the entry is actively using.
+    """
+    current_ski = config_entry.data[CONF_DEVICE_SKI]
+    return not any(
+        domain == DOMAIN and ski == current_ski
+        for domain, ski in device_entry.identifiers
+    )
+
+
 async def _async_reload_entry(hass: HomeAssistant, entry: EebusConfigEntry) -> None:
     """Reload on options change."""
     await hass.config_entries.async_reload(entry.entry_id)

--- a/custom_components/eebus/quality_scale.yaml
+++ b/custom_components/eebus/quality_scale.yaml
@@ -76,8 +76,11 @@ rules:
     status: exempt
     comment: Authentication failures start reauthentication; other connection issues are communicated via availability and logging.
   stale-devices:
-    status: exempt
-    comment: One device per config entry, removed on unload.
+    status: done
+    comment: >-
+      async_remove_config_entry_device allows removing a device manually from
+      the UI once its identifier no longer matches the entry's canonical SKI
+      (e.g. an orphan left behind by a SKI canonicalization migration).
   async-dependency: done
   inject-websession:
     status: exempt

--- a/custom_components/eebus/tests/test_init.py
+++ b/custom_components/eebus/tests/test_init.py
@@ -82,6 +82,30 @@ def test_remove_replaced_heartbeat_switch():
     entity_registry.async_remove.assert_called_once_with("switch.eebus_heartbeat")
 
 
+async def test_remove_config_entry_device_allows_stale_identifier():
+    """A device whose identifier no longer matches the canonical SKI is removable."""
+    from custom_components.eebus import async_remove_config_entry_device
+
+    canonical = "682F708CEBA5DF9ADCB9E6787EA911D9FC3AC490"
+    hass = MagicMock()
+    entry = MagicMock(data={CONF_DEVICE_SKI: canonical})
+    device = MagicMock(identifiers={("eebus", canonical.lower())})
+
+    assert await async_remove_config_entry_device(hass, entry, device) is True
+
+
+async def test_remove_config_entry_device_blocks_active_identifier():
+    """The device the entry is actively using cannot be removed from the UI."""
+    from custom_components.eebus import async_remove_config_entry_device
+
+    canonical = "682F708CEBA5DF9ADCB9E6787EA911D9FC3AC490"
+    hass = MagicMock()
+    entry = MagicMock(data={CONF_DEVICE_SKI: canonical})
+    device = MagicMock(identifiers={("eebus", canonical)})
+
+    assert await async_remove_config_entry_device(hass, entry, device) is False
+
+
 @pytest.mark.asyncio
 async def test_unload_entry():
     """Test async_unload_entry shuts down coordinator."""


### PR DESCRIPTION
## Summary
- `async_remove_config_entry_device()` lets HA's UI delete a device whose identifier no longer matches the entry's canonical SKI. PR #126's device-registry migration only fires on the v1→v2 config-entry version transition — entries already at v2 before that fix shipped (e.g. from SPEC2-04) can still carry an orphaned duplicate device with no path to remove it, since HA blocks manual device removal unless the integration opts in.
- `quality_scale.yaml`'s `stale-devices` exemption claimed "one device per config entry, removed on unload" — no longer true once a canonicalization can leave a second device behind. Marked `done` with the new mitigation.
- Confirmed live on the production VR940 instance: found exactly this orphaned duplicate (disabled by the user as a manual workaround), the officially-supported removal path (`config/device_registry/remove_config_entry`) was rejected with "Config entry does not support device removal" until this hook exists.

## Test plan
- [x] `PYTHONPATH=. pytest` — 173 passed
- [x] `ruff check custom_components/` — clean
- [x] `mypy custom_components/eebus` — clean