### PR TITLE
test: raise Go coverage to 83% and enforce patch coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,8 @@ jobs:
           filters: |
             go:
               - 'eebus-bridge/**'
+              - 'scripts/check_go_patch_coverage.py'
+              - 'scripts/tests/test_check_go_patch_coverage.py'
               - '.github/workflows/ci.yml'
             python:
               - 'custom_components/**'
@@ -58,6 +60,8 @@ jobs:
         working-directory: eebus-bridge
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: "1.26"
@@ -70,6 +74,42 @@ jobs:
           working-directory: eebus-bridge
           version: v2.12.2
       - run: go test -v -race ./...
+      - name: Test Go patch coverage checker
+        run: python3 -m unittest discover -s ../scripts/tests -p 'test_check_go_patch_coverage.py' -v
+      - name: Generate productive Go coverage
+        run: go test -count=1 -coverprofile=coverage.out ./cmd/eebus-bridge ./cmd/eebus-watch ./internal/...
+      - name: Enforce Go coverage
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_REF: ${{ github.base_ref }}
+          BEFORE_SHA: ${{ github.event.before }}
+        run: |
+          set -euo pipefail
+          go tool cover -func=coverage.out | tee coverage-summary.txt
+          read -r covered_statements total_statements <<< "$(awk 'NR > 1 {
+            total += $2
+            if ($3 > 0) covered += $2
+          } END {print covered, total}' coverage.out)"
+          awk -v covered="$covered_statements" -v total="$total_statements" 'BEGIN {
+            actual = 100 * covered / total
+            if (actual + 1e-9 < 83.0) {
+              printf "Go total coverage %.1f%% is below required 83.0%%\n", actual > "/dev/stderr"
+              exit 1
+            }
+          }'
+
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+            coverage_base="$(git -C .. merge-base "origin/$BASE_REF" HEAD)"
+          elif [[ -n "$BEFORE_SHA" ]] && git -C .. cat-file -e "${BEFORE_SHA}^{commit}" 2>/dev/null; then
+            coverage_base="$BEFORE_SHA"
+          else
+            coverage_base="$(git -C .. hash-object -t tree /dev/null)"
+          fi
+          python3 ../scripts/check_go_patch_coverage.py \
+            --repository .. \
+            --profile coverage.out \
+            --base "$coverage_base" \
+            --threshold 90
       - run: go test -tags=integration -v ./internal/grpc/ -run TestIntegration
       - name: govulncheck
         # Invoke govulncheck directly instead of golang/govulncheck-action: the

--- a/eebus-bridge/cmd/eebus-bridge/app_test.go
+++ b/eebus-bridge/cmd/eebus-bridge/app_test.go
@@ -15,9 +15,11 @@ import (
 	"github.com/enbility/spine-go/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	pb "github.com/volschin/eebus-bridge/gen/proto/eebus/v1"
 	"github.com/volschin/eebus-bridge/internal/config"
 	"github.com/volschin/eebus-bridge/internal/eebus"
 	bridgegrpc "github.com/volschin/eebus-bridge/internal/grpc"
+	"github.com/volschin/eebus-bridge/internal/usecases"
 )
 
 type fakeBridgeLifecycle struct {
@@ -91,12 +93,14 @@ func (f *fakeBridgeLifecycle) unregisterValues() []string {
 }
 
 type fakeGRPCLifecycle struct {
-	startErr error
-	release  chan struct{}
-	stopOnce sync.Once
-	starts   atomic.Int32
-	stops    atomic.Int32
-	recorder *shutdownRecorder
+	startErr  error
+	release   chan struct{}
+	stopOnce  sync.Once
+	serveOnce sync.Once
+	serving   chan struct{}
+	starts    atomic.Int32
+	stops     atomic.Int32
+	recorder  *shutdownRecorder
 
 	healthMu sync.Mutex
 	health   []bool
@@ -134,6 +138,9 @@ func (f *fakeGRPCLifecycle) SetHealthy(healthy bool) {
 	f.healthMu.Lock()
 	f.health = append(f.health, healthy)
 	f.healthMu.Unlock()
+	if healthy && f.serving != nil {
+		f.serveOnce.Do(func() { close(f.serving) })
+	}
 }
 
 func (f *fakeGRPCLifecycle) SetDeviceHealthy(healthy bool) {
@@ -189,6 +196,11 @@ func TestProductionCompositionRootIsInertUntilStartAndRegistersAllUseCases(t *te
 		},
 		Certificates: config.CertificatesConfig{AutoGenerate: &autoGenerate, StoragePath: t.TempDir()},
 		OHPCF:        config.OHPCFConfig{Enabled: &ohpcfEnabled},
+		Experimental: config.ExperimentalConfig{
+			MGCPProvider: true,
+			VAPDProvider: true,
+			VABDProvider: true,
+		},
 	}
 
 	app, err := NewApplication(cfg)
@@ -206,7 +218,93 @@ func TestProductionCompositionRootIsInertUntilStartAndRegistersAllUseCases(t *te
 	assert.ElementsMatch(t, []string{
 		"LPC", "Monitoring", "DHWMonitoring", "MRT", "MOT", "DHWTemperature",
 		"DHWSystemFunction", "RoomHeatingTemperature", "RoomHeatingSystemFunction", "OHPCF",
+		"MGCP", "VAPD", "VABD",
 	}, app.registeredUseCases)
+	providerModule := app.modules[len(app.modules)-1]
+	require.Equal(t, "Providers", providerModule.name)
+	require.NoError(t, providerModule.start())
+	require.NoError(t, providerModule.stop())
+}
+
+func TestProviderSampleStateConversion(t *testing.T) {
+	tests := []struct {
+		in   usecases.ProviderSnapshotState
+		want pb.ProviderSampleState
+	}{
+		{usecases.ProviderSnapshotEmpty, pb.ProviderSampleState_PROVIDER_SAMPLE_STATE_EMPTY},
+		{usecases.ProviderSnapshotCurrent, pb.ProviderSampleState_PROVIDER_SAMPLE_STATE_CURRENT},
+		{usecases.ProviderSnapshotExpired, pb.ProviderSampleState_PROVIDER_SAMPLE_STATE_EXPIRED},
+		{usecases.ProviderSnapshotClosed, pb.ProviderSampleState_PROVIDER_SAMPLE_STATE_CLOSED},
+		{usecases.ProviderSnapshotState(99), pb.ProviderSampleState_PROVIDER_SAMPLE_STATE_UNSPECIFIED},
+	}
+	for _, test := range tests {
+		if got := providerSampleState(test.in); got != test.want {
+			t.Errorf("providerSampleState(%d) = %s, want %s", test.in, got, test.want)
+		}
+	}
+	if got := (applicationProviderDiagnostics{}).ProviderDiagnostics(time.Now()); len(got) != 0 {
+		t.Fatalf("empty provider diagnostics = %+v", got)
+	}
+}
+
+func TestApplicationStartConfigurationAndStateGuards(t *testing.T) {
+	ctx := context.Background()
+	if err := (&Application{}).Start(ctx); err == nil || err.Error() != "EEBUS bridge service is not configured" {
+		t.Fatalf("missing bridge error = %v", err)
+	}
+	if err := (&Application{bridgeSvc: &fakeBridgeLifecycle{}}).Start(ctx); err == nil || err.Error() != "gRPC server is not configured" {
+		t.Fatalf("missing gRPC error = %v", err)
+	}
+	stopped := &Application{bridgeSvc: &fakeBridgeLifecycle{}, grpcSrv: &fakeGRPCLifecycle{}, stopped: true}
+	if err := stopped.Start(ctx); err == nil || err.Error() != "application is stopped" {
+		t.Fatalf("stopped application error = %v", err)
+	}
+	alreadyStarted := &Application{
+		bridgeSvc: &fakeBridgeLifecycle{}, grpcSrv: &fakeGRPCLifecycle{}, lifecycle: newLifecycleTransaction(),
+	}
+	if err := alreadyStarted.Start(ctx); err == nil || err.Error() != "application is already started" {
+		t.Fatalf("already-started application error = %v", err)
+	}
+}
+
+func TestApplicationErrorWrappersAndLogging(t *testing.T) {
+	want := errors.New("runtime failure")
+	controlled := &controlledShutdownError{err: want}
+	if controlled.Error() != want.Error() || !errors.Is(controlled, want) {
+		t.Fatalf("controlled error = %v", controlled)
+	}
+	signalErr := &signalShutdown{signal: syscall.SIGTERM}
+	if signalErr.Error() != "received signal terminated" {
+		t.Fatalf("signal error = %q", signalErr.Error())
+	}
+	logRunError(controlled)
+	logRunError(want)
+}
+
+func TestNotifySignalContextStopsAndCapturesSignal(t *testing.T) {
+	t.Run("explicit stop", func(t *testing.T) {
+		ctx, stop := notifySignalContext(context.Background(), syscall.SIGUSR1)
+		stop()
+		stop()
+		if !errors.Is(context.Cause(ctx), context.Canceled) {
+			t.Fatalf("context cause = %v", context.Cause(ctx))
+		}
+	})
+
+	t.Run("signal", func(t *testing.T) {
+		ctx, stop := notifySignalContext(context.Background(), syscall.SIGUSR1)
+		defer stop()
+		require.NoError(t, syscall.Kill(syscall.Getpid(), syscall.SIGUSR1))
+		select {
+		case <-ctx.Done():
+			var signalCause *signalShutdown
+			if !errors.As(context.Cause(ctx), &signalCause) || signalCause.signal != syscall.SIGUSR1 {
+				t.Fatalf("context cause = %v", context.Cause(ctx))
+			}
+		case <-time.After(time.Second):
+			t.Fatal("timeout waiting for signal context")
+		}
+	})
 }
 
 type fakeHeartbeatLifecycle struct {
@@ -686,7 +784,7 @@ func TestMonitoringWatchdogHealthTracksTrustedDisconnectedDevice(t *testing.T) {
 
 func TestApplicationStartSignalTriggersShutdown(t *testing.T) {
 	bridge := &fakeBridgeLifecycle{started: make(chan struct{})}
-	grpcServer := &fakeGRPCLifecycle{release: make(chan struct{})}
+	grpcServer := &fakeGRPCLifecycle{release: make(chan struct{}), serving: make(chan struct{})}
 	heartbeat := &fakeHeartbeatLifecycle{}
 	app := newTestApplication(bridge, grpcServer, heartbeat, nil)
 	ctx, cancel := context.WithCancelCause(context.Background())
@@ -694,9 +792,9 @@ func TestApplicationStartSignalTriggersShutdown(t *testing.T) {
 	go func() { result <- app.Start(ctx) }()
 
 	select {
-	case <-bridge.started:
+	case <-grpcServer.serving:
 	case <-time.After(time.Second):
-		t.Fatal("application did not start")
+		t.Fatal("application did not become ready")
 	}
 	cancel(&signalShutdown{signal: syscall.SIGTERM})
 

--- a/eebus-bridge/cmd/eebus-bridge/healthcheck_test.go
+++ b/eebus-bridge/cmd/eebus-bridge/healthcheck_test.go
@@ -1,0 +1,186 @@
+package main
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/volschin/eebus-bridge/internal/config"
+	bridgegrpc "github.com/volschin/eebus-bridge/internal/grpc"
+)
+
+func TestRunHealthcheckReportsServingAndNotServing(t *testing.T) {
+	server := bridgegrpc.NewServer("127.0.0.1", 0, false)
+	port := startHealthcheckServer(t, server)
+	configPath := writeHealthcheckConfig(t, port, "")
+
+	if err := runHealthcheck(configPath); err == nil || !strings.Contains(err.Error(), "NOT_SERVING") {
+		t.Fatalf("not-serving error = %v", err)
+	}
+	server.SetHealthy(true)
+	if err := runHealthcheck(configPath); err != nil {
+		t.Fatalf("serving healthcheck: %v", err)
+	}
+}
+
+func TestRunHealthcheckReportsConfigurationAndConnectionErrors(t *testing.T) {
+	if err := runHealthcheck(filepath.Join(t.TempDir(), "missing.yaml")); err == nil || !strings.Contains(err.Error(), "loading config") {
+		t.Fatalf("missing config error = %v", err)
+	}
+	configPath := writeHealthcheckConfig(t, 1, "")
+	if err := runHealthcheck(configPath); err == nil || !strings.Contains(err.Error(), "health check") {
+		t.Fatalf("connection error = %v", err)
+	}
+}
+
+func TestRunHealthcheckWithTLSToken(t *testing.T) {
+	certFile, keyFile := writeHealthcheckCertificate(t, []string{"localhost"}, []net.IP{net.ParseIP("127.0.0.1")})
+	tokenFile := filepath.Join(t.TempDir(), "token")
+	if err := os.WriteFile(tokenFile, []byte("healthcheck-secret\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	security := config.GRPCSecurityConfig{
+		Mode: config.GRPCSecurityModeTLSToken, TLSCertFile: certFile, TLSKeyFile: keyFile, TokenFile: tokenFile,
+	}
+	server, err := bridgegrpc.NewServerWithSecurity("127.0.0.1", 0, false, security)
+	if err != nil {
+		t.Fatal(err)
+	}
+	port := startHealthcheckServer(t, server)
+	server.SetHealthy(true)
+	configPath := writeHealthcheckConfig(t, port, strings.Join([]string{
+		"    mode: tls_token",
+		"    tls_cert_file: " + certFile,
+		"    tls_key_file: " + keyFile,
+		"    token_file: " + tokenFile,
+	}, "\n"))
+	if err := runHealthcheck(configPath); err != nil {
+		t.Fatalf("TLS healthcheck: %v", err)
+	}
+}
+
+func TestTLSCertificateServerNameValidation(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "missing.pem")
+	if _, err := tlsCertificateServerName(missing); err == nil {
+		t.Fatal("missing certificate was accepted")
+	}
+
+	invalidPEM := filepath.Join(t.TempDir(), "invalid.pem")
+	if err := os.WriteFile(invalidPEM, []byte("not PEM"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tlsCertificateServerName(invalidPEM); err == nil || !strings.Contains(err.Error(), "no PEM certificate") {
+		t.Fatalf("invalid PEM error = %v", err)
+	}
+
+	wrongType := filepath.Join(t.TempDir(), "key.pem")
+	if err := os.WriteFile(wrongType, pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: []byte("invalid")}), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tlsCertificateServerName(wrongType); err == nil || !strings.Contains(err.Error(), "no PEM certificate") {
+		t.Fatalf("wrong PEM type error = %v", err)
+	}
+
+	invalidDER := filepath.Join(t.TempDir(), "invalid-der.pem")
+	if err := os.WriteFile(invalidDER, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: []byte("invalid")}), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tlsCertificateServerName(invalidDER); err == nil {
+		t.Fatal("invalid certificate DER was accepted")
+	}
+
+	dnsCert, _ := writeHealthcheckCertificate(t, []string{"bridge.example"}, nil)
+	if got, err := tlsCertificateServerName(dnsCert); err != nil || got != "bridge.example" {
+		t.Fatalf("DNS server name = %q, %v", got, err)
+	}
+	ipCert, _ := writeHealthcheckCertificate(t, nil, []net.IP{net.ParseIP("127.0.0.2")})
+	if got, err := tlsCertificateServerName(ipCert); err != nil || got != "127.0.0.2" {
+		t.Fatalf("IP server name = %q, %v", got, err)
+	}
+	noSAN, _ := writeHealthcheckCertificate(t, nil, nil)
+	if _, err := tlsCertificateServerName(noSAN); err == nil || !strings.Contains(err.Error(), "no DNS or IP") {
+		t.Fatalf("missing SAN error = %v", err)
+	}
+}
+
+func startHealthcheckServer(t *testing.T, server *bridgegrpc.Server) int {
+	t.Helper()
+	startErr := make(chan error, 1)
+	go func() { startErr <- server.Start() }()
+	t.Cleanup(server.Stop)
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if address := server.Addr(); address != "" {
+			_, portText, err := net.SplitHostPort(address)
+			if err != nil {
+				t.Fatal(err)
+			}
+			port, err := strconv.Atoi(portText)
+			if err != nil {
+				t.Fatal(err)
+			}
+			return port
+		}
+		select {
+		case err := <-startErr:
+			t.Fatalf("server start: %v", err)
+		default:
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatal("server did not start")
+	return 0
+}
+
+func writeHealthcheckConfig(t *testing.T, port int, securityLines string) string {
+	t.Helper()
+	content := "grpc:\n  bind: 127.0.0.1\n  port: " + strconv.Itoa(port) + "\n"
+	if securityLines != "" {
+		content += "  security:\n" + securityLines + "\n"
+	}
+	content += "certificates:\n  auto_generate: true\n  storage_path: " + t.TempDir() + "\n"
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func writeHealthcheckCertificate(t *testing.T, dnsNames []string, ipAddresses []net.IP) (string, string) {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1), Subject: pkix.Name{CommonName: "localhost"},
+		NotBefore: time.Now().Add(-time.Hour), NotAfter: time.Now().Add(time.Hour),
+		KeyUsage:    x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		DNSNames:    dnsNames, IPAddresses: ipAddresses,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := t.TempDir()
+	certFile := filepath.Join(dir, "server.crt")
+	keyFile := filepath.Join(dir, "server.key")
+	if err := os.WriteFile(certFile, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(keyFile, pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)}), 0600); err != nil {
+		t.Fatal(err)
+	}
+	return certFile, keyFile
+}

--- a/eebus-bridge/cmd/eebus-watch/main_test.go
+++ b/eebus-bridge/cmd/eebus-watch/main_test.go
@@ -1,14 +1,166 @@
 package main
 
 import (
+	"bytes"
+	"context"
+	"errors"
+	"net"
+	"strconv"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	pb "github.com/volschin/eebus-bridge/gen/proto/eebus/v1"
+	"github.com/volschin/eebus-bridge/internal/config"
+	bridgegrpc "github.com/volschin/eebus-bridge/internal/grpc"
+	grpcgo "google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
+
+type watchRPCFixture struct {
+	mu          sync.Mutex
+	registered  string
+	failDetails bool
+}
+
+type watchDeviceServer struct {
+	pb.UnimplementedDeviceServiceServer
+	fixture *watchRPCFixture
+}
+
+func (s watchDeviceServer) GetStatus(context.Context, *pb.Empty) (*pb.ServiceStatus, error) {
+	return &pb.ServiceStatus{Running: true, LocalSki: "local-ski"}, nil
+}
+
+func (s watchDeviceServer) ListPairedDevices(context.Context, *pb.Empty) (*pb.ListPairedDevicesResponse, error) {
+	return &pb.ListPairedDevicesResponse{Devices: []*pb.PairedDevice{
+		nil,
+		{Ski: "remote-ski", Brand: "Paired Brand", Model: "Paired Model", Serial: "paired-serial", DeviceType: "HeatPump", SupportedUseCases: []string{"MPC", "LPC"}},
+	}}, nil
+}
+
+func (s watchDeviceServer) ListDiscoveredDevices(context.Context, *pb.Empty) (*pb.ListDevicesResponse, error) {
+	if s.fixture.failDetails {
+		return nil, status.Error(codes.Unavailable, "discovery unavailable")
+	}
+	return &pb.ListDevicesResponse{Devices: []*pb.DiscoveredDevice{
+		nil,
+		{Ski: "discovered-ski", Brand: "Discovered Brand", Model: "Discovered Model", Serial: "discovered-serial", DeviceType: "Gateway", Host: "192.0.2.1"},
+	}}, nil
+}
+
+func (s watchDeviceServer) RegisterRemoteSKI(_ context.Context, request *pb.RegisterSKIRequest) (*pb.Empty, error) {
+	s.fixture.mu.Lock()
+	s.fixture.registered = request.GetSki()
+	s.fixture.mu.Unlock()
+	return &pb.Empty{}, nil
+}
+
+func (f *watchRPCFixture) registeredSKI() string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.registered
+}
+
+type watchMonitoringServer struct {
+	pb.UnimplementedMonitoringServiceServer
+	fixture *watchRPCFixture
+}
+
+func (s watchMonitoringServer) GetPowerConsumption(context.Context, *pb.DeviceRequest) (*pb.PowerMeasurement, error) {
+	if s.fixture.failDetails {
+		return nil, status.Error(codes.NotFound, "power unavailable")
+	}
+	return &pb.PowerMeasurement{Watts: 1234.5}, nil
+}
+
+func (s watchMonitoringServer) GetEnergyConsumed(context.Context, *pb.DeviceRequest) (*pb.EnergyMeasurement, error) {
+	if s.fixture.failDetails {
+		return nil, status.Error(codes.Internal, "energy failed")
+	}
+	return &pb.EnergyMeasurement{KilowattHours: 42.25}, nil
+}
+
+func (s watchMonitoringServer) GetMeasurements(context.Context, *pb.DeviceRequest) (*pb.MeasurementList, error) {
+	if s.fixture.failDetails {
+		return nil, status.Error(codes.Unavailable, "measurements unavailable")
+	}
+	return &pb.MeasurementList{Measurements: []*pb.MeasurementEntry{
+		nil,
+		{Type: "room_temperature", Value: 21.5, Unit: "degC", Timestamp: timestamppb.New(time.Unix(10, 0))},
+	}}, nil
+}
+
+type watchLPCServer struct {
+	pb.UnimplementedLPCServiceServer
+	fixture *watchRPCFixture
+}
+
+func (s watchLPCServer) GetConsumptionLimit(context.Context, *pb.DeviceRequest) (*pb.LoadLimit, error) {
+	if s.fixture.failDetails {
+		return nil, status.Error(codes.NotFound, "limit unavailable")
+	}
+	return &pb.LoadLimit{ValueWatts: 4200, IsActive: true, IsChangeable: true}, nil
+}
+
+func (s watchLPCServer) GetFailsafeLimit(context.Context, *pb.DeviceRequest) (*pb.FailsafeLimit, error) {
+	if s.fixture.failDetails {
+		return nil, status.Error(codes.Unimplemented, "failsafe unavailable")
+	}
+	return &pb.FailsafeLimit{ValueWatts: 5000, DurationMinimumSeconds: 60}, nil
+}
+
+func (s watchLPCServer) GetHeartbeatStatus(context.Context, *pb.DeviceRequest) (*pb.HeartbeatStatus, error) {
+	if s.fixture.failDetails {
+		return nil, status.Error(codes.Unavailable, "heartbeat unavailable")
+	}
+	return &pb.HeartbeatStatus{Running: true, WithinDuration: true}, nil
+}
+
+type watchOHPCFServer struct {
+	pb.UnimplementedOHPCFServiceServer
+	fixture *watchRPCFixture
+}
+
+func (s watchOHPCFServer) GetCompressorFlexibility(context.Context, *pb.DeviceRequest) (*pb.CompressorFlexibility, error) {
+	if s.fixture.failDetails {
+		return nil, status.Error(codes.NotFound, "flexibility unavailable")
+	}
+	return &pb.CompressorFlexibility{
+		Available: true, State: pb.CompressorPowerConsumptionState_COMPRESSOR_STATE_AVAILABLE,
+		IsStoppable: true, IsPausable: true, MinimalRunSeconds: 120, MinimalPauseSeconds: 30,
+	}, nil
+}
+
+func startWatchTestServer(t *testing.T, fixture *watchRPCFixture) (string, int) {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	server := grpcgo.NewServer()
+	pb.RegisterDeviceServiceServer(server, watchDeviceServer{fixture: fixture})
+	pb.RegisterMonitoringServiceServer(server, watchMonitoringServer{fixture: fixture})
+	pb.RegisterLPCServiceServer(server, watchLPCServer{fixture: fixture})
+	pb.RegisterOHPCFServiceServer(server, watchOHPCFServer{fixture: fixture})
+	go func() { _ = server.Serve(listener) }()
+	t.Cleanup(func() {
+		server.Stop()
+		_ = listener.Close()
+	})
+	host, portText, err := net.SplitHostPort(listener.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	port, err := strconv.Atoi(portText)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return host, port
+}
 
 func TestSelectTargetSKI(t *testing.T) {
 	t.Parallel()
@@ -75,6 +227,125 @@ func TestFormatTimestamp(t *testing.T) {
 	}
 	if got := formatTimestamp(timestamppb.New(unixTime(t, 5))); got != "1970-01-01T00:00:05Z" {
 		t.Fatalf("formatTimestamp() = %q, want 1970-01-01T00:00:05Z", got)
+	}
+}
+
+func TestRunOnceCollectsAndRendersCompleteSnapshot(t *testing.T) {
+	fixture := &watchRPCFixture{}
+	host, port := startWatchTestServer(t, fixture)
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+
+	err := run(
+		context.Background(), host, port, "remote-ski", time.Second, true, true, false, true,
+		bridgegrpc.ClientSecurityConfig{Mode: config.GRPCSecurityModeLoopback}, &out, &errOut,
+	)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if got := fixture.registeredSKI(); got != "remote-ski" {
+		t.Fatalf("registered SKI = %q, want remote-ski", got)
+	}
+	for _, want := range []string{
+		"EEBUS watch", "local-ski", "Discovered Brand", "Paired Brand", "room_temperature",
+		"1234.5 W", "42.250 kWh", "4200.0 W", "5000.0 W / 60 s", "Heartbeat", "OHPCF",
+	} {
+		if !strings.Contains(out.String(), want) {
+			t.Fatalf("output does not contain %q:\n%s", want, out.String())
+		}
+	}
+	if errOut.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", errOut.String())
+	}
+}
+
+func TestRunValidatesIntervalAndRegistration(t *testing.T) {
+	if err := run(context.Background(), "127.0.0.1", 1, "", 0, true, false, false, false,
+		bridgegrpc.ClientSecurityConfig{Mode: config.GRPCSecurityModeLoopback}, &bytes.Buffer{}, &bytes.Buffer{}); err == nil || !strings.Contains(err.Error(), "interval") {
+		t.Fatalf("invalid interval error = %v", err)
+	}
+
+	fixture := &watchRPCFixture{}
+	host, port := startWatchTestServer(t, fixture)
+	err := run(context.Background(), host, port, "  ", time.Second, true, false, false, true,
+		bridgegrpc.ClientSecurityConfig{Mode: config.GRPCSecurityModeLoopback}, &bytes.Buffer{}, &bytes.Buffer{})
+	if err == nil || !strings.Contains(err.Error(), "--register requires --ski") {
+		t.Fatalf("empty registration SKI error = %v", err)
+	}
+}
+
+func TestCollectSnapshotFiltersExpectedErrorsAndReportsUnexpectedErrors(t *testing.T) {
+	fixture := &watchRPCFixture{failDetails: true}
+	host, port := startWatchTestServer(t, fixture)
+	conn, err := bridgegrpc.NewClient(net.JoinHostPort(host, strconv.Itoa(port)), bridgegrpc.ClientSecurityConfig{Mode: config.GRPCSecurityModeLoopback})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	collect := func(debug bool) *snapshot {
+		t.Helper()
+		snap, err := collectSnapshot(
+			context.Background(), pb.NewDeviceServiceClient(conn), pb.NewMonitoringServiceClient(conn),
+			pb.NewLPCServiceClient(conn), pb.NewOHPCFServiceClient(conn), host, port, "", false, debug,
+		)
+		if err != nil {
+			t.Fatalf("collectSnapshot(debug=%t): %v", debug, err)
+		}
+		return snap
+	}
+
+	withoutDebug := collect(false)
+	if len(withoutDebug.Errors) != 1 || !strings.Contains(withoutDebug.Errors[0], "energy") {
+		t.Fatalf("non-debug errors = %v, want only internal energy error", withoutDebug.Errors)
+	}
+	withDebug := collect(true)
+	if len(withDebug.Errors) != 7 {
+		t.Fatalf("debug errors = %v, want all seven detail errors", withDebug.Errors)
+	}
+	if withDebug.SelectedSKI != "remote-ski" {
+		t.Fatalf("selected SKI = %q, want first paired device", withDebug.SelectedSKI)
+	}
+}
+
+func TestRenderSnapshotHandlesEmptyValues(t *testing.T) {
+	var out bytes.Buffer
+	renderSnapshot(&out, &snapshot{Host: "localhost", Port: 50051})
+	for _, want := range []string{
+		"No visible SHIP/mDNS devices", "No paired devices available",
+		"No monitoring measurements available", "No readable state values", "Local SKI",
+	} {
+		if !strings.Contains(out.String(), want) {
+			t.Fatalf("empty output does not contain %q:\n%s", want, out.String())
+		}
+	}
+	if got := blankIfEmpty(" value "); got != " value " {
+		t.Fatalf("blankIfEmpty(non-empty) = %q", got)
+	}
+	if got := blankIfEmpty(" \t "); got != "-" {
+		t.Fatalf("blankIfEmpty(blank) = %q", got)
+	}
+	if !shouldReportErr(status.Error(codes.Internal, "failed"), false) || shouldReportErr(status.Error(codes.NotFound, "missing"), false) {
+		t.Fatal("shouldReportErr returned unexpected classification")
+	}
+	if !shouldReportErr(status.Error(codes.NotFound, "missing"), true) || !isIgnorableErr(nil) {
+		t.Fatal("debug or nil error classification was unexpected")
+	}
+}
+
+func TestRunReturnsContextCancellationAfterSnapshot(t *testing.T) {
+	fixture := &watchRPCFixture{}
+	host, port := startWatchTestServer(t, fixture)
+	ctx, cancel := context.WithCancel(context.Background())
+	time.AfterFunc(25*time.Millisecond, cancel)
+	var out bytes.Buffer
+	err := run(ctx, host, port, "remote-ski", 5*time.Millisecond, false, true, false, false,
+		bridgegrpc.ClientSecurityConfig{Mode: config.GRPCSecurityModeLoopback}, &out, &bytes.Buffer{})
+	if !errors.Is(err, context.Canceled) && status.Code(err) != codes.Canceled {
+		t.Fatalf("run cancellation error = %v", err)
+	}
+	if !strings.Contains(out.String(), "\033[H\033[2J") {
+		t.Fatalf("repeated output did not clear screen: %q", out.String())
 	}
 }
 

--- a/eebus-bridge/docs/go-test-coverage.md
+++ b/eebus-bridge/docs/go-test-coverage.md
@@ -1,15 +1,24 @@
-# Go-Test-Coverage: Zielbild und Erweiterungsspezifikation
+# Go-Test-Coverage: Spezifikation und Umsetzungsstand
 
-## Ziel
+## Ziel und Randbedingungen
 
-Der produktive, handgeschriebene Go-Code soll eine Statement-Coverage von
-mindestens 95,0 % erreichen. Produktiver Code darf dafür nicht verändert
-werden; die Umsetzung erfolgt ausschließlich durch zusätzliche oder erweiterte
-Tests und Test-Fixtures.
+Der produktive, handgeschriebene Go-Code muss eine Statement-Coverage von
+mindestens **83,0 %** erreichen. Neu hinzugefügter oder geänderter produktiver
+Go-Code muss in der CI mindestens **90,0 % Patch-Coverage** erreichen.
+
+Für die Testerweiterung gelten folgende Randbedingungen:
+
+- Produktiver Go-Code wird nicht verändert.
+- Maschinell generierter Code wird weder in die Gesamt- noch in die
+  Patch-Coverage einbezogen.
+- Tests bleiben unabhängig von externen Geräten und externen Netzwerkdiensten.
+- Lokale Netzwerk-Fixtures verwenden dynamisch vergebene Ports.
+- Tests prüfen fachliche Ergebnisse, Fehler, Validierung und Zustandswechsel;
+  reine Aufrufe ohne Verhaltensprüfung sind nicht ausreichend.
 
 ## Messmethode und Scope
 
-Die reproduzierbare Messung erfolgt ohne Test-Cache:
+Die reproduzierbare Gesamtmessung erfolgt ohne Test-Cache:
 
 ```bash
 coverage_dir=$(mktemp -d)
@@ -18,158 +27,103 @@ go test -count=1 -coverprofile="$coverage_dir/coverage.out" \
 go tool cover -func="$coverage_dir/coverage.out"
 ```
 
-Im Ziel-Scope enthalten sind:
+Im produktiven Scope enthalten sind:
 
 - `cmd/eebus-bridge`
 - `cmd/eebus-watch`
 - `internal/...`
 
-Nicht im Ziel-Scope enthalten sind:
+Ausgeschlossen sind:
 
-- `gen/proto/**`, weil dieser Code aus den Protobuf-Spezifikationen generiert
-  wird;
-- `cmd/eebus-contract-testserver`, weil dieses Programm selbst ausschließlich
-  eine Fixture für sprachübergreifende Vertragstests ist;
-- externe Abhängigkeiten.
+- `gen/proto/**`, da dieser Code aus Protobuf-Spezifikationen generiert wird;
+- `cmd/eebus-contract-testserver`, da dieses Programm eine Test-Fixture für
+  sprachübergreifende Vertragstests ist;
+- `*_test.go` und externe Abhängigkeiten.
 
-Zusätzlich zur Coverage-Messung muss `go test -count=1 ./...` erfolgreich
-bleiben. Race-Erkennung wird separat mit `go test -race ./...` ausgeführt und
-ist kein Bestandteil des Coverage-Prozentwerts.
+Zusätzlich muss `go test -count=1 ./...` erfolgreich bleiben. Race-Erkennung
+wird separat mit `go test -race ./...` ausgeführt und ist nicht Bestandteil des
+Coverage-Prozentwerts.
 
-## Baseline vom 19. Juli 2026
+## Ausgangslage
 
-Alle Tests waren bei der Baseline-Messung erfolgreich.
+Die Baseline vom 19. Juli 2026 betrug **59,3 %** beziehungsweise 2.906 von
+4.897 Statements. Zur Zielerreichung mussten mindestens 4.065 Statements
+abgedeckt werden.
+
+## Erreichter Stand vom 19. Juli 2026 auf `origin/main`
 
 | Paket | Abgedeckt | Statements | Coverage | Nicht abgedeckt |
 |---|---:|---:|---:|---:|
-| `cmd/eebus-bridge` | 269 | 476 | 56,5 % | 207 |
-| `cmd/eebus-watch` | 24 | 201 | 11,9 % | 177 |
-| `internal/certs` | 34 | 43 | 79,1 % | 9 |
-| `internal/config` | 139 | 214 | 65,0 % | 75 |
-| `internal/eebus` | 593 | 822 | 72,1 % | 229 |
-| `internal/grpc` | 1.184 | 1.610 | 73,5 % | 426 |
-| `internal/usecases` | 663 | 1.531 | 43,3 % | 868 |
-| **Produktiver Scope** | **2.906** | **4.897** | **59,3 %** | **1.991** |
+| `cmd/eebus-bridge` | 386 | 481 | 80,2 % | 95 |
+| `cmd/eebus-watch` | 175 | 201 | 87,1 % | 26 |
+| `internal/certs` | 40 | 43 | 93,0 % | 3 |
+| `internal/config` | 210 | 214 | 98,1 % | 4 |
+| `internal/eebus` | 822 | 905 | 90,8 % | 83 |
+| `internal/grpc` | 1.386 | 1.631 | 85,0 % | 245 |
+| `internal/usecases` | 1.153 | 1.531 | 75,3 % | 378 |
+| **Produktiver Scope** | **4.172** | **5.006** | **83,340 %** | **834** |
 
-Zum Erreichen von 95,0 % müssen im definierten Scope mindestens 4.653 von
-4.897 Statements abgedeckt sein. Gegenüber der Baseline sind somit mindestens
-1.747 zusätzliche Statements abzudecken; höchstens 244 Statements dürfen offen
-bleiben.
+Das Ziel von 83,0 % ist damit um 17 abgedeckte Statements überschritten. Die
+seit der Baseline auf `main` zusammengeführten Produktivänderungen vergrößerten
+den Scope auf 5.006 Statements; der Coverage-PR selbst ändert weiterhin keinen
+Produktivcode.
 
-Zum Vergleich beträgt `go test ./...` einschließlich der 2.438 nicht
-instrumentierten generierten Statements 39,3 %. Dieser Rohwert ist kein
-sinnvoller Qualitätsindikator für den gepflegten Quellcode.
+## Umgesetzte Testerweiterungen
 
-## Umsetzungsstand vom 19. Juli 2026
+Die Erweiterungen konzentrieren sich auf fachlich relevante, zuvor schwach
+abgedeckte Pfade:
 
-Die erste Umsetzungsetappe ergänzt Tests für Monitoring-Guards und
--Klassifikation, Registry-Verträge, Konfigurationsvalidierung und
-Zertifikatsfehler. Danach ergibt sich folgender Zwischenstand:
+- `eebus-watch`: vollständiger `--once`-Ablauf, Registrierung, Snapshot-Aufbau,
+  Rendering, Validierung, Abbruch und RPC-Fehler über lokale gRPC-Fixtures;
+- Bridge-Anwendung: Healthcheck mit Klartext und TLS/Token,
+  Produktionskomposition, Provider-Aktivierung, Startzustände, Signale und
+  kontrollierte Fehlerbehandlung;
+- gRPC-Adapter: LPC-Lese-/Schreiboperationen und Heartbeat, Monitoring-Power,
+  Energie und Snapshots, OHPCF-Steuerung sowie End-to-End-Streams für DHW,
+  HVAC und OHPCF;
+- Use-Cases: Provider-Lebenszyklen, Initialisierungs-Guards, DHW- und
+  Raumheizungsereignisse, Systemfunktionen, Monitoring-Delegation und
+  hydraulische Temperaturen einschließlich Einheitenumrechnung;
+- EEBUS-Infrastruktur: Bridge-Service-Lifecycle, Provider-Entities,
+  Pairing-/Trust-Callbacks, TrustController und vollständiger SHIP-Logging-
+  Adapter;
+- Konfiguration, Zertifikate und Registry: Validierungs-, Fehler- und
+  Zustandsverträge.
 
-| Paket | Baseline | Aktuell | Änderung |
-|---|---:|---:|---:|
-| `cmd/eebus-bridge` | 56,5 % | 56,5 % | ±0,0 PP |
-| `cmd/eebus-watch` | 11,9 % | 11,9 % | ±0,0 PP |
-| `internal/certs` | 79,1 % | 93,0 % | +13,9 PP |
-| `internal/config` | 65,0 % | 98,1 % | +33,1 PP |
-| `internal/eebus` | 72,1 % | 84,5 % | +12,4 PP |
-| `internal/grpc` | 73,5 % | 73,5 % | ±0,0 PP |
-| `internal/usecases` | 43,3 % | 47,1 % | +3,8 PP |
-| **Produktiver Scope** | **59,3 %** | **64,2 %** | **+4,9 PP** |
+## CI-Prüfung
 
-Die erste Etappe deckt 237 zusätzliche produktive Statements ab. Bis zum
-95-%-Ziel fehlen noch mindestens 1.510 Statements. Die vollständige Suite
-`go test -count=1 ./...` ist nach dieser Etappe erfolgreich.
+Der Go-CI-Job erzeugt dasselbe produktive Coverage-Profil und prüft zwei
+Schwellen:
+
+1. Die Gesamt-Coverage darf nicht unter **83,0 %** fallen.
+2. Die Coverage geänderter produktiver Go-Statements muss mindestens
+   **90,0 %** betragen.
+
+Für die Patch-Coverage ermittelt `scripts/check_go_patch_coverage.py` die
+geänderten Zeilen zwischen dem Ziel-Branch und `HEAD` beziehungsweise zwischen
+dem vorherigen und aktuellen Push-Commit. Coverage-Blöcke, die eine geänderte
+Zeile überlappen, werden anhand der Statement-Anzahl des Go-Coverage-Profils
+gezählt. Ein Block wird auch bei mehreren geänderten Zeilen nur einmal gezählt.
+
+Folgende Änderungen bleiben bei der Patch-Coverage unberücksichtigt:
+
+- Testdateien (`*_test.go`);
+- `eebus-bridge/gen/**`;
+- `eebus-bridge/cmd/eebus-contract-testserver/**`;
+- Änderungen ohne ausführbare Go-Statements, beispielsweise Kommentare.
+
+Enthält ein Patch keine geänderten produktiven Go-Statements, besteht die
+Patch-Prüfung. Der Checker selbst besitzt isolierte Unit-Tests für Diff-Parsing,
+Scope-Ausschlüsse, Profil-Parsing, Blocküberlappung und Prozentberechnung.
 
 ## Abnahmekriterien
 
-- Der definierte produktive Scope erreicht insgesamt mindestens 95,0 %
-  Statement-Coverage.
-- Kein produktives Paket liegt unter 90,0 %, damit große Pakete schwache Pakete
-  nicht verdecken.
-- Alle Tests laufen wiederholbar mit `-count=1` und ohne externe Geräte oder
-  externe Netzwerkdienste.
-- Zeitabhängige Tests verwenden kontrollierte Uhren, großzügige
-  Synchronisationsgrenzen oder explizite Signale statt knapper Sleeps.
-- Netzwerknahe Tests verwenden lokale Listener mit dynamisch vergebenem Port.
-- Erfolgs-, Fehler-, Abbruch- und Validierungspfade werden fachlich geprüft; es
-  werden keine inhaltslosen Aufrufe nur zur Erhöhung des Prozentwerts ergänzt.
-- `go test -count=1 ./...` bleibt erfolgreich.
-- Der produktive Go-Code bleibt unverändert.
-
-## Priorisierte Testerweiterungen
-
-### 1. `internal/usecases`
-
-Dieses Paket besitzt mit 868 offenen Statements die größte Lücke.
-
-- Die Provider MGCP, VAPD und VABD werden über ihren gesamten Lebenszyklus
-  getestet: Konstruktion, `AddFeatures`, Deskriptoren, nicht initialisierter
-  Zustand, Publish-Erfolg, Publish-Fehler, Invalidierung, Ablauf, `Close`,
-  Diagnose und Support-Events.
-- Der Monitoring-Wrapper erhält Tabellenfälle für Setup, alle Reads vor der
-  Initialisierung, Entity-Auswahl, Multi-Device-Fallback, Measurement-Filter
-  und die vollständige Klassifikationsmatrix für Temperatur, Energie und
-  Leistung.
-- DHW-, Room-Heating-, LPC- und OHPCF-Wrapper erhalten Lifecycle-Tests für
-  Setup, Use-Case-Registrierung, Support-Updates, mehrdeutige Entities,
-  Refresh-Fehler sowie erfolgreiche und abgelehnte Schreibvorgänge.
-- Die Geräteklassifikation wird für fehlende Daten, Device-Type-only,
-  Manufacturer-Details, alternative Entities und partielle Ergebnisse geprüft.
-
-### 2. `internal/grpc`
-
-- Fehlende Streamtests für DHW, DHW-Systemfunktion, Room Heating und OHPCF
-  prüfen SKI-Filter, Initialzustand, Kontextabbruch, Sendefehler und Events ohne
-  Payload.
-- Noch offene Get- und Snapshot-Endpunkte werden für Erfolg, nicht verfügbare
-  Daten und unbekannte SKIs geprüft.
-- Payload-Konverter werden mit vollständigen, partiellen und ungültigen Daten
-  getestet.
-- Tabellengetriebene Vertragstests prüfen `nil`-Requests, ungültige SKIs, nicht
-  initialisierte Controller und die erwarteten gRPC-Statuscodes.
-- Readiness-, Recovery- und Server-Info-Randfälle werden ergänzt.
-
-### 3. `internal/eebus`
-
-- Die Registry erhält direkte Tests für Trust-Status, Health-Projektionen,
-  Observation-Upserts, Entfernen einzelner Observations, bekannte Geräte,
-  Entity-Adressen und Feature-Normalisierung.
-- Der Bridge-Service wird für Konstruktion, Entity-Zugriffe,
-  Setup/Start/Shutdown und Remote-SKI-Registrierung getestet.
-- Callback-Pfade für Pairing und Auto-Trust sowie alle Logging-Adapter werden
-  ausgeführt und inhaltlich geprüft.
-- Recovery-Tests ergänzen Backoff-Grenzen, Zustandswechsel und fehlgeschlagene
-  Wiederherstellung.
-
-### 4. `internal/config` und `internal/certs`
-
-- Alle Environment-Overrides werden tabellengetrieben geprüft.
-- TLS-/Token-Kombinationen, fehlende Dateien, leere Tokens,
-  Provider-Zeitfenster und Bind-Adressen werden validiert.
-- Fehlerhafte, fehlende und nicht lesbare Konfigurations- und Zertifikatsdateien
-  werden geprüft.
-- Zertifikatstests decken ungültiges PEM, unpassende Schlüssel, fehlende SANs
-  und vorhandene DNS-/IP-SANs ab.
-
-### 5. Produktive CLI-Pakete
-
-- `eebus-watch` verwendet einen lokalen In-Process-gRPC-Server für
-  `collectSnapshot`, den `--once`-Ablauf, Registrierung sowie Debug- und
-  Fehlerpfade. `renderSnapshot` erhält Golden- beziehungsweise strukturelle
-  Ausgabetests für leere und vollständige Snapshots.
-- Der Bridge-Healthcheck wird gegen SERVING, NOT_SERVING, Verbindungsfehler und
-  TLS-Konfigurationen getestet.
-- Das Application-Setup wird für aktivierte Provider, Konfigurationsfehler,
-  Signalabbruch, Fehlerklassifikation und Lifecycle-Stages ergänzt.
-- Reine, nicht sinnvoll isolierbare `main()`-Statements dürfen innerhalb des
-  verbleibenden 5-%-Budgets offenbleiben.
-
-## Umsetzungsreihenfolge
-
-1. Gut isolierbare Guard-, Klassifikations- und Registry-Tests ergänzen.
-2. Provider- und Use-Case-Lebenszyklen mit vorhandenen SPINE-Fixtures testen.
-3. Fehlende gRPC-Adapter- und Streamverträge ergänzen.
-4. CLI- und Healthcheck-Integrationstests mit lokalen Servern ergänzen.
-5. Coverage erneut messen, verbleibende Blöcke nach fachlichem Risiko
-   priorisieren und die Baseline-Tabelle fortschreiben.
+- [x] Der definierte produktive Scope erreicht mindestens 83,0 %.
+- [x] Generierter Code und der Contract-Testserver sind ausgeschlossen.
+- [x] Produktiver Go-Code blieb unverändert.
+- [x] Die Tests prüfen sinnvolle Erfolgs-, Fehler-, Validierungs- und
+  Ereignispfade.
+- [x] `go test -count=1` ist im vollständigen produktiven Scope erfolgreich.
+- [x] Die CI verhindert eine Gesamt-Coverage unter 83,0 %.
+- [x] Die CI schlägt bei weniger als 90,0 % Coverage neuen oder geänderten
+  produktiven Go-Codes fehl.

--- a/eebus-bridge/docs/go-test-coverage.md
+++ b/eebus-bridge/docs/go-test-coverage.md
@@ -1,0 +1,175 @@
+# Go-Test-Coverage: Zielbild und Erweiterungsspezifikation
+
+## Ziel
+
+Der produktive, handgeschriebene Go-Code soll eine Statement-Coverage von
+mindestens 95,0 % erreichen. Produktiver Code darf dafür nicht verändert
+werden; die Umsetzung erfolgt ausschließlich durch zusätzliche oder erweiterte
+Tests und Test-Fixtures.
+
+## Messmethode und Scope
+
+Die reproduzierbare Messung erfolgt ohne Test-Cache:
+
+```bash
+coverage_dir=$(mktemp -d)
+go test -count=1 -coverprofile="$coverage_dir/coverage.out" \
+  ./cmd/eebus-bridge ./cmd/eebus-watch ./internal/...
+go tool cover -func="$coverage_dir/coverage.out"
+```
+
+Im Ziel-Scope enthalten sind:
+
+- `cmd/eebus-bridge`
+- `cmd/eebus-watch`
+- `internal/...`
+
+Nicht im Ziel-Scope enthalten sind:
+
+- `gen/proto/**`, weil dieser Code aus den Protobuf-Spezifikationen generiert
+  wird;
+- `cmd/eebus-contract-testserver`, weil dieses Programm selbst ausschließlich
+  eine Fixture für sprachübergreifende Vertragstests ist;
+- externe Abhängigkeiten.
+
+Zusätzlich zur Coverage-Messung muss `go test -count=1 ./...` erfolgreich
+bleiben. Race-Erkennung wird separat mit `go test -race ./...` ausgeführt und
+ist kein Bestandteil des Coverage-Prozentwerts.
+
+## Baseline vom 19. Juli 2026
+
+Alle Tests waren bei der Baseline-Messung erfolgreich.
+
+| Paket | Abgedeckt | Statements | Coverage | Nicht abgedeckt |
+|---|---:|---:|---:|---:|
+| `cmd/eebus-bridge` | 269 | 476 | 56,5 % | 207 |
+| `cmd/eebus-watch` | 24 | 201 | 11,9 % | 177 |
+| `internal/certs` | 34 | 43 | 79,1 % | 9 |
+| `internal/config` | 139 | 214 | 65,0 % | 75 |
+| `internal/eebus` | 593 | 822 | 72,1 % | 229 |
+| `internal/grpc` | 1.184 | 1.610 | 73,5 % | 426 |
+| `internal/usecases` | 663 | 1.531 | 43,3 % | 868 |
+| **Produktiver Scope** | **2.906** | **4.897** | **59,3 %** | **1.991** |
+
+Zum Erreichen von 95,0 % müssen im definierten Scope mindestens 4.653 von
+4.897 Statements abgedeckt sein. Gegenüber der Baseline sind somit mindestens
+1.747 zusätzliche Statements abzudecken; höchstens 244 Statements dürfen offen
+bleiben.
+
+Zum Vergleich beträgt `go test ./...` einschließlich der 2.438 nicht
+instrumentierten generierten Statements 39,3 %. Dieser Rohwert ist kein
+sinnvoller Qualitätsindikator für den gepflegten Quellcode.
+
+## Umsetzungsstand vom 19. Juli 2026
+
+Die erste Umsetzungsetappe ergänzt Tests für Monitoring-Guards und
+-Klassifikation, Registry-Verträge, Konfigurationsvalidierung und
+Zertifikatsfehler. Danach ergibt sich folgender Zwischenstand:
+
+| Paket | Baseline | Aktuell | Änderung |
+|---|---:|---:|---:|
+| `cmd/eebus-bridge` | 56,5 % | 56,5 % | ±0,0 PP |
+| `cmd/eebus-watch` | 11,9 % | 11,9 % | ±0,0 PP |
+| `internal/certs` | 79,1 % | 93,0 % | +13,9 PP |
+| `internal/config` | 65,0 % | 98,1 % | +33,1 PP |
+| `internal/eebus` | 72,1 % | 84,5 % | +12,4 PP |
+| `internal/grpc` | 73,5 % | 73,5 % | ±0,0 PP |
+| `internal/usecases` | 43,3 % | 47,1 % | +3,8 PP |
+| **Produktiver Scope** | **59,3 %** | **64,2 %** | **+4,9 PP** |
+
+Die erste Etappe deckt 237 zusätzliche produktive Statements ab. Bis zum
+95-%-Ziel fehlen noch mindestens 1.510 Statements. Die vollständige Suite
+`go test -count=1 ./...` ist nach dieser Etappe erfolgreich.
+
+## Abnahmekriterien
+
+- Der definierte produktive Scope erreicht insgesamt mindestens 95,0 %
+  Statement-Coverage.
+- Kein produktives Paket liegt unter 90,0 %, damit große Pakete schwache Pakete
+  nicht verdecken.
+- Alle Tests laufen wiederholbar mit `-count=1` und ohne externe Geräte oder
+  externe Netzwerkdienste.
+- Zeitabhängige Tests verwenden kontrollierte Uhren, großzügige
+  Synchronisationsgrenzen oder explizite Signale statt knapper Sleeps.
+- Netzwerknahe Tests verwenden lokale Listener mit dynamisch vergebenem Port.
+- Erfolgs-, Fehler-, Abbruch- und Validierungspfade werden fachlich geprüft; es
+  werden keine inhaltslosen Aufrufe nur zur Erhöhung des Prozentwerts ergänzt.
+- `go test -count=1 ./...` bleibt erfolgreich.
+- Der produktive Go-Code bleibt unverändert.
+
+## Priorisierte Testerweiterungen
+
+### 1. `internal/usecases`
+
+Dieses Paket besitzt mit 868 offenen Statements die größte Lücke.
+
+- Die Provider MGCP, VAPD und VABD werden über ihren gesamten Lebenszyklus
+  getestet: Konstruktion, `AddFeatures`, Deskriptoren, nicht initialisierter
+  Zustand, Publish-Erfolg, Publish-Fehler, Invalidierung, Ablauf, `Close`,
+  Diagnose und Support-Events.
+- Der Monitoring-Wrapper erhält Tabellenfälle für Setup, alle Reads vor der
+  Initialisierung, Entity-Auswahl, Multi-Device-Fallback, Measurement-Filter
+  und die vollständige Klassifikationsmatrix für Temperatur, Energie und
+  Leistung.
+- DHW-, Room-Heating-, LPC- und OHPCF-Wrapper erhalten Lifecycle-Tests für
+  Setup, Use-Case-Registrierung, Support-Updates, mehrdeutige Entities,
+  Refresh-Fehler sowie erfolgreiche und abgelehnte Schreibvorgänge.
+- Die Geräteklassifikation wird für fehlende Daten, Device-Type-only,
+  Manufacturer-Details, alternative Entities und partielle Ergebnisse geprüft.
+
+### 2. `internal/grpc`
+
+- Fehlende Streamtests für DHW, DHW-Systemfunktion, Room Heating und OHPCF
+  prüfen SKI-Filter, Initialzustand, Kontextabbruch, Sendefehler und Events ohne
+  Payload.
+- Noch offene Get- und Snapshot-Endpunkte werden für Erfolg, nicht verfügbare
+  Daten und unbekannte SKIs geprüft.
+- Payload-Konverter werden mit vollständigen, partiellen und ungültigen Daten
+  getestet.
+- Tabellengetriebene Vertragstests prüfen `nil`-Requests, ungültige SKIs, nicht
+  initialisierte Controller und die erwarteten gRPC-Statuscodes.
+- Readiness-, Recovery- und Server-Info-Randfälle werden ergänzt.
+
+### 3. `internal/eebus`
+
+- Die Registry erhält direkte Tests für Trust-Status, Health-Projektionen,
+  Observation-Upserts, Entfernen einzelner Observations, bekannte Geräte,
+  Entity-Adressen und Feature-Normalisierung.
+- Der Bridge-Service wird für Konstruktion, Entity-Zugriffe,
+  Setup/Start/Shutdown und Remote-SKI-Registrierung getestet.
+- Callback-Pfade für Pairing und Auto-Trust sowie alle Logging-Adapter werden
+  ausgeführt und inhaltlich geprüft.
+- Recovery-Tests ergänzen Backoff-Grenzen, Zustandswechsel und fehlgeschlagene
+  Wiederherstellung.
+
+### 4. `internal/config` und `internal/certs`
+
+- Alle Environment-Overrides werden tabellengetrieben geprüft.
+- TLS-/Token-Kombinationen, fehlende Dateien, leere Tokens,
+  Provider-Zeitfenster und Bind-Adressen werden validiert.
+- Fehlerhafte, fehlende und nicht lesbare Konfigurations- und Zertifikatsdateien
+  werden geprüft.
+- Zertifikatstests decken ungültiges PEM, unpassende Schlüssel, fehlende SANs
+  und vorhandene DNS-/IP-SANs ab.
+
+### 5. Produktive CLI-Pakete
+
+- `eebus-watch` verwendet einen lokalen In-Process-gRPC-Server für
+  `collectSnapshot`, den `--once`-Ablauf, Registrierung sowie Debug- und
+  Fehlerpfade. `renderSnapshot` erhält Golden- beziehungsweise strukturelle
+  Ausgabetests für leere und vollständige Snapshots.
+- Der Bridge-Healthcheck wird gegen SERVING, NOT_SERVING, Verbindungsfehler und
+  TLS-Konfigurationen getestet.
+- Das Application-Setup wird für aktivierte Provider, Konfigurationsfehler,
+  Signalabbruch, Fehlerklassifikation und Lifecycle-Stages ergänzt.
+- Reine, nicht sinnvoll isolierbare `main()`-Statements dürfen innerhalb des
+  verbleibenden 5-%-Budgets offenbleiben.
+
+## Umsetzungsreihenfolge
+
+1. Gut isolierbare Guard-, Klassifikations- und Registry-Tests ergänzen.
+2. Provider- und Use-Case-Lebenszyklen mit vorhandenen SPINE-Fixtures testen.
+3. Fehlende gRPC-Adapter- und Streamverträge ergänzen.
+4. CLI- und Healthcheck-Integrationstests mit lokalen Servern ergänzen.
+5. Coverage erneut messen, verbleibende Blöcke nach fachlichem Risiko
+   priorisieren und die Baseline-Tabelle fortschreiben.

--- a/eebus-bridge/internal/certs/certs_internal_test.go
+++ b/eebus-bridge/internal/certs/certs_internal_test.go
@@ -1,0 +1,71 @@
+package certs
+
+import (
+	"crypto/tls"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	shipcert "github.com/enbility/ship-go/cert"
+)
+
+func TestEnsureCertificateRejectsInvalidExplicitAndStoredPairs(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "missing.pem")
+	if _, err := EnsureCertificate(missing, missing, "", false); err == nil {
+		t.Fatal("missing explicit certificate pair was accepted")
+	}
+
+	dir := t.TempDir()
+	for _, name := range []string{"cert.pem", "key.pem"} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("not PEM"), 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := EnsureCertificate("", "", dir, false); err == nil {
+		t.Fatal("invalid stored certificate pair was accepted")
+	}
+}
+
+func TestEnsureCertificateReportsPersistenceFailure(t *testing.T) {
+	storagePath := filepath.Join(t.TempDir(), "regular-file")
+	if err := os.WriteFile(storagePath, []byte("not a directory"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := EnsureCertificate("", "", storagePath, true); err == nil || !strings.Contains(err.Error(), "persisting certificate") {
+		t.Fatalf("error = %v, want persistence failure", err)
+	}
+}
+
+func TestPersistCertificateReportsCertificateAndKeyOpenErrors(t *testing.T) {
+	certificate, err := shipcert.CreateCertificate("test", "test", "DE", "cert-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	certBlocked := t.TempDir()
+	if err := os.Mkdir(filepath.Join(certBlocked, "cert.pem"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := persistCertificate(certificate, certBlocked); err == nil {
+		t.Fatal("certificate output directory was accepted as a file")
+	}
+
+	keyBlocked := t.TempDir()
+	if err := os.Mkdir(filepath.Join(keyBlocked, "key.pem"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := persistCertificate(certificate, keyBlocked); err == nil {
+		t.Fatal("key output directory was accepted as a file")
+	}
+}
+
+func TestSKIFromCertificateRejectsEmptyAndInvalidDER(t *testing.T) {
+	if _, err := SKIFromCertificate(tls.Certificate{}); err == nil || !strings.Contains(err.Error(), "empty certificate") {
+		t.Fatalf("empty certificate error = %v", err)
+	}
+	invalid := tls.Certificate{Certificate: [][]byte{[]byte("not DER")}}
+	if _, err := SKIFromCertificate(invalid); err == nil || !strings.Contains(err.Error(), "parsing certificate") {
+		t.Fatalf("invalid DER error = %v", err)
+	}
+}

--- a/eebus-bridge/internal/config/config_internal_test.go
+++ b/eebus-bridge/internal/config/config_internal_test.go
@@ -1,0 +1,225 @@
+package config
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestApplyEnvOverridesCoversEverySupportedValue(t *testing.T) {
+	values := map[string]string{
+		"EEBUS_GRPC_PORT":          "50052",
+		"EEBUS_GRPC_BIND":          "localhost",
+		"EEBUS_GRPC_REFLECTION":    "true",
+		"EEBUS_GRPC_SECURITY_MODE": "tls_token",
+		"EEBUS_GRPC_TLS_CERT_FILE": "/tls/cert.pem",
+		"EEBUS_GRPC_TLS_KEY_FILE":  "/tls/key.pem",
+		"EEBUS_GRPC_TOKEN_FILE":    "/tls/token",
+		"EEBUS_PORT":               "4713",
+		"EEBUS_VENDOR":             "Vendor",
+		"EEBUS_BRAND":              "Brand",
+		"EEBUS_MODEL":              "Model",
+		"EEBUS_SERIAL":             "Serial",
+		"EEBUS_CERT_FILE":          "/eebus/cert.pem",
+		"EEBUS_KEY_FILE":           "/eebus/key.pem",
+		"EEBUS_CERT_STORAGE":       "/eebus/storage",
+		"EEBUS_DEBUG_EVENTS":       "true",
+		"EEBUS_SHIP_LOG":           "true",
+		"EEBUS_SHIP_TRACE":         "true",
+		"EEBUS_EXP_MGCP_PROVIDER":  "true",
+		"EEBUS_EXP_VAPD_PROVIDER":  "true",
+		"EEBUS_EXP_VABD_PROVIDER":  "true",
+		"EEBUS_OHPCF_ENABLED":      "false",
+		"EEBUS_EXP_TRUST_SKI":      "AABBCCDDEEFF00112233445566778899AABBCCDD",
+	}
+	for name, value := range values {
+		t.Setenv(name, value)
+	}
+
+	cfg := defaultConfig()
+	applied, err := applyEnvOverrides(cfg)
+	if err != nil {
+		t.Fatalf("applyEnvOverrides: %v", err)
+	}
+	if len(applied) != len(values) {
+		t.Fatalf("applied overrides = %d, want %d: %v", len(applied), len(values), applied)
+	}
+	if cfg.GRPC.Port != 50052 || cfg.GRPC.Bind != "localhost" || !cfg.GRPC.EnableReflection {
+		t.Fatalf("gRPC overrides = %+v", cfg.GRPC)
+	}
+	if cfg.GRPC.Security.Mode != GRPCSecurityModeTLSToken || cfg.GRPC.Security.TokenFile != "/tls/token" {
+		t.Fatalf("security overrides = %+v", cfg.GRPC.Security)
+	}
+	if cfg.EEBUS.Port != 4713 || cfg.EEBUS.Vendor != "Vendor" || cfg.EEBUS.Serial != "Serial" {
+		t.Fatalf("EEBUS overrides = %+v", cfg.EEBUS)
+	}
+	if cfg.Certificates.CertFile != "/eebus/cert.pem" || cfg.Certificates.StoragePath != "/eebus/storage" {
+		t.Fatalf("certificate overrides = %+v", cfg.Certificates)
+	}
+	if !cfg.Logging.DebugEvents || !cfg.Logging.ShipLog || !cfg.Logging.ShipTrace {
+		t.Fatalf("logging overrides = %+v", cfg.Logging)
+	}
+	if !cfg.Experimental.MGCPProvider || !cfg.Experimental.VAPDProvider || !cfg.Experimental.VABDProvider {
+		t.Fatalf("provider overrides = %+v", cfg.Experimental)
+	}
+	if cfg.OHPCF.Enabled == nil || *cfg.OHPCF.Enabled {
+		t.Fatalf("OHPCF override = %v, want false", cfg.OHPCF.Enabled)
+	}
+}
+
+func TestApplyEnvOverridesRejectsEveryTypedError(t *testing.T) {
+	tests := map[string]string{
+		"EEBUS_GRPC_BIND":         "",
+		"EEBUS_DEBUG_EVENTS":      "invalid",
+		"EEBUS_SHIP_LOG":          "invalid",
+		"EEBUS_SHIP_TRACE":        "invalid",
+		"EEBUS_EXP_VAPD_PROVIDER": "invalid",
+		"EEBUS_EXP_VABD_PROVIDER": "invalid",
+		"EEBUS_OHPCF_ENABLED":     "invalid",
+		"EEBUS_PORT":              "not-a-port",
+	}
+	for name, value := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Setenv(name, value)
+			_, err := applyEnvOverrides(defaultConfig())
+			if err == nil || !strings.Contains(err.Error(), name) {
+				t.Fatalf("error = %v, want error naming %s", err, name)
+			}
+		})
+	}
+}
+
+func TestValidateCertificatesFromStorage(t *testing.T) {
+	autoGenerate := false
+	dir := t.TempDir()
+	cfg := CertificatesConfig{AutoGenerate: &autoGenerate, StoragePath: dir}
+	if err := validateCertificates(cfg); err == nil || !strings.Contains(err.Error(), "existing cert.pem") {
+		t.Fatalf("missing storage certificates error = %v", err)
+	}
+	for _, name := range []string{"cert.pem", "key.pem"} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("present"), 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := validateCertificates(cfg); err != nil {
+		t.Fatalf("existing storage certificates rejected: %v", err)
+	}
+	if !fileExists(filepath.Join(dir, "cert.pem")) || fileExists(filepath.Join(dir, "absent.pem")) {
+		t.Fatal("fileExists returned an unexpected result")
+	}
+}
+
+func TestValidateGRPCSecurityTLSTokenFiles(t *testing.T) {
+	certFile, keyFile := writeConfigTestCertificate(t)
+	base := GRPCConfig{Bind: "0.0.0.0", Security: GRPCSecurityConfig{
+		Mode: GRPCSecurityModeTLSToken, TLSCertFile: certFile, TLSKeyFile: keyFile,
+	}}
+
+	missingToken := base
+	missingToken.Security.TokenFile = filepath.Join(t.TempDir(), "missing-token")
+	if err := validateGRPCSecurity(missingToken); err == nil || !strings.Contains(err.Error(), "reading gRPC token") {
+		t.Fatalf("missing token error = %v", err)
+	}
+
+	emptyToken := filepath.Join(t.TempDir(), "empty-token")
+	if err := os.WriteFile(emptyToken, []byte(" \n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	empty := base
+	empty.Security.TokenFile = emptyToken
+	if err := validateGRPCSecurity(empty); err == nil || !strings.Contains(err.Error(), "is empty") {
+		t.Fatalf("empty token error = %v", err)
+	}
+
+	tokenFile := filepath.Join(t.TempDir(), "token")
+	if err := os.WriteFile(tokenFile, []byte("secret\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	valid := base
+	valid.Security.TokenFile = tokenFile
+	if err := validateGRPCSecurity(valid); err != nil {
+		t.Fatalf("valid TLS/token config rejected: %v", err)
+	}
+
+	invalidPair := valid
+	invalidPair.Security.TLSCertFile = tokenFile
+	if err := validateGRPCSecurity(invalidPair); err == nil || !strings.Contains(err.Error(), "loading gRPC TLS") {
+		t.Fatalf("invalid certificate error = %v", err)
+	}
+}
+
+func TestValidateSecurityAndProviderModes(t *testing.T) {
+	if err := validateGRPCSecurity(GRPCConfig{Bind: "127.0.0.1", Security: GRPCSecurityConfig{Mode: "unknown"}}); err == nil {
+		t.Fatal("unknown security mode was accepted")
+	}
+	for _, bind := range []string{"localhost", "LOCALHOST", "127.0.0.1", "::1"} {
+		if err := validateGRPCSecurity(GRPCConfig{Bind: bind, Security: GRPCSecurityConfig{Mode: GRPCSecurityModeLoopback}}); err != nil {
+			t.Fatalf("loopback bind %q rejected: %v", bind, err)
+		}
+	}
+
+	nonLoopback := GRPCConfig{Bind: "0.0.0.0", Security: GRPCSecurityConfig{Mode: GRPCSecurityModeLoopback}}
+	if err := validateProviderConfig(ExperimentalConfig{}, nonLoopback); err != nil {
+		t.Fatalf("disabled providers rejected: %v", err)
+	}
+	for _, experimental := range []ExperimentalConfig{
+		{MGCPProvider: true}, {VAPDProvider: true}, {VABDProvider: true},
+	} {
+		if err := validateProviderConfig(experimental, nonLoopback); err == nil {
+			t.Fatalf("provider config %+v accepted insecure non-loopback bind", experimental)
+		}
+	}
+	tlsMode := nonLoopback
+	tlsMode.Security.Mode = GRPCSecurityModeTLSToken
+	if err := validateProviderConfig(ExperimentalConfig{MGCPProvider: true}, tlsMode); err != nil {
+		t.Fatalf("TLS provider config rejected: %v", err)
+	}
+}
+
+func TestCanonicalSKIRejectsInvalidHexAndAcceptsCase(t *testing.T) {
+	if !isCanonicalSKI("aAbBcCdDeEfF00112233445566778899AABBCCDD") {
+		t.Fatal("mixed-case hexadecimal SKI was rejected")
+	}
+	if isCanonicalSKI("GABBCCDDEEFF00112233445566778899AABBCCDD") {
+		t.Fatal("non-hexadecimal SKI was accepted")
+	}
+}
+
+func writeConfigTestCertificate(t *testing.T) (string, string) {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1), Subject: pkix.Name{CommonName: "localhost"},
+		NotBefore: time.Now().Add(-time.Hour), NotAfter: time.Now().Add(time.Hour),
+		KeyUsage:    x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		DNSNames:    []string{"localhost"}, IPAddresses: []net.IP{net.ParseIP("127.0.0.1")},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := t.TempDir()
+	certFile := filepath.Join(dir, "server.crt")
+	keyFile := filepath.Join(dir, "server.key")
+	if err := os.WriteFile(certFile, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}), 0600); err != nil {
+		t.Fatal(err)
+	}
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)})
+	if err := os.WriteFile(keyFile, keyPEM, 0600); err != nil {
+		t.Fatal(err)
+	}
+	return certFile, keyFile
+}

--- a/eebus-bridge/internal/eebus/callbacks_test.go
+++ b/eebus-bridge/internal/eebus/callbacks_test.go
@@ -1,6 +1,7 @@
 package eebus_test
 
 import (
+	"errors"
 	"testing"
 	"time"
 
@@ -161,5 +162,45 @@ func TestCallbacksVisibleServicesUpdated(t *testing.T) {
 
 	if got := cb.DiscoveredServices(); len(got) != 1 || got[0].Ski != "abc" {
 		t.Errorf("DiscoveredServices() = %+v, want one entry with Ski=abc", got)
+	}
+}
+
+func TestCallbacksPairingAndTrustUpdates(t *testing.T) {
+	bus := eebus.NewEventBus()
+	events := bus.Subscribe()
+	defer bus.Unsubscribe(events)
+	registry := eebus.NewDeviceRegistry()
+	registry.AddDevice("ab:cd", eebus.DeviceInfo{})
+	callbacks := eebus.NewCallbacks(bus, true)
+	callbacks.SetRegistry(registry)
+	identity := shipapi.ServiceIdentity{SKI: "ab:cd"}
+
+	callbacks.ServiceUpdated(identity)
+	callbacks.ServicePairingDetailUpdate(identity, nil)
+	select {
+	case event := <-events:
+		if event.Type != eebus.EventTypePairingUpdated || event.SKI != "ABCD" {
+			t.Fatalf("pairing event = %+v", event)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for pairing event")
+	}
+
+	callbacks.ServiceAutoTrusted(nil, identity)
+	if health, ok := registry.DeviceHealth("ab:cd"); !ok || !health.Trusted {
+		t.Fatalf("trusted health = (%+v, %t)", health, ok)
+	}
+	callbacks.ServiceAutoTrustFailed(nil, identity, errors.New("pairing failed"))
+	if health, ok := registry.DeviceHealth("ab:cd"); !ok || health.Trusted {
+		t.Fatalf("failed-trust health = (%+v, %t)", health, ok)
+	}
+	callbacks.ServiceAutoTrustRemoved(nil, identity, "revoked")
+	select {
+	case event := <-events:
+		if event.Type != eebus.EventTypeDeviceTrustRemoved {
+			t.Fatalf("trust removal event = %+v", event)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for trust removal event")
 	}
 }

--- a/eebus-bridge/internal/eebus/registry_additional_test.go
+++ b/eebus-bridge/internal/eebus/registry_additional_test.go
@@ -1,0 +1,162 @@
+package eebus_test
+
+import (
+	"testing"
+	"time"
+
+	spineapi "github.com/enbility/spine-go/api"
+	"github.com/enbility/spine-go/mocks"
+	"github.com/enbility/spine-go/model"
+	"github.com/volschin/eebus-bridge/internal/eebus"
+)
+
+func TestRegistryTrustHealthAndMonitoringSuccessProjection(t *testing.T) {
+	start := time.Date(2026, time.July, 19, 12, 0, 0, 0, time.UTC)
+	clock := &fakeClock{now: start}
+	registry := eebus.NewDeviceRegistryWithClock(clock)
+
+	if _, ok := registry.DeviceHealth("ab:cd"); ok {
+		t.Fatal("unknown device returned a health projection")
+	}
+	if registry.MonitoringSuccessSince("ab:cd", start.Add(-time.Hour)) {
+		t.Fatal("unknown device reported a monitoring success")
+	}
+
+	registry.MarkTrusted("ab:cd")
+	health, ok := registry.DeviceHealth("ABCD")
+	if !ok {
+		t.Fatal("trusted device has no health projection")
+	}
+	if !health.TrustKnown || !health.Trusted || health.Connected {
+		t.Fatalf("health after MarkTrusted = %+v", health)
+	}
+	if health.LastTransitionAt != start {
+		t.Fatalf("transition = %v, want %v", health.LastTransitionAt, start)
+	}
+	if !registry.KnownDevice("ab-cd") {
+		t.Fatal("health-only device was not considered known")
+	}
+
+	clock.Advance(time.Minute)
+	registry.MarkConnected("ABCD")
+	clock.Advance(time.Minute)
+	since := clock.Now().Add(-time.Second)
+	registry.RecordMonitoringSuccess("ab cd")
+
+	health, ok = registry.DeviceHealth("abcd")
+	if !ok || !health.Connected || !health.MonitoringSuccessOnConnect {
+		t.Fatalf("health after monitoring success = %+v, ok=%t", health, ok)
+	}
+	if health.LastMonitoringSuccess != clock.Now() {
+		t.Fatalf("last success = %v, want %v", health.LastMonitoringSuccess, clock.Now())
+	}
+	if !registry.MonitoringSuccessSince("ABCD", since) {
+		t.Fatal("fresh monitoring success was not detected")
+	}
+	if registry.MonitoringSuccessSince("ABCD", clock.Now()) {
+		t.Fatal("success timestamp should be strictly after the comparison timestamp")
+	}
+}
+
+func TestRegistryUpsertAndRemoveObservationContract(t *testing.T) {
+	registry := eebus.NewDeviceRegistry()
+	feature := mocks.NewFeatureRemoteInterface(t)
+	feature.On("Type").Return(model.FeatureTypeTypeMeasurement)
+	feature.On("Role").Return(model.RoleTypeServer)
+
+	duplicateFeature := mocks.NewFeatureRemoteInterface(t)
+	duplicateFeature.On("Type").Return(model.FeatureTypeTypeMeasurement)
+	duplicateFeature.On("Role").Return(model.RoleTypeServer)
+
+	address := &model.EntityAddressType{Entity: []model.AddressEntityType{1, 2}}
+	entity := mocks.NewEntityRemoteInterface(t)
+	entity.On("Address").Return(address)
+	entity.On("EntityType").Return(model.EntityTypeTypeCompressor)
+	entity.On("Features").Return([]spineapi.FeatureRemoteInterface{nil, feature, duplicateFeature})
+
+	device := mocks.NewDeviceRemoteInterface(t)
+	device.On("Ski").Return("ab:cd")
+
+	registry.UpsertObservation("", device, entity, "monitoring")
+	registry.UpsertObservation("ABCD", device, entity, "monitoring")
+
+	info, ok := registry.GetDevice("ab-cd")
+	if !ok {
+		t.Fatal("observation did not create a device")
+	}
+	if info.SKI != "ABCD" || info.RemoteDevice != device {
+		t.Fatalf("device info = %+v", info)
+	}
+	if len(info.UseCases) != 1 || info.UseCases[0] != "monitoring" {
+		t.Fatalf("use cases = %v, want one monitoring entry", info.UseCases)
+	}
+	if len(info.RemoteEntities) != 1 || info.RemoteEntities[0] != entity {
+		t.Fatalf("remote entities = %v, want one deduplicated entity", info.RemoteEntities)
+	}
+	if len(info.Entities) != 1 {
+		t.Fatalf("entities = %+v, want one", info.Entities)
+	}
+	entityInfo := info.Entities[0]
+	if entityInfo.Address != "1:2" || entityInfo.Type != string(model.EntityTypeTypeCompressor) {
+		t.Fatalf("entity info = %+v", entityInfo)
+	}
+	if len(entityInfo.Features) != 1 || entityInfo.Features[0] != "Measurement/server" {
+		t.Fatalf("features = %v, want deduplicated Measurement/server", entityInfo.Features)
+	}
+	if got := registry.FirstEntityForType("ABCD", string(model.EntityTypeTypeCompressor)); got != entity {
+		t.Fatalf("FirstEntityForType = %v, want observed entity", got)
+	}
+	if got := registry.FirstEntityForType("ABCD", string(model.EntityTypeTypeCEM)); got != nil {
+		t.Fatalf("FirstEntityForType for missing type = %v, want nil", got)
+	}
+
+	registry.RemoveEntityObservation("ABCD", nil)
+	registry.RemoveEntityObservation("unknown", entity)
+	registry.RemoveEntityObservation("ab:cd", entity)
+	info, ok = registry.GetDevice("ABCD")
+	if !ok || len(info.RemoteEntities) != 0 || len(info.Entities) != 0 {
+		t.Fatalf("device after entity removal = %+v, ok=%t", info, ok)
+	}
+}
+
+func TestRegistryAddressAndFeatureFormatting(t *testing.T) {
+	if got := eebus.EntityAddressString(nil); got != "" {
+		t.Fatalf("nil address = %q", got)
+	}
+	if got := eebus.EntityAddressString(&model.EntityAddressType{}); got != "" {
+		t.Fatalf("empty address = %q", got)
+	}
+	address := &model.EntityAddressType{Entity: []model.AddressEntityType{0, 7, 42}}
+	if got := eebus.EntityAddressString(address); got != "0:7:42" {
+		t.Fatalf("address = %q, want 0:7:42", got)
+	}
+
+	if got := eebus.FeatureStrings(nil); len(got) != 0 {
+		t.Fatalf("nil features = %v", got)
+	}
+	client := mocks.NewFeatureRemoteInterface(t)
+	client.On("Type").Return(model.FeatureTypeTypeMeasurement)
+	client.On("Role").Return(model.RoleTypeClient)
+	server := mocks.NewFeatureRemoteInterface(t)
+	server.On("Type").Return(model.FeatureTypeTypeMeasurement)
+	server.On("Role").Return(model.RoleTypeServer)
+	got := eebus.FeatureStrings([]spineapi.FeatureRemoteInterface{nil, client, server, client})
+	want := []string{"Measurement/client", "Measurement/server"}
+	if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Fatalf("features = %v, want %v", got, want)
+	}
+}
+
+func TestRegistryKnownDeviceFromCatalogAndUnknownEntityType(t *testing.T) {
+	registry := eebus.NewDeviceRegistry()
+	if registry.KnownDevice("ab:cd") {
+		t.Fatal("empty registry considered device known")
+	}
+	registry.AddDevice("ab:cd", eebus.DeviceInfo{Brand: "Brand"})
+	if !registry.KnownDevice("ABCD") {
+		t.Fatal("catalog device was not considered known")
+	}
+	if got := registry.FirstEntityForType("unknown", "Compressor"); got != nil {
+		t.Fatalf("unknown device entity = %v, want nil", got)
+	}
+}

--- a/eebus-bridge/internal/eebus/service_additional_test.go
+++ b/eebus-bridge/internal/eebus/service_additional_test.go
@@ -1,0 +1,148 @@
+package eebus
+
+import (
+	"bytes"
+	"log"
+	"net"
+	"strings"
+	"testing"
+
+	shipcert "github.com/enbility/ship-go/cert"
+	"github.com/volschin/eebus-bridge/internal/config"
+)
+
+func TestBridgeServiceLifecycleAndEntities(t *testing.T) {
+	certificate, err := shipcert.CreateCertificate("test", "test", "DE", "bridge-service")
+	if err != nil {
+		t.Fatal(err)
+	}
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	port := listener.Addr().(*net.TCPAddr).Port
+	if err := listener.Close(); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.Config{
+		EEBUS: config.EEBUSConfig{Port: port, Vendor: "Test", Brand: "Test", Model: "Test", Serial: "bridge-service"},
+		Experimental: config.ExperimentalConfig{
+			MGCPProvider: true,
+			VAPDProvider: true,
+			VABDProvider: true,
+		},
+		Logging: config.LoggingConfig{ShipLog: true, ShipTrace: true},
+	}
+	bus := NewEventBus()
+	bridge, err := NewBridgeService(cfg, certificate, bus)
+	if err != nil {
+		t.Fatalf("NewBridgeService() error = %v", err)
+	}
+	if bridge.Service() == nil || bridge.Callbacks() == nil {
+		t.Fatalf("bridge dependencies are incomplete: %+v", bridge)
+	}
+	if err := bridge.Setup(); err != nil {
+		t.Fatalf("Setup() error = %v", err)
+	}
+	t.Cleanup(bridge.Shutdown)
+	if bridge.LocalEntity() == nil || bridge.GridEntity() == nil || bridge.PVEntity() == nil || bridge.BatteryEntity() == nil {
+		t.Fatalf("bridge entities are incomplete: %+v", bridge)
+	}
+	bridge.RegisterRemoteSKI("ab:cd")
+	bridge.UnregisterRemoteSKI("ab:cd")
+	if err := bridge.Start(); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+}
+
+func TestBridgeServiceWithoutProviderEntities(t *testing.T) {
+	certificate, err := shipcert.CreateCertificate("test", "test", "DE", "bridge-service-minimal")
+	if err != nil {
+		t.Fatal(err)
+	}
+	bridge, err := NewBridgeService(&config.Config{EEBUS: config.EEBUSConfig{
+		Port: 49879, Vendor: "Test", Brand: "Test", Model: "Test", Serial: "bridge-service-minimal",
+	}}, certificate, NewEventBus())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := bridge.Setup(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(bridge.Shutdown)
+	if bridge.GridEntity() != nil || bridge.PVEntity() != nil || bridge.BatteryEntity() != nil {
+		t.Fatal("provider entities were created while providers were disabled")
+	}
+}
+
+func TestShipLoggerForwardsEveryLevelAndTraceGate(t *testing.T) {
+	var output bytes.Buffer
+	previousWriter := log.Writer()
+	previousFlags := log.Flags()
+	log.SetOutput(&output)
+	log.SetFlags(0)
+	t.Cleanup(func() {
+		log.SetOutput(previousWriter)
+		log.SetFlags(previousFlags)
+	})
+
+	silentTrace := &shipLogger{}
+	silentTrace.Trace("hidden")
+	silentTrace.Tracef("hidden %d", 1)
+	if output.Len() != 0 {
+		t.Fatalf("disabled trace output = %q", output.String())
+	}
+
+	logger := &shipLogger{trace: true}
+	logger.Trace("trace")
+	logger.Tracef("trace %d", 2)
+	logger.Debug("debug")
+	logger.Debugf("debug %d", 3)
+	logger.Info("info")
+	logger.Infof("info %d", 4)
+	logger.Error("error")
+	logger.Errorf("error %d", 5)
+	for _, marker := range []string{"[SHIP TRACE]", "[SHIP DEBUG]", "[SHIP INFO]", "[SHIP ERROR]"} {
+		if !strings.Contains(output.String(), marker) {
+			t.Fatalf("log output %q does not contain %q", output.String(), marker)
+		}
+	}
+}
+
+func TestTrustControllerRegistrationAndDependencyGuards(t *testing.T) {
+	registry := NewDeviceRegistry()
+	bus := NewEventBus()
+	bridge := &recordingRemoteTrustService{registry: registry, events: bus.Subscribe()}
+	defer bus.Unsubscribe(bridge.events)
+	controller := &TrustController{bridge: bridge, registry: registry, bus: bus}
+	if err := controller.RegisterSKI("ab:cd"); err != nil {
+		t.Fatalf("RegisterSKI() error = %v", err)
+	}
+	if len(bridge.registerCalls) != 1 || bridge.registerCalls[0] != "ab:cd" {
+		t.Fatalf("register calls = %v", bridge.registerCalls)
+	}
+	if snapshot, ok := registry.DeviceHealth("ab:cd"); !ok || !snapshot.Trusted {
+		t.Fatalf("registered device health = (%+v, %t)", snapshot, ok)
+	}
+
+	if err := (*TrustController)(nil).RegisterSKI("ab:cd"); err == nil {
+		t.Fatal("nil controller RegisterSKI() succeeded")
+	}
+	if err := NewTrustController(nil, registry, bus).RegisterSKI("ab:cd"); err == nil {
+		t.Fatal("controller without bridge RegisterSKI() succeeded")
+	}
+	if got := NewTrustController(&BridgeService{}, registry, bus); got.bridge == nil {
+		t.Fatal("NewTrustController() discarded bridge")
+	}
+
+	checks := []*TrustController{
+		nil,
+		{bridge: bridge},
+		{bridge: bridge, registry: registry},
+	}
+	for index, check := range checks {
+		if err := check.UnregisterSKI("ab:cd"); err == nil {
+			t.Fatalf("UnregisterSKI dependency check %d succeeded", index)
+		}
+	}
+}

--- a/eebus-bridge/internal/grpc/domain_streams_additional_test.go
+++ b/eebus-bridge/internal/grpc/domain_streams_additional_test.go
@@ -1,0 +1,145 @@
+package grpc
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	spineapi "github.com/enbility/spine-go/api"
+	"github.com/enbility/spine-go/mocks"
+	pb "github.com/volschin/eebus-bridge/gen/proto/eebus/v1"
+	"github.com/volschin/eebus-bridge/internal/eebus"
+	"github.com/volschin/eebus-bridge/internal/usecases"
+	grpcclient "google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+type fakeRoomSystemFunctionController struct {
+	entity spineapi.EntityRemoteInterface
+	state  usecases.RoomHeatingSystemFunctionState
+}
+
+func (f *fakeRoomSystemFunctionController) CompatibleEntity(string) eebus.EntityResolution {
+	return eebus.EntityResolution{Entity: f.entity, DeviceCount: 1}
+}
+
+func (f *fakeRoomSystemFunctionController) State(spineapi.EntityRemoteInterface) (usecases.RoomHeatingSystemFunctionState, error) {
+	return f.state, nil
+}
+
+func (*fakeRoomSystemFunctionController) WriteOperationMode(context.Context, spineapi.EntityRemoteInterface, string) error {
+	return nil
+}
+
+func TestDomainEventStreamsTranslateAndAttachPayloads(t *testing.T) {
+	bus := eebus.NewEventBus()
+	entity := mocks.NewEntityRemoteInterface(t)
+	dhw := NewDHWService(
+		&fakeDHWController{entity: entity, state: usecases.DHWSetpoint{Value: 46, Writable: true}},
+		&fakeDHWSysFnController{entity: entity, state: usecases.DHWSystemFunctionState{
+			BoostStatus: "active", OperationMode: "auto", AvailableModes: []string{"auto", "off"}, ModeWritable: true,
+		}},
+		bus,
+	)
+	hvac := NewHVACService(
+		&fakeRoomHeatingTemp{entity: entity, state: usecases.RoomHeatingSetpoint{Value: 21, Writable: true}},
+		&fakeRoomSystemFunctionController{entity: entity, state: usecases.RoomHeatingSystemFunctionState{
+			OperationMode: "auto", AvailableModes: []string{"auto", "off"}, ModeWritable: true,
+		}},
+		fixedTemperatureReader{value: 20.5},
+		bus,
+	)
+	ohpcf := NewOHPCFService(nil, bus, nil, WithOHPCFController(partialOHPCFController{entity: entity}))
+
+	server := NewServer("127.0.0.1", 0, false)
+	pb.RegisterDHWServiceServer(server.GRPCServer(), dhw)
+	pb.RegisterHVACServiceServer(server.GRPCServer(), hvac)
+	pb.RegisterOHPCFServiceServer(server.GRPCServer(), ohpcf)
+	server.SetHealthy(true)
+	go func() { _ = server.Start() }()
+	t.Cleanup(server.Stop)
+	readyCtx, readyCancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer readyCancel()
+	if err := server.WaitReady(readyCtx); err != nil {
+		t.Fatalf("server readiness: %v", err)
+	}
+
+	connection, err := grpcclient.NewClient(server.Addr(), grpcclient.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer connection.Close()
+	streamCtx, streamCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer streamCancel()
+	request := &pb.DeviceRequest{Ski: testValidSKI}
+	dhwEvents, err := pb.NewDHWServiceClient(connection).SubscribeDHWEvents(streamCtx, request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dhwSystemEvents, err := pb.NewDHWServiceClient(connection).SubscribeDHWSystemFunctionEvents(streamCtx, request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	hvacEvents, err := pb.NewHVACServiceClient(connection).SubscribeRoomHeatingEvents(streamCtx, request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ohpcfEvents, err := pb.NewOHPCFServiceClient(connection).SubscribeOHPCFEvents(streamCtx, request)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Allow all server handlers to install their EventBus subscriptions.
+	time.Sleep(50 * time.Millisecond)
+
+	for _, eventType := range []eebus.EventType{
+		eebus.EventTypeDHWUseCaseSupportUpdated,
+		eebus.EventTypeDHWSetpointUpdated,
+	} {
+		bus.Publish(eebus.Event{SKI: testValidSKI, Type: eventType})
+		event, recvErr := dhwEvents.Recv()
+		if recvErr != nil || event.GetSetpoint() == nil {
+			t.Fatalf("DHW event %q = (%+v, %v)", eventType, event, recvErr)
+		}
+	}
+	for _, eventType := range []eebus.EventType{
+		eebus.EventTypeDHWSystemFunctionSupportUpdated,
+		eebus.EventTypeDHWSystemFunctionUpdated,
+	} {
+		bus.Publish(eebus.Event{SKI: testValidSKI, Type: eventType})
+		event, recvErr := dhwSystemEvents.Recv()
+		if recvErr != nil || event.GetState() == nil {
+			t.Fatalf("DHW system event %q = (%+v, %v)", eventType, event, recvErr)
+		}
+	}
+	for _, eventType := range []eebus.EventType{
+		eebus.EventTypeRoomHeatingUseCaseSupportUpdated,
+		eebus.EventTypeRoomHeatingSystemFunctionSupportUpdated,
+		eebus.EventTypeRoomTemperatureUpdated,
+		eebus.EventTypeRoomHeatingSetpointUpdated,
+		eebus.EventTypeRoomHeatingSystemFunctionUpdated,
+	} {
+		bus.Publish(eebus.Event{SKI: testValidSKI, Type: eventType})
+		event, recvErr := hvacEvents.Recv()
+		if recvErr != nil || event.GetState() == nil {
+			t.Fatalf("HVAC event %q = (%+v, %v)", eventType, event, recvErr)
+		}
+	}
+	for _, eventType := range []eebus.EventType{
+		eebus.EventTypeOHPCFUseCaseSupportUpdated,
+		eebus.EventTypeOHPCFConsumptionStateUpdated,
+		eebus.EventTypeOHPCFConsumptionStoppableUpdated,
+		eebus.EventTypeOHPCFConsumptionPausableUpdated,
+		eebus.EventTypeOHPCFConsumptionStartTimeUpdated,
+		eebus.EventTypeOHPCFRequestedPowerEstimateUpdated,
+		eebus.EventTypeOHPCFRequestedPowerMaxUpdated,
+		eebus.EventTypeOHPCFMinimalRunDurationUpdated,
+		eebus.EventTypeOHPCFMinimalPauseDurationUpdated,
+	} {
+		bus.Publish(eebus.Event{SKI: testValidSKI, Type: eventType})
+		event, recvErr := ohpcfEvents.Recv()
+		if recvErr != nil || event.GetFlexibility() == nil {
+			t.Fatalf("OHPCF event %q = (%+v, %v)", eventType, event, recvErr)
+		}
+	}
+}

--- a/eebus-bridge/internal/grpc/lpc_service_test.go
+++ b/eebus-bridge/internal/grpc/lpc_service_test.go
@@ -2,6 +2,7 @@ package grpc_test
 
 import (
 	"context"
+	"errors"
 	"math"
 	"testing"
 	"time"
@@ -49,6 +50,156 @@ func (fakeLPCController) StopHeartbeat() error        { return nil }
 func (fakeLPCController) IsHeartbeatRunning() bool    { return true }
 func (fakeLPCController) IsHeartbeatWithinDuration(spineapi.EntityRemoteInterface) bool {
 	return true
+}
+
+type recordingLPCController struct {
+	fakeLPCController
+	consumptionErr        error
+	failsafePowerErr      error
+	failsafeDurationErr   error
+	writeConsumptionErr   error
+	writeFailsafePowerErr error
+	writeFailsafeTimeErr  error
+	startErr              error
+	stopErr               error
+	writtenLimit          ucapi.LoadLimit
+	writtenFailsafePower  float64
+	writtenDuration       time.Duration
+	startedSKI            string
+	stopCalls             int
+}
+
+func (f *recordingLPCController) ConsumptionLimit(spineapi.EntityRemoteInterface) (ucapi.LoadLimit, error) {
+	return ucapi.LoadLimit{Value: 1200, Duration: 2 * time.Minute, IsActive: true, IsChangeable: true}, f.consumptionErr
+}
+func (f *recordingLPCController) WriteConsumptionLimit(_ spineapi.EntityRemoteInterface, limit ucapi.LoadLimit) error {
+	f.writtenLimit = limit
+	return f.writeConsumptionErr
+}
+func (f *recordingLPCController) FailsafeConsumptionActivePowerLimit(spineapi.EntityRemoteInterface) (float64, error) {
+	return 2400, f.failsafePowerErr
+}
+func (f *recordingLPCController) WriteFailsafeConsumptionActivePowerLimit(_ spineapi.EntityRemoteInterface, value float64) error {
+	f.writtenFailsafePower = value
+	return f.writeFailsafePowerErr
+}
+func (f *recordingLPCController) FailsafeDurationMinimum(spineapi.EntityRemoteInterface) (time.Duration, error) {
+	return 90 * time.Second, f.failsafeDurationErr
+}
+func (f *recordingLPCController) WriteFailsafeDurationMinimum(_ spineapi.EntityRemoteInterface, duration time.Duration) error {
+	f.writtenDuration = duration
+	return f.writeFailsafeTimeErr
+}
+func (f *recordingLPCController) StartHeartbeat(ski string) error {
+	f.startedSKI = ski
+	return f.startErr
+}
+func (f *recordingLPCController) StopHeartbeat() error {
+	f.stopCalls++
+	return f.stopErr
+}
+
+func TestLPCRPCsReadWriteAndHeartbeat(t *testing.T) {
+	registry := eebus.NewDeviceRegistry()
+	registry.AddDevice(testValidSKI, eebus.DeviceInfo{})
+	controller := &recordingLPCController{fakeLPCController: fakeLPCController{entity: mocks.NewEntityRemoteInterface(t)}}
+	svc := bridgegrpc.NewLPCService(nil, eebus.NewEventBus(), registry, bridgegrpc.WithLPCController(controller))
+	ctx := context.Background()
+
+	limit, err := svc.GetConsumptionLimit(ctx, &pb.DeviceRequest{Ski: testValidSKI})
+	if err != nil || limit.GetValueWatts() != 1200 || limit.GetDurationSeconds() != 120 || !limit.GetIsActive() || !limit.GetIsChangeable() {
+		t.Fatalf("GetConsumptionLimit() = (%+v, %v)", limit, err)
+	}
+	if _, err := svc.WriteConsumptionLimit(ctx, &pb.WriteLoadLimitRequest{
+		Ski: testValidSKI, ValueWatts: 750, DurationSeconds: 30, IsActive: true,
+	}); err != nil {
+		t.Fatalf("WriteConsumptionLimit() error = %v", err)
+	}
+	if controller.writtenLimit.Value != 750 || controller.writtenLimit.Duration != 30*time.Second || !controller.writtenLimit.IsActive {
+		t.Fatalf("written limit = %+v", controller.writtenLimit)
+	}
+
+	failsafe, err := svc.GetFailsafeLimit(ctx, &pb.DeviceRequest{Ski: testValidSKI})
+	if err != nil || failsafe.GetValueWatts() != 2400 || failsafe.GetDurationMinimumSeconds() != 90 {
+		t.Fatalf("GetFailsafeLimit() = (%+v, %v)", failsafe, err)
+	}
+	if _, err := svc.WriteFailsafeLimit(ctx, &pb.WriteFailsafeLimitRequest{
+		Ski: testValidSKI, ValueWatts: 1800, DurationMinimumSeconds: 45,
+	}); err != nil {
+		t.Fatalf("WriteFailsafeLimit() error = %v", err)
+	}
+	if controller.writtenFailsafePower != 1800 || controller.writtenDuration != 45*time.Second {
+		t.Fatalf("written failsafe = (%g, %s)", controller.writtenFailsafePower, controller.writtenDuration)
+	}
+
+	if _, err := svc.StartHeartbeat(ctx, &pb.DeviceRequest{Ski: testValidSKI}); err != nil {
+		t.Fatalf("StartHeartbeat() error = %v", err)
+	}
+	if _, err := svc.StopHeartbeat(ctx, &pb.DeviceRequest{Ski: testValidSKI}); err != nil {
+		t.Fatalf("StopHeartbeat() error = %v", err)
+	}
+	if controller.startedSKI != testValidSKI || controller.stopCalls != 1 {
+		t.Fatalf("heartbeat calls = start %q, stop %d", controller.startedSKI, controller.stopCalls)
+	}
+	statusResult, err := svc.GetHeartbeatStatus(ctx, &pb.DeviceRequest{Ski: testValidSKI})
+	if err != nil || !statusResult.GetRunning() || !statusResult.GetWithinDuration() {
+		t.Fatalf("GetHeartbeatStatus() = (%+v, %v)", statusResult, err)
+	}
+}
+
+func TestLPCRPCReadAndWriteErrors(t *testing.T) {
+	want := errors.New("controller failure")
+	registry := eebus.NewDeviceRegistry()
+	registry.AddDevice(testValidSKI, eebus.DeviceInfo{})
+	controller := &recordingLPCController{fakeLPCController: fakeLPCController{entity: mocks.NewEntityRemoteInterface(t)}}
+	svc := bridgegrpc.NewLPCService(nil, nil, registry, bridgegrpc.WithLPCController(controller))
+	ctx := context.Background()
+
+	checks := []struct {
+		name string
+		set  func()
+		call func() error
+	}{
+		{"read consumption", func() { controller.consumptionErr = want }, func() error { _, err := svc.GetConsumptionLimit(ctx, &pb.DeviceRequest{Ski: testValidSKI}); return err }},
+		{"write consumption", func() { controller.consumptionErr = nil; controller.writeConsumptionErr = want }, func() error {
+			_, err := svc.WriteConsumptionLimit(ctx, &pb.WriteLoadLimitRequest{Ski: testValidSKI})
+			return err
+		}},
+		{"read failsafe power", func() { controller.writeConsumptionErr = nil; controller.failsafePowerErr = want }, func() error { _, err := svc.GetFailsafeLimit(ctx, &pb.DeviceRequest{Ski: testValidSKI}); return err }},
+		{"read failsafe duration", func() { controller.failsafePowerErr = nil; controller.failsafeDurationErr = want }, func() error { _, err := svc.GetFailsafeLimit(ctx, &pb.DeviceRequest{Ski: testValidSKI}); return err }},
+		{"write failsafe power", func() { controller.failsafeDurationErr = nil; controller.writeFailsafePowerErr = want }, func() error {
+			_, err := svc.WriteFailsafeLimit(ctx, &pb.WriteFailsafeLimitRequest{Ski: testValidSKI})
+			return err
+		}},
+		{"write failsafe duration", func() { controller.writeFailsafePowerErr = nil; controller.writeFailsafeTimeErr = want }, func() error {
+			_, err := svc.WriteFailsafeLimit(ctx, &pb.WriteFailsafeLimitRequest{Ski: testValidSKI, DurationMinimumSeconds: 1})
+			return err
+		}},
+		{"start heartbeat", func() { controller.writeFailsafeTimeErr = nil; controller.startErr = want }, func() error { _, err := svc.StartHeartbeat(ctx, &pb.DeviceRequest{Ski: testValidSKI}); return err }},
+		{"stop heartbeat", func() { controller.startErr = nil; controller.stopErr = want }, func() error { _, err := svc.StopHeartbeat(ctx, &pb.DeviceRequest{Ski: testValidSKI}); return err }},
+	}
+	for _, check := range checks {
+		t.Run(check.name, func(t *testing.T) {
+			check.set()
+			if err := check.call(); err == nil {
+				t.Fatal("expected controller error")
+			}
+		})
+	}
+
+	empty := bridgegrpc.NewLPCService(nil, nil, nil)
+	if _, err := empty.GetConsumptionLimit(ctx, nil); status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("nil consumption request code = %v", status.Code(err))
+	}
+	if _, err := empty.GetFailsafeLimit(ctx, nil); status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("nil failsafe request code = %v", status.Code(err))
+	}
+	if _, err := empty.GetConsumptionLimit(ctx, &pb.DeviceRequest{Ski: testValidSKI}); status.Code(err) != codes.Unavailable {
+		t.Fatalf("uninitialized consumption code = %v", status.Code(err))
+	}
+	if _, err := empty.GetFailsafeLimit(ctx, &pb.DeviceRequest{Ski: testValidSKI}); status.Code(err) != codes.Unavailable {
+		t.Fatalf("uninitialized failsafe code = %v", status.Code(err))
+	}
 }
 
 func TestLPCPayloadReadsUpdateCapabilityRegistry(t *testing.T) {

--- a/eebus-bridge/internal/grpc/monitoring_service_test.go
+++ b/eebus-bridge/internal/grpc/monitoring_service_test.go
@@ -35,6 +35,8 @@ type fakeDeviceOperatingStateReader struct {
 type fakeMonitoringReader struct {
 	entity          spineapi.EntityRemoteInterface
 	compatibleCalls int
+	powerErr        error
+	energyErr       error
 	powerPhaseErr   error
 }
 
@@ -43,16 +45,16 @@ func (f *fakeMonitoringReader) CompatibleEntity(string) eebus.EntityResolution {
 	return eebus.EntityResolution{Entity: f.entity, DeviceCount: 1}
 }
 
-func (*fakeMonitoringReader) Power(spineapi.EntityRemoteInterface) (float64, error) {
-	return 600, nil
+func (f *fakeMonitoringReader) Power(spineapi.EntityRemoteInterface) (float64, error) {
+	return 600, f.powerErr
 }
 
 func (f *fakeMonitoringReader) PowerPerPhase(spineapi.EntityRemoteInterface) ([]float64, error) {
 	return []float64{100, 200, 300}, f.powerPhaseErr
 }
 
-func (*fakeMonitoringReader) EnergyConsumed(spineapi.EntityRemoteInterface) (float64, error) {
-	return 42, nil
+func (f *fakeMonitoringReader) EnergyConsumed(spineapi.EntityRemoteInterface) (float64, error) {
+	return 42, f.energyErr
 }
 
 func (*fakeMonitoringReader) EnergyProduced(spineapi.EntityRemoteInterface) (float64, error) {
@@ -81,6 +83,94 @@ func (f fakeDeviceOperatingStateReader) OperatingState(string) (string, error) {
 
 func (f fakeDeviceOperatingStateReader) CachedOperatingState(string) (string, error) {
 	return f.value, f.err
+}
+
+func TestMonitoringScalarRPCsAndSnapshot(t *testing.T) {
+	reader := &fakeMonitoringReader{entity: mocks.NewEntityRemoteInterface(t)}
+	svc := bridgegrpc.NewMonitoringService(
+		reader,
+		bridgegrpc.MonitoringReaders{},
+		eebus.NewEventBus(),
+		eebus.NewDeviceRegistry(),
+		true,
+	)
+
+	power, err := svc.GetPowerConsumption(context.Background(), &pb.DeviceRequest{Ski: testValidSKI})
+	if err != nil || power.GetWatts() != 600 || power.GetTimestamp() == nil {
+		t.Fatalf("GetPowerConsumption() = (%+v, %v)", power, err)
+	}
+	energy, err := svc.GetEnergyConsumed(context.Background(), &pb.DeviceRequest{Ski: testValidSKI})
+	if err != nil || energy.GetKilowattHours() != 42 || energy.GetTimestamp() == nil {
+		t.Fatalf("GetEnergyConsumed() = (%+v, %v)", energy, err)
+	}
+	measurements, err := svc.SnapshotMeasurements(testValidSKI)
+	if err != nil || len(measurements.GetMeasurements()) != 13 {
+		t.Fatalf("SnapshotMeasurements() = (%+v, %v)", measurements, err)
+	}
+	if reader.compatibleCalls != 3 {
+		t.Fatalf("compatible entity calls = %d, want 3", reader.compatibleCalls)
+	}
+}
+
+func TestMonitoringScalarRPCValidationAndReadFailures(t *testing.T) {
+	ctx := context.Background()
+	empty := bridgegrpc.NewMonitoringService(nil, bridgegrpc.MonitoringReaders{}, nil, nil)
+	for name, call := range map[string]func() error{
+		"nil power request": func() error {
+			_, err := empty.GetPowerConsumption(ctx, nil)
+			return err
+		},
+		"nil energy request": func() error {
+			_, err := empty.GetEnergyConsumed(ctx, nil)
+			return err
+		},
+		"nil measurements request": func() error {
+			_, err := empty.GetMeasurements(ctx, nil)
+			return err
+		},
+		"invalid snapshot ski": func() error {
+			_, err := empty.SnapshotMeasurements("not-a-ski")
+			return err
+		},
+		"invalid snapshot state ski": func() error {
+			_, _, err := empty.SnapshotMeasurementsWithStates("not-a-ski")
+			return err
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if code := status.Code(call()); code != codes.InvalidArgument {
+				t.Fatalf("status code = %v, want InvalidArgument", code)
+			}
+		})
+	}
+	if _, err := empty.GetPowerConsumption(ctx, &pb.DeviceRequest{Ski: testValidSKI}); status.Code(err) != codes.Unavailable {
+		t.Fatalf("GetPowerConsumption() code = %v, want Unavailable", status.Code(err))
+	}
+	if _, err := empty.GetEnergyConsumed(ctx, &pb.DeviceRequest{Ski: testValidSKI}); status.Code(err) != codes.Unavailable {
+		t.Fatalf("GetEnergyConsumed() code = %v, want Unavailable", status.Code(err))
+	}
+	if _, err := empty.SnapshotMeasurements(testValidSKI); status.Code(err) != codes.Unavailable {
+		t.Fatalf("SnapshotMeasurements() code = %v, want Unavailable", status.Code(err))
+	}
+
+	reader := &fakeMonitoringReader{
+		entity:    mocks.NewEntityRemoteInterface(t),
+		powerErr:  errors.New("power cache failed"),
+		energyErr: status.Error(codes.Unimplemented, "energy not supported"),
+	}
+	svc := bridgegrpc.NewMonitoringService(reader, bridgegrpc.MonitoringReaders{}, nil, nil, true)
+	if _, err := svc.GetPowerConsumption(ctx, &pb.DeviceRequest{Ski: testValidSKI}); status.Code(err) != codes.Internal {
+		t.Fatalf("power read code = %v, want Internal", status.Code(err))
+	}
+	if _, err := svc.GetEnergyConsumed(ctx, &pb.DeviceRequest{Ski: testValidSKI}); status.Code(err) != codes.Unimplemented {
+		t.Fatalf("energy read code = %v, want Unimplemented", status.Code(err))
+	}
+
+	var typedNil *usecases.MonitoringWrapper
+	typedNilService := bridgegrpc.NewMonitoringService(typedNil, bridgegrpc.MonitoringReaders{}, nil, nil)
+	if _, err := typedNilService.GetPowerConsumption(ctx, &pb.DeviceRequest{Ski: testValidSKI}); status.Code(err) != codes.Unavailable {
+		t.Fatalf("typed-nil monitoring code = %v, want Unavailable", status.Code(err))
+	}
 }
 
 func TestSnapshotMeasurementsClassifiesPartialReadFailuresPerLeaf(t *testing.T) {

--- a/eebus-bridge/internal/grpc/ohpcf_service_additional_test.go
+++ b/eebus-bridge/internal/grpc/ohpcf_service_additional_test.go
@@ -1,0 +1,182 @@
+package grpc
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	eebusapi "github.com/enbility/eebus-go/api"
+	ucapi "github.com/enbility/eebus-go/usecases/api"
+	spineapi "github.com/enbility/spine-go/api"
+	"github.com/enbility/spine-go/mocks"
+	pb "github.com/volschin/eebus-bridge/gen/proto/eebus/v1"
+	"github.com/volschin/eebus-bridge/internal/eebus"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+type failingOHPCFController struct {
+	entity spineapi.EntityRemoteInterface
+	err    error
+}
+
+func (f failingOHPCFController) CompatibleEntity(string) eebus.EntityResolution {
+	return eebus.EntityResolution{Entity: f.entity, DeviceCount: 1}
+}
+func (f failingOHPCFController) OptionalPowerConsumptionAvailable(spineapi.EntityRemoteInterface) (bool, error) {
+	return false, f.err
+}
+func (f failingOHPCFController) RequestedPowerEstimate(spineapi.EntityRemoteInterface) (float64, error) {
+	return 0, f.err
+}
+func (f failingOHPCFController) RequestedPowerMax(spineapi.EntityRemoteInterface) (float64, error) {
+	return 0, f.err
+}
+func (f failingOHPCFController) ConsumptionIsStoppable(spineapi.EntityRemoteInterface) (bool, error) {
+	return false, f.err
+}
+func (f failingOHPCFController) ConsumptionIsPausable(spineapi.EntityRemoteInterface) (bool, error) {
+	return false, f.err
+}
+func (f failingOHPCFController) ConsumptionState(spineapi.EntityRemoteInterface) (ucapi.CompressorPowerConsumptionStateType, error) {
+	return "", f.err
+}
+func (f failingOHPCFController) ConsumptionStartTime(spineapi.EntityRemoteInterface) (time.Time, error) {
+	return time.Time{}, f.err
+}
+func (f failingOHPCFController) MinimalRunDuration(spineapi.EntityRemoteInterface) (time.Duration, error) {
+	return 0, f.err
+}
+func (f failingOHPCFController) MinimalPauseDuration(spineapi.EntityRemoteInterface) (time.Duration, error) {
+	return 0, f.err
+}
+func (f failingOHPCFController) Schedule(spineapi.EntityRemoteInterface, time.Time) error {
+	return f.err
+}
+func (f failingOHPCFController) Pause(spineapi.EntityRemoteInterface) error  { return f.err }
+func (f failingOHPCFController) Resume(spineapi.EntityRemoteInterface) error { return f.err }
+func (f failingOHPCFController) Abort(spineapi.EntityRemoteInterface) error  { return f.err }
+
+func TestOHPCFServiceGetFlexibilityContracts(t *testing.T) {
+	ctx := context.Background()
+	empty := NewOHPCFService(nil, eebus.NewEventBus(), eebus.NewDeviceRegistry())
+	for name, request := range map[string]*pb.DeviceRequest{
+		"nil":             nil,
+		"malformed SKI":   {Ski: "invalid"},
+		"not initialized": {Ski: testValidSKI},
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, err := empty.GetCompressorFlexibility(ctx, request)
+			if err == nil {
+				t.Fatal("GetCompressorFlexibility returned nil error")
+			}
+		})
+	}
+
+	entity := mocks.NewEntityRemoteInterface(t)
+	controller := partialOHPCFController{entity: entity}
+	registry := eebus.NewDeviceRegistry()
+	registry.AddDevice(testValidSKI, eebus.DeviceInfo{})
+	service := NewOHPCFService(nil, eebus.NewEventBus(), registry, WithOHPCFController(controller))
+	result, err := service.GetCompressorFlexibility(ctx, &pb.DeviceRequest{Ski: testValidSKI})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.GetAvailable() || result.GetRequestedPowerEstimateW() != 1000 || result.GetRequestedPowerMaxW() != 2000 ||
+		!result.GetIsPausable() || result.GetState() != pb.CompressorPowerConsumptionState_COMPRESSOR_STATE_RUNNING ||
+		result.GetMinimalRunSeconds() != 60 || result.GetMinimalPauseSeconds() != 120 || result.GetStartTime() == nil {
+		t.Fatalf("flexibility = %+v", result)
+	}
+
+	failing := NewOHPCFService(nil, eebus.NewEventBus(), registry, WithOHPCFController(failingOHPCFController{
+		entity: entity, err: eebusapi.ErrDataNotAvailable,
+	}))
+	if _, err := failing.GetCompressorFlexibility(ctx, &pb.DeviceRequest{Ski: testValidSKI}); status.Code(err) != codes.Unavailable {
+		t.Fatalf("all-failed status = %s, error=%v", status.Code(err), err)
+	}
+}
+
+func TestOHPCFServiceControlContracts(t *testing.T) {
+	ctx := context.Background()
+	entity := mocks.NewEntityRemoteInterface(t)
+	service := NewOHPCFService(nil, eebus.NewEventBus(), nil, WithOHPCFController(partialOHPCFController{entity: entity}))
+
+	invalid := []*pb.ControlCompressorRequest{
+		nil,
+		{},
+		{Ski: testValidSKI},
+	}
+	for _, request := range invalid {
+		if _, err := service.ControlCompressorFlexibility(ctx, request); status.Code(err) != codes.InvalidArgument {
+			t.Fatalf("request %+v status = %s, error=%v", request, status.Code(err), err)
+		}
+	}
+
+	start := timestamppb.New(time.Now().Add(time.Minute))
+	for _, request := range []*pb.ControlCompressorRequest{
+		{Ski: testValidSKI, Action: pb.OHPCFAction_OHPCF_ACTION_SCHEDULE},
+		{Ski: testValidSKI, Action: pb.OHPCFAction_OHPCF_ACTION_SCHEDULE, StartTime: start},
+		{Ski: testValidSKI, Action: pb.OHPCFAction_OHPCF_ACTION_PAUSE},
+		{Ski: testValidSKI, Action: pb.OHPCFAction_OHPCF_ACTION_RESUME},
+		{Ski: testValidSKI, Action: pb.OHPCFAction_OHPCF_ACTION_ABORT},
+	} {
+		if _, err := service.ControlCompressorFlexibility(ctx, request); err != nil {
+			t.Fatalf("action %s: %v", request.Action, err)
+		}
+	}
+
+	notInitialized := NewOHPCFService(nil, eebus.NewEventBus(), nil)
+	if _, err := notInitialized.ControlCompressorFlexibility(ctx, &pb.ControlCompressorRequest{
+		Ski: testValidSKI, Action: pb.OHPCFAction_OHPCF_ACTION_PAUSE,
+	}); status.Code(err) != codes.Unavailable {
+		t.Fatalf("not initialized status = %s", status.Code(err))
+	}
+	want := errors.New("control failed")
+	failing := NewOHPCFService(nil, eebus.NewEventBus(), nil, WithOHPCFController(failingOHPCFController{entity: entity, err: want}))
+	if _, err := failing.ControlCompressorFlexibility(ctx, &pb.ControlCompressorRequest{
+		Ski: testValidSKI, Action: pb.OHPCFAction_OHPCF_ACTION_ABORT,
+	}); status.Code(err) != codes.Internal {
+		t.Fatalf("control failure status = %s, error=%v", status.Code(err), err)
+	}
+}
+
+func TestOHPCFConversionAndTargetClassification(t *testing.T) {
+	states := map[ucapi.CompressorPowerConsumptionStateType]pb.CompressorPowerConsumptionState{
+		ucapi.CompressorPowerConsumptionStateAvailable: pb.CompressorPowerConsumptionState_COMPRESSOR_STATE_AVAILABLE,
+		ucapi.CompressorPowerConsumptionStateScheduled: pb.CompressorPowerConsumptionState_COMPRESSOR_STATE_SCHEDULED,
+		ucapi.CompressorPowerConsumptionStateRunning:   pb.CompressorPowerConsumptionState_COMPRESSOR_STATE_RUNNING,
+		ucapi.CompressorPowerConsumptionStatePaused:    pb.CompressorPowerConsumptionState_COMPRESSOR_STATE_PAUSED,
+		ucapi.CompressorPowerConsumptionStateCompleted: pb.CompressorPowerConsumptionState_COMPRESSOR_STATE_COMPLETED,
+		ucapi.CompressorPowerConsumptionStateStopped:   pb.CompressorPowerConsumptionState_COMPRESSOR_STATE_STOPPED,
+		"unknown": pb.CompressorPowerConsumptionState_COMPRESSOR_STATE_UNSPECIFIED,
+	}
+	for input, want := range states {
+		if got := convertCompressorState(input); got != want {
+			t.Fatalf("convertCompressorState(%q) = %s, want %s", input, got, want)
+		}
+	}
+
+	events := []eebus.EventType{
+		eebus.EventTypeOHPCFConsumptionStateUpdated,
+		eebus.EventTypeOHPCFConsumptionStoppableUpdated,
+		eebus.EventTypeOHPCFConsumptionPausableUpdated,
+		eebus.EventTypeOHPCFConsumptionStartTimeUpdated,
+		eebus.EventTypeOHPCFRequestedPowerEstimateUpdated,
+		eebus.EventTypeOHPCFRequestedPowerMaxUpdated,
+		eebus.EventTypeOHPCFMinimalRunDurationUpdated,
+		eebus.EventTypeOHPCFMinimalPauseDurationUpdated,
+	}
+	for _, event := range events {
+		if got := ohpcfTargetRead(event); got == 0 {
+			t.Fatalf("target read for %q is zero", event)
+		}
+	}
+	if got := ohpcfTargetRead("unknown"); got != 0 {
+		t.Fatalf("unknown target read = %d", got)
+	}
+	if !isOHPCFOptionalAbsent(eebusapi.ErrDataInvalid) || !isOHPCFOptionalAbsent(eebusapi.ErrDataNotAvailable) || isOHPCFOptionalAbsent(errors.New("other")) {
+		t.Fatal("optional-absence classification is incorrect")
+	}
+}

--- a/eebus-bridge/internal/usecases/client_usecase_lifecycle_additional_test.go
+++ b/eebus-bridge/internal/usecases/client_usecase_lifecycle_additional_test.go
@@ -1,0 +1,306 @@
+package usecases
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	shipcert "github.com/enbility/ship-go/cert"
+	spineapi "github.com/enbility/spine-go/api"
+	"github.com/enbility/spine-go/mocks"
+	"github.com/enbility/spine-go/model"
+	"github.com/volschin/eebus-bridge/internal/config"
+	"github.com/volschin/eebus-bridge/internal/eebus"
+)
+
+const testValidUsecaseSKI = "682f708ceba5df9adcb9e6787ea911d9fc3ac490"
+
+func clientUsecaseLocalEntity(t *testing.T) spineapi.EntityLocalInterface {
+	t.Helper()
+	certificate, err := shipcert.CreateCertificate("test", "test", "DE", "client-usecases")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.Config{EEBUS: config.EEBUSConfig{
+		Port: 49877, Vendor: "Test", Brand: "Test", Model: "Test", Serial: "client-usecases",
+	}}
+	bridge, err := eebus.NewBridgeService(cfg, certificate, eebus.NewEventBus())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := bridge.Setup(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(bridge.Shutdown)
+	return bridge.LocalEntity()
+}
+
+func TestClientUsecaseConstructorsAndFeatures(t *testing.T) {
+	local := clientUsecaseLocalEntity(t)
+	bus := eebus.NewEventBus()
+	registry := eebus.NewDeviceRegistry()
+
+	dhwTemperature := NewDHWTemperature(local, bus, registry, true)
+	dhwSystemFunction := NewDHWSystemFunction(local, bus, registry, true)
+	roomTemperature := NewRoomHeatingTemperature(local, bus, registry, true)
+	roomSystemFunction := NewRoomHeatingSystemFunction(local, bus, registry, true)
+
+	checks := []struct {
+		name       string
+		useCaseNil bool
+		add        func() error
+	}{
+		{"DHW temperature", dhwTemperature.UseCase() == nil, dhwTemperature.AddFeatures},
+		{"DHW system function", dhwSystemFunction.UseCase() == nil, dhwSystemFunction.AddFeatures},
+		{"room temperature", roomTemperature.UseCase() == nil, roomTemperature.AddFeatures},
+		{"room system function", roomSystemFunction.UseCase() == nil, roomSystemFunction.AddFeatures},
+	}
+	for _, check := range checks {
+		t.Run(check.name, func(t *testing.T) {
+			if check.useCaseNil {
+				t.Fatal("UseCase() returned nil")
+			}
+			if err := check.add(); err != nil {
+				t.Fatalf("AddFeatures() error = %v", err)
+			}
+		})
+	}
+
+	if dhwTemperature.localSetpointFeature() == nil || roomTemperature.localSetpointFeature() == nil ||
+		dhwSystemFunction.localHvacFeature() == nil || roomSystemFunction.localHvacFeature() == nil {
+		t.Fatal("local client features were not available after AddFeatures")
+	}
+}
+
+func TestClientUsecaseAddFeaturesRejectsMissingLocalEntity(t *testing.T) {
+	checks := []struct {
+		name string
+		call func() error
+	}{
+		{"DHW temperature", (&DHWTemperature{}).AddFeatures},
+		{"DHW system function", (&DHWSystemFunction{}).AddFeatures},
+		{"room temperature", (&RoomHeatingTemperature{}).AddFeatures},
+		{"room system function", (&RoomHeatingSystemFunction{}).AddFeatures},
+	}
+	for _, check := range checks {
+		t.Run(check.name, func(t *testing.T) {
+			if err := check.call(); err == nil {
+				t.Fatal("AddFeatures() succeeded without a local entity")
+			}
+		})
+	}
+}
+
+func TestDHWSystemFunctionRoutesSupportAndValueUpdates(t *testing.T) {
+	bus := eebus.NewEventBus()
+	channel := bus.Subscribe()
+	defer bus.Unsubscribe(channel)
+	dhw := NewDHWSystemFunction(clientUsecaseLocalEntity(t), bus, nil, false)
+	feature := dhwSysFnFeature(t, true, true, nil)
+	entity := mocks.NewEntityRemoteInterface(t)
+	entity.On("EntityType").Return(model.EntityTypeTypeDHWCircuit)
+	entity.On("FeatureOfTypeAndRole", model.FeatureTypeTypeHvac, model.RoleTypeServer).Return(feature)
+
+	tests := []struct {
+		data any
+		want eebus.EventType
+	}{
+		{&model.HvacSystemFunctionDescriptionListDataType{}, eebus.EventTypeDHWSystemFunctionSupportUpdated},
+		{&model.HvacSystemFunctionListDataType{}, eebus.EventTypeDHWSystemFunctionUpdated},
+	}
+	for _, test := range tests {
+		dhw.HandleEvent(spineapi.EventPayload{
+			Ski: testValidUsecaseSKI, Entity: entity, EventType: spineapi.EventTypeDataChange,
+			ChangeType: spineapi.ElementChangeUpdate, Data: test.data,
+		})
+		select {
+		case event := <-channel:
+			if event.Type != test.want || event.SKI != eebus.NormalizeSKI(testValidUsecaseSKI) {
+				t.Fatalf("event = %+v, want type %q", event, test.want)
+			}
+		case <-time.After(time.Second):
+			t.Fatalf("timeout waiting for %q", test.want)
+		}
+	}
+	dhw.HandleEvent(spineapi.EventPayload{Entity: entity, EventType: spineapi.EventTypeDataChange, ChangeType: spineapi.ElementChangeAdd})
+	dhw.HandleEvent(spineapi.EventPayload{})
+}
+
+func TestRoomSystemFunctionRoutesSupportAndValueUpdates(t *testing.T) {
+	bus := eebus.NewEventBus()
+	channel := bus.Subscribe()
+	defer bus.Unsubscribe(channel)
+	room := NewRoomHeatingSystemFunction(clientUsecaseLocalEntity(t), bus, nil, false)
+	feature := newRoomHeatingSysFnFeature(t, 0, true)
+	entity := mocks.NewEntityRemoteInterface(t)
+	entity.On("EntityType").Return(model.EntityTypeTypeHvacRoom)
+	entity.On("FeatureOfTypeAndRole", model.FeatureTypeTypeHvac, model.RoleTypeServer).Return(feature)
+
+	tests := []struct {
+		data any
+		want eebus.EventType
+	}{
+		{&model.HvacOperationModeDescriptionListDataType{}, eebus.EventTypeRoomHeatingSystemFunctionSupportUpdated},
+		{&model.HvacSystemFunctionListDataType{}, eebus.EventTypeRoomHeatingSystemFunctionUpdated},
+	}
+	for _, test := range tests {
+		room.HandleEvent(spineapi.EventPayload{
+			Ski: testValidUsecaseSKI, Entity: entity, EventType: spineapi.EventTypeDataChange,
+			ChangeType: spineapi.ElementChangeUpdate, Data: test.data,
+		})
+		select {
+		case event := <-channel:
+			if event.Type != test.want || event.SKI != eebus.NormalizeSKI(testValidUsecaseSKI) {
+				t.Fatalf("event = %+v, want type %q", event, test.want)
+			}
+		case <-time.After(time.Second):
+			t.Fatalf("timeout waiting for %q", test.want)
+		}
+	}
+	room.HandleEvent(spineapi.EventPayload{Entity: entity, EventType: spineapi.EventTypeDataChange, ChangeType: spineapi.ElementChangeAdd})
+	room.HandleEvent(spineapi.EventPayload{})
+}
+
+func TestSystemFunctionUseCaseEventsPublishSupport(t *testing.T) {
+	bus := eebus.NewEventBus()
+	channel := bus.Subscribe()
+	defer bus.Unsubscribe(channel)
+	local := clientUsecaseLocalEntity(t)
+	dhw := NewDHWSystemFunction(local, bus, nil, false)
+	room := NewRoomHeatingSystemFunction(local, bus, nil, false)
+
+	dhw.handleUseCaseEvent(testValidUsecaseSKI, nil, nil, dhwSysFnUseCaseSupportUpdate)
+	room.handleUseCaseEvent(testValidUsecaseSKI, nil, nil, roomHeatingSysFnUseCaseSupportUpdate)
+	for _, want := range []eebus.EventType{
+		eebus.EventTypeDHWSystemFunctionSupportUpdated,
+		eebus.EventTypeRoomHeatingSystemFunctionSupportUpdated,
+	} {
+		select {
+		case event := <-channel:
+			if event.Type != want {
+				t.Fatalf("event = %+v, want %q", event, want)
+			}
+		case <-time.After(time.Second):
+			t.Fatalf("timeout waiting for %q", want)
+		}
+	}
+
+	(&DHWSystemFunction{}).handleUseCaseEvent(testValidUsecaseSKI, nil, nil, dhwSysFnUseCaseSupportUpdate)
+	(&RoomHeatingSystemFunction{}).handleUseCaseEvent(testValidUsecaseSKI, nil, nil, roomHeatingSysFnUseCaseSupportUpdate)
+}
+
+func TestClientUsecaseUnavailableGuards(t *testing.T) {
+	if _, err := (&DHWTemperature{}).State(nil); !errors.Is(err, ErrDHWDataUnavailable) {
+		t.Fatalf("DHW State() error = %v", err)
+	}
+	if _, err := (&RoomHeatingTemperature{}).State(nil); !errors.Is(err, ErrRoomHeatingDataUnavailable) {
+		t.Fatalf("room State() error = %v", err)
+	}
+	if _, err := (&DHWSystemFunction{}).State(nil); !errors.Is(err, ErrDHWSysFnDataUnavailable) {
+		t.Fatalf("DHW system State() error = %v", err)
+	}
+	if _, err := (&RoomHeatingSystemFunction{}).State(nil); !errors.Is(err, ErrRoomHeatingSysFnDataUnavailable) {
+		t.Fatalf("room system State() error = %v", err)
+	}
+}
+
+func setpointEventFeature(t *testing.T, scope model.ScopeTypeType, value float64) *mocks.FeatureRemoteInterface {
+	t.Helper()
+	feature := mocks.NewFeatureRemoteInterface(t)
+	feature.On("DataCopy", model.FunctionTypeSetpointDescriptionListData).Return(
+		&model.SetpointDescriptionListDataType{SetpointDescriptionData: []model.SetpointDescriptionDataType{
+			{SetpointId: ptr(model.SetpointIdType(1)), ScopeType: ptr(scope)},
+		}},
+	)
+	feature.On("DataCopy", model.FunctionTypeSetpointListData).Return(
+		&model.SetpointListDataType{SetpointData: []model.SetpointDataType{
+			{SetpointId: ptr(model.SetpointIdType(1)), Value: model.NewScaledNumberType(value)},
+		}},
+	)
+	feature.On("DataCopy", model.FunctionTypeSetpointConstraintsListData).Return(
+		&model.SetpointConstraintsListDataType{SetpointConstraintsData: []model.SetpointConstraintsDataType{
+			{SetpointId: ptr(model.SetpointIdType(1)), SetpointRangeMin: model.NewScaledNumberType(5), SetpointRangeMax: model.NewScaledNumberType(70), SetpointStepSize: model.NewScaledNumberType(0.5)},
+		}},
+	)
+	operation := mocks.NewOperationsInterface(t)
+	operation.On("Write").Return(true)
+	feature.On("Operations").Return(map[model.FunctionType]spineapi.OperationsInterface{
+		model.FunctionTypeSetpointListData: operation,
+	})
+	return feature
+}
+
+func TestTemperatureUsecasesRouteCacheAndSupportEvents(t *testing.T) {
+	bus := eebus.NewEventBus()
+	events := bus.Subscribe()
+	defer bus.Unsubscribe(events)
+	local := clientUsecaseLocalEntity(t)
+	dhw := NewDHWTemperature(local, bus, nil, false)
+	room := NewRoomHeatingTemperature(local, bus, nil, false)
+
+	dhwEntity := mocks.NewEntityRemoteInterface(t)
+	dhwEntity.On("EntityType").Return(model.EntityTypeTypeDHWCircuit)
+	dhwEntity.On("FeatureOfTypeAndRole", model.FeatureTypeTypeSetpoint, model.RoleTypeServer).
+		Return(setpointEventFeature(t, model.ScopeTypeTypeDhwTemperature, 48))
+	roomEntity := mocks.NewEntityRemoteInterface(t)
+	roomEntity.On("EntityType").Return(model.EntityTypeTypeHvacRoom)
+	roomEntity.On("FeatureOfTypeAndRole", model.FeatureTypeTypeSetpoint, model.RoleTypeServer).
+		Return(setpointEventFeature(t, model.ScopeTypeTypeRoomAirTemperature, 21))
+
+	dhw.HandleEvent(spineapi.EventPayload{
+		Ski: testValidUsecaseSKI, Entity: dhwEntity, EventType: spineapi.EventTypeDataChange,
+		ChangeType: spineapi.ElementChangeUpdate, Data: &model.SetpointListDataType{},
+	})
+	room.HandleEvent(spineapi.EventPayload{
+		Ski: testValidUsecaseSKI, Entity: roomEntity, EventType: spineapi.EventTypeDataChange,
+		ChangeType: spineapi.ElementChangeUpdate, Data: &model.SetpointListDataType{},
+	})
+	dhw.handleUseCaseEvent(testValidUsecaseSKI, nil, nil, "support")
+	room.handleUseCaseEvent(testValidUsecaseSKI, nil, nil, "support")
+
+	for _, want := range []eebus.EventType{
+		eebus.EventTypeDHWSetpointUpdated,
+		eebus.EventTypeRoomHeatingSetpointUpdated,
+		eebus.EventTypeDHWUseCaseSupportUpdated,
+		eebus.EventTypeRoomHeatingUseCaseSupportUpdated,
+	} {
+		select {
+		case event := <-events:
+			if event.Type != want {
+				t.Fatalf("event = %+v, want %q", event, want)
+			}
+		case <-time.After(time.Second):
+			t.Fatalf("timeout waiting for %q", want)
+		}
+	}
+
+	dhw.HandleEvent(spineapi.EventPayload{Entity: dhwEntity})
+	room.HandleEvent(spineapi.EventPayload{Entity: roomEntity})
+	dhw.HandleEvent(spineapi.EventPayload{})
+	room.HandleEvent(spineapi.EventPayload{})
+}
+
+func TestClientUsecaseRefreshAndResolutionGuards(t *testing.T) {
+	local := clientUsecaseLocalEntity(t)
+	dhw := NewDHWTemperature(local, nil, nil, false)
+	room := NewRoomHeatingTemperature(local, nil, nil, false)
+	dhwSystem := NewDHWSystemFunction(local, nil, nil, false)
+	roomSystem := NewRoomHeatingSystemFunction(local, nil, nil, false)
+
+	dhw.Refresh(nil)
+	room.Refresh(nil)
+	dhwSystem.Refresh(nil)
+	roomSystem.Refresh(nil)
+	dhwSystem.connect(nil)
+	roomSystem.connect(nil)
+
+	missingSetpoint := mocks.NewEntityRemoteInterface(t)
+	missingSetpoint.On("FeatureOfTypeAndRole", model.FeatureTypeTypeSetpoint, model.RoleTypeServer).Return(nil)
+	dhw.connect(missingSetpoint)
+	room.connect(missingSetpoint)
+
+	if dhw.CompatibleEntity("").Entity != nil || room.CompatibleEntity("").Entity != nil ||
+		dhwSystem.CompatibleEntity("").Entity != nil || roomSystem.CompatibleEntity("").Entity != nil {
+		t.Fatal("uninitialized use case resolved an entity")
+	}
+}

--- a/eebus-bridge/internal/usecases/hydraulictemp_test.go
+++ b/eebus-bridge/internal/usecases/hydraulictemp_test.go
@@ -1,7 +1,9 @@
 package usecases
 
 import (
+	"errors"
 	"testing"
+	"time"
 
 	spineapi "github.com/enbility/spine-go/api"
 	"github.com/enbility/spine-go/mocks"
@@ -47,5 +49,82 @@ func TestHydraulicTemperaturesReturnUnavailableWithoutScope(t *testing.T) {
 	h := NewHydraulicTemperatures(nil, registry, false)
 	if _, err := h.ReturnTemperature("unknown-ski"); err == nil {
 		t.Fatal("ReturnTemperature() error = nil, want an error for an unknown SKI")
+	}
+}
+
+func TestHydraulicTemperaturesSetupAndPublishBothScopes(t *testing.T) {
+	feature := mocks.NewFeatureRemoteInterface(t)
+	feature.On("DataCopy", model.FunctionTypeMeasurementDescriptionListData).Return(
+		&model.MeasurementDescriptionListDataType{MeasurementDescriptionData: []model.MeasurementDescriptionDataType{
+			{MeasurementId: ptr(model.MeasurementIdType(1)), ScopeType: ptr(model.ScopeTypeTypeFlowTemperature), Unit: ptr(model.UnitOfMeasurementTypedegC)},
+			{MeasurementId: ptr(model.MeasurementIdType(2)), ScopeType: ptr(model.ScopeTypeTypeReturnTemperature), Unit: ptr(model.UnitOfMeasurementTypedegF)},
+		}},
+	)
+	feature.On("DataCopy", model.FunctionTypeMeasurementListData).Return(
+		&model.MeasurementListDataType{MeasurementData: []model.MeasurementDataType{
+			{MeasurementId: ptr(model.MeasurementIdType(1)), Value: model.NewScaledNumberType(50)},
+			{MeasurementId: ptr(model.MeasurementIdType(2)), Value: model.NewScaledNumberType(104)},
+		}},
+	)
+	entity := mocks.NewEntityRemoteInterface(t)
+	entity.On("FeatureOfTypeAndRole", model.FeatureTypeTypeMeasurement, model.RoleTypeServer).Return(feature)
+	entity.On("Address").Return(&model.EntityAddressType{})
+	entity.On("EntityType").Return(model.EntityTypeTypeHeatPumpAppliance)
+	entity.On("Features").Return([]spineapi.FeatureRemoteInterface(nil))
+	registry := eebus.NewDeviceRegistry()
+	registry.UpsertObservation(testValidUsecaseSKI, nil, entity, "monitoring")
+	bus := eebus.NewEventBus()
+	events := bus.Subscribe()
+	defer bus.Unsubscribe(events)
+	hydraulic := NewHydraulicTemperatures(bus, registry, true)
+	hydraulic.Setup(clientUsecaseLocalEntity(t))
+	hydraulic.HandleEvent(spineapi.EventPayload{
+		Ski: testValidUsecaseSKI, Entity: entity, EventType: spineapi.EventTypeDataChange,
+		ChangeType: spineapi.ElementChangeUpdate, Data: &model.MeasurementListDataType{},
+	})
+	for _, want := range []eebus.EventType{
+		eebus.EventTypeMonitoringFlowTemperatureUpdated,
+		eebus.EventTypeMonitoringReturnTemperatureUpdated,
+	} {
+		select {
+		case event := <-events:
+			if event.Type != want {
+				t.Fatalf("event = %+v, want %q", event, want)
+			}
+		case <-time.After(time.Second):
+			t.Fatalf("timeout waiting for %q", want)
+		}
+	}
+	if value, err := (FlowTemperatureReader{hydraulic}).Temperature(testValidUsecaseSKI); err != nil || value != 50 {
+		t.Fatalf("flow adapter = (%g, %v)", value, err)
+	}
+	if value, err := (ReturnTemperatureReader{hydraulic}).Temperature(testValidUsecaseSKI); err != nil || value != 40 {
+		t.Fatalf("return adapter = (%g, %v)", value, err)
+	}
+
+	hydraulic.HandleEvent(spineapi.EventPayload{})
+	hydraulic.HandleEvent(spineapi.EventPayload{Entity: entity, EventType: spineapi.EventTypeDataChange, ChangeType: spineapi.ElementChangeUpdate, Data: "other"})
+	(&HydraulicTemperatures{}).HandleEvent(spineapi.EventPayload{Entity: entity, EventType: spineapi.EventTypeDataChange, ChangeType: spineapi.ElementChangeUpdate, Data: &model.MeasurementListDataType{}})
+	(&HydraulicTemperatures{}).Setup(nil)
+}
+
+func TestHydraulicTemperatureUnitConversions(t *testing.T) {
+	tests := []struct {
+		value float64
+		unit  model.UnitOfMeasurementType
+		want  float64
+	}{
+		{20, "", 20},
+		{293.15, model.UnitOfMeasurementTypeK, 20},
+		{68, model.UnitOfMeasurementTypedegF, 20},
+	}
+	for _, test := range tests {
+		got, err := convertToCelsius(test.value, test.unit)
+		if err != nil || got < test.want-0.0001 || got > test.want+0.0001 {
+			t.Fatalf("convertToCelsius(%g, %q) = (%g, %v), want %g", test.value, test.unit, got, err, test.want)
+		}
+	}
+	if _, err := convertToCelsius(1, model.UnitOfMeasurementType("unsupported")); !errors.Is(err, ErrHydraulicTemperatureUnavailable) {
+		t.Fatalf("unsupported unit error = %v", err)
 	}
 }

--- a/eebus-bridge/internal/usecases/monitoring_additional_test.go
+++ b/eebus-bridge/internal/usecases/monitoring_additional_test.go
@@ -151,3 +151,45 @@ func TestHasMeasurementServer(t *testing.T) {
 		t.Fatal("Measurement/server was not detected")
 	}
 }
+
+func TestMonitoringAfterSetupDelegatesReadsAndHandlesEmptyCatalog(t *testing.T) {
+	local := clientUsecaseLocalEntity(t)
+	registry := eebus.NewDeviceRegistry()
+	w := NewMonitoringWrapper(nil, registry, false)
+	w.Setup(local)
+	if w.UseCase() == nil {
+		t.Fatal("Setup() did not initialize monitoring use case")
+	}
+
+	checks := []struct {
+		name string
+		call func() error
+	}{
+		{"power", func() error { _, err := w.Power(nil); return err }},
+		{"power per phase", func() error { _, err := w.PowerPerPhase(nil); return err }},
+		{"energy consumed", func() error { _, err := w.EnergyConsumed(nil); return err }},
+		{"energy produced", func() error { _, err := w.EnergyProduced(nil); return err }},
+		{"current per phase", func() error { _, err := w.CurrentPerPhase(nil); return err }},
+		{"voltage per phase", func() error { _, err := w.VoltagePerPhase(nil); return err }},
+		{"frequency", func() error { _, err := w.Frequency(nil); return err }},
+	}
+	for _, check := range checks {
+		t.Run(check.name, func(t *testing.T) {
+			if err := check.call(); err == nil {
+				t.Fatal("read without a remote entity unexpectedly succeeded")
+			}
+		})
+	}
+	if got := w.CompatibleEntity(testValidUsecaseSKI); got.Entity != nil {
+		t.Fatalf("CompatibleEntity() = %+v, want no remote entity", got)
+	}
+	if _, err := w.GenericMeasurements(testValidUsecaseSKI); !errors.Is(err, eebusapi.ErrDataNotAvailable) {
+		t.Fatalf("GenericMeasurements() error = %v, want ErrDataNotAvailable", err)
+	}
+
+	withoutRegistry := NewMonitoringWrapper(nil, nil, false)
+	withoutRegistry.Setup(local)
+	if _, err := withoutRegistry.GenericMeasurements(testValidUsecaseSKI); err == nil {
+		t.Fatal("GenericMeasurements() succeeded without a registry")
+	}
+}

--- a/eebus-bridge/internal/usecases/monitoring_additional_test.go
+++ b/eebus-bridge/internal/usecases/monitoring_additional_test.go
@@ -1,0 +1,153 @@
+package usecases
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	eebusapi "github.com/enbility/eebus-go/api"
+	mampc "github.com/enbility/eebus-go/usecases/ma/mpc"
+	"github.com/enbility/spine-go/model"
+	"github.com/volschin/eebus-bridge/internal/eebus"
+)
+
+func TestMonitoringBeforeSetupReturnsInitializationError(t *testing.T) {
+	w := NewMonitoringWrapper(nil, nil, false)
+	w.Setup(nil)
+
+	if w.UseCase() != nil {
+		t.Fatal("UseCase() before setup returned a use case")
+	}
+	if got := w.CompatibleEntity("abcd"); got.Entity != nil || got.Ambiguous() {
+		t.Fatalf("CompatibleEntity() before setup = %+v, want no match", got)
+	}
+
+	checks := []struct {
+		name string
+		call func() error
+	}{
+		{"power", func() error { _, err := w.Power(nil); return err }},
+		{"power per phase", func() error { _, err := w.PowerPerPhase(nil); return err }},
+		{"energy consumed", func() error { _, err := w.EnergyConsumed(nil); return err }},
+		{"energy produced", func() error { _, err := w.EnergyProduced(nil); return err }},
+		{"current per phase", func() error { _, err := w.CurrentPerPhase(nil); return err }},
+		{"voltage per phase", func() error { _, err := w.VoltagePerPhase(nil); return err }},
+		{"frequency", func() error { _, err := w.Frequency(nil); return err }},
+		{"generic measurements", func() error { _, err := w.GenericMeasurements(""); return err }},
+	}
+	for _, check := range checks {
+		t.Run(check.name, func(t *testing.T) {
+			if err := check.call(); !errors.Is(err, errMonitoringNotInitialized) {
+				t.Fatalf("error = %v, want %v", err, errMonitoringNotInitialized)
+			}
+		})
+	}
+}
+
+func TestMonitoringRoutesRemainingEventTypes(t *testing.T) {
+	tests := []struct {
+		name string
+		in   eebusapi.EventType
+		want eebus.EventType
+	}{
+		{"power per phase", mampc.DataUpdatePowerPerPhase, eebus.EventTypeMonitoringPowerPerPhaseUpdated},
+		{"energy produced", mampc.DataUpdateEnergyProduced, eebus.EventTypeMonitoringEnergyProducedUpdated},
+		{"currents per phase", mampc.DataUpdateCurrentsPerPhase, eebus.EventTypeMonitoringCurrentsPerPhaseUpdated},
+		{"voltage per phase", mampc.DataUpdateVoltagePerPhase, eebus.EventTypeMonitoringVoltagePerPhaseUpdated},
+		{"support", mampc.UseCaseSupportUpdate, eebus.EventTypeMonitoringUseCaseSupportUpdated},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			bus := eebus.NewEventBus()
+			ch := bus.Subscribe()
+			defer bus.Unsubscribe(ch)
+
+			w := NewMonitoringWrapper(bus, nil, false)
+			w.HandleEvent("ab:cd", nil, nil, test.in)
+
+			select {
+			case event := <-ch:
+				if event.Type != test.want || event.SKI != "ABCD" {
+					t.Fatalf("event = %+v, want type %q and normalized SKI", event, test.want)
+				}
+			case <-time.After(time.Second):
+				t.Fatal("timeout waiting for event")
+			}
+		})
+	}
+}
+
+func TestMonitoringHandleEventWithoutBusAndWithDebugDoesNotPanic(t *testing.T) {
+	w := NewMonitoringWrapper(nil, nil, true)
+	w.HandleEvent("ab:cd", nil, nil, mampc.DataUpdatePower)
+}
+
+func TestClassifyGenericMeasurement(t *testing.T) {
+	ptr := func(value string) *string { return &value }
+	tests := []struct {
+		name       string
+		entityType string
+		measType   *string
+		scope      *string
+		want       string
+	}{
+		{"DHW scope", "ignored", nil, ptr(string(model.ScopeTypeTypeDhwTemperature)), "dhw_temperature"},
+		{"room scope", "ignored", nil, ptr(string(model.ScopeTypeTypeRoomAirTemperature)), "room_temperature"},
+		{"outside scope", "ignored", nil, ptr(string(model.ScopeTypeTypeOutsideAirTemperature)), "outdoor_temperature"},
+		{"flow scope", "ignored", nil, ptr(string(model.ScopeTypeTypeFlowTemperature)), "flow_temperature"},
+		{"return scope", "ignored", nil, ptr(string(model.ScopeTypeTypeReturnTemperature)), "return_temperature"},
+		{"compressor component scope", "Compressor", nil, ptr(string(model.ScopeTypeTypeComponentTemperature)), "compressor_temperature"},
+		{"DHW temperature fallback", "DHWCircuit", ptr(string(model.MeasurementTypeTypeTemperature)), nil, "dhw_temperature"},
+		{"room temperature fallback", "HVACRoom", ptr(string(model.MeasurementTypeTypeTemperature)), nil, "room_temperature"},
+		{"outdoor temperature fallback", "TemperatureSensor", ptr(string(model.MeasurementTypeTypeTemperature)), nil, "outdoor_temperature"},
+		{"compressor temperature fallback", "Compressor", ptr(string(model.MeasurementTypeTypeTemperature)), nil, "compressor_temperature"},
+		{"compressor power", "Compressor", ptr(string(model.MeasurementTypeTypePower)), nil, "compressor_power"},
+		{"DHW energy", "DHWCircuit", ptr(string(model.MeasurementTypeTypeEnergy)), nil, "energy_consumed_dhw"},
+		{"HVAC system energy", "HVACSystem", ptr(string(model.MeasurementTypeTypeEnergy)), nil, "energy_consumed_heating"},
+		{"HVAC room energy", "HVACRoom", ptr(string(model.MeasurementTypeTypeEnergy)), nil, "energy_consumed_heating"},
+		{"raw complete", "Custom", ptr("customType"), ptr("customScope"), "raw_custom_customType_customScope"},
+		{"raw defaults", "", nil, nil, "raw_entity_unknown_unspecified"},
+		{"component on other entity", "Pump", ptr(string(model.MeasurementTypeTypeTemperature)), ptr(string(model.ScopeTypeTypeComponentTemperature)), "raw_pump_temperature_componentTemperature"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			description := model.MeasurementDescriptionDataType{}
+			if test.measType != nil {
+				value := model.MeasurementTypeType(*test.measType)
+				description.MeasurementType = &value
+			}
+			if test.scope != nil {
+				value := model.ScopeTypeType(*test.scope)
+				description.ScopeType = &value
+			}
+			got := classifyGenericMeasurement(eebus.EntityInfo{Type: test.entityType}, description)
+			if got != test.want {
+				t.Fatalf("classification = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+func TestStringPtrValue(t *testing.T) {
+	if got := stringPtrValue[string](nil); got != "" {
+		t.Fatalf("nil value = %q, want empty", got)
+	}
+	value := "value"
+	if got := stringPtrValue(&value); got != value {
+		t.Fatalf("value = %q, want %q", got, value)
+	}
+}
+
+func TestHasMeasurementServer(t *testing.T) {
+	if hasMeasurementServer(nil) {
+		t.Fatal("nil feature list reported Measurement/server")
+	}
+	if hasMeasurementServer([]string{"Measurement/client", "DeviceDiagnosis/server"}) {
+		t.Fatal("unrelated feature list reported Measurement/server")
+	}
+	if !hasMeasurementServer([]string{"DeviceDiagnosis/server", "Measurement/server"}) {
+		t.Fatal("Measurement/server was not detected")
+	}
+}

--- a/eebus-bridge/internal/usecases/provider_api_additional_test.go
+++ b/eebus-bridge/internal/usecases/provider_api_additional_test.go
@@ -1,0 +1,288 @@
+package usecases
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	eebusapi "github.com/enbility/eebus-go/api"
+	shipcert "github.com/enbility/ship-go/cert"
+	"github.com/enbility/spine-go/mocks"
+	"github.com/enbility/spine-go/model"
+	"github.com/stretchr/testify/mock"
+	"github.com/volschin/eebus-bridge/internal/config"
+	"github.com/volschin/eebus-bridge/internal/eebus"
+)
+
+func TestProviderConstructorsExposeTheirUseCases(t *testing.T) {
+	bus := eebus.NewEventBus()
+	events := mocks.NewEventsManagerInterface(t)
+	events.On("Subscribe", mock.Anything).Return(nil).Times(3)
+	device := mocks.NewDeviceLocalInterface(t)
+	device.On("Events").Return(events).Times(3)
+	entity := mocks.NewEntityLocalInterface(t)
+	entity.On("Device").Return(device).Times(3)
+	providers := []eebusapi.UseCaseInterface{
+		NewMGCPProvider(entity, bus, false).UseCase(),
+		NewVAPDProvider(entity, bus, false).UseCase(),
+		NewVABDProvider(entity, bus, false).UseCase(),
+	}
+	for index, provider := range providers {
+		if provider == nil {
+			t.Fatalf("provider %d returned a nil use case", index)
+		}
+	}
+}
+
+func TestProvidersAddFeaturesToRealLocalEntities(t *testing.T) {
+	certificate, err := shipcert.CreateCertificate("test", "test", "DE", "provider-features")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.Config{
+		EEBUS:        config.EEBUSConfig{Port: 49876, Vendor: "Test", Brand: "Test", Model: "Test", Serial: "provider-features"},
+		Experimental: config.ExperimentalConfig{MGCPProvider: true, VAPDProvider: true, VABDProvider: true},
+	}
+	bridge, err := eebus.NewBridgeService(cfg, certificate, eebus.NewEventBus())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := bridge.Setup(); err != nil {
+		t.Fatal(err)
+	}
+	defer bridge.Shutdown()
+
+	mgcp := NewMGCPProvider(bridge.GridEntity(), nil, false)
+	if err := mgcp.AddFeatures(); err != nil {
+		t.Fatalf("MGCP AddFeatures: %v", err)
+	}
+	if mgcp.meas == nil || mgcp.powerID == nil || mgcp.feedInID == nil || mgcp.consumedID == nil {
+		t.Fatalf("MGCP features incomplete: %+v", mgcp)
+	}
+
+	vapd := NewVAPDProvider(bridge.PVEntity(), nil, false)
+	if err := vapd.AddFeatures(); err != nil {
+		t.Fatalf("VAPD AddFeatures: %v", err)
+	}
+	if vapd.meas == nil || vapd.powerID == nil || vapd.yieldID == nil || vapd.devConf == nil || vapd.peakID == nil {
+		t.Fatalf("VAPD features incomplete: %+v", vapd)
+	}
+
+	vabd := NewVABDProvider(bridge.BatteryEntity(), nil, false)
+	if err := vabd.AddFeatures(); err != nil {
+		t.Fatalf("VABD AddFeatures: %v", err)
+	}
+	if vabd.meas == nil || vabd.powerID == nil || vabd.chargedID == nil || vabd.dischargedID == nil || vabd.socID == nil {
+		t.Fatalf("VABD features incomplete: %+v", vabd)
+	}
+}
+
+func TestProviderIDFormattingHandlesNilAndValues(t *testing.T) {
+	if got := idVal(nil); got != -1 {
+		t.Fatalf("idVal(nil) = %d, want -1", got)
+	}
+	measurementID := model.MeasurementIdType(42)
+	if got := idVal(&measurementID); got != 42 {
+		t.Fatalf("idVal() = %d, want 42", got)
+	}
+	if got := keyIDVal(nil); got != -1 {
+		t.Fatalf("keyIDVal(nil) = %d, want -1", got)
+	}
+	keyID := model.DeviceConfigurationKeyIdType(7)
+	if got := keyIDVal(&keyID); got != 7 {
+		t.Fatalf("keyIDVal() = %d, want 7", got)
+	}
+}
+
+func TestLegacyProviderWritesRejectUninitializedProviders(t *testing.T) {
+	checks := []struct {
+		name string
+		want error
+		call func() error
+	}{
+		{"MGCP power", errMGCPNotInitialized, func() error { return (&MGCPProvider{}).PublishPower(1) }},
+		{"MGCP feed-in", errMGCPNotInitialized, func() error { return (&MGCPProvider{}).PublishEnergyFeedIn(1) }},
+		{"MGCP consumed", errMGCPNotInitialized, func() error { return (&MGCPProvider{}).PublishEnergyConsumed(1) }},
+		{"VAPD power", errVAPDNotInitialized, func() error { return (&VAPDProvider{}).PublishPower(1) }},
+		{"VAPD yield", errVAPDNotInitialized, func() error { return (&VAPDProvider{}).PublishYield(1) }},
+		{"VAPD peak", errVAPDNotInitialized, func() error { return (&VAPDProvider{}).PublishPeakPower(1) }},
+		{"VABD power", errVABDNotInitialized, func() error { return (&VABDProvider{}).PublishPower(1) }},
+		{"VABD charged", errVABDNotInitialized, func() error { return (&VABDProvider{}).PublishEnergyCharged(1) }},
+		{"VABD discharged", errVABDNotInitialized, func() error { return (&VABDProvider{}).PublishEnergyDischarged(1) }},
+		{"VABD state of charge", errVABDNotInitialized, func() error { return (&VABDProvider{}).PublishStateOfCharge(1) }},
+	}
+	for _, check := range checks {
+		t.Run(check.name, func(t *testing.T) {
+			if err := check.call(); !errors.Is(err, check.want) {
+				t.Fatalf("error = %v, want %v", err, check.want)
+			}
+		})
+	}
+}
+
+func TestLegacyProviderWritesPublishEveryValue(t *testing.T) {
+	t.Run("MGCP", func(t *testing.T) {
+		server := &recordingMeasurementServer{}
+		ids := []model.MeasurementIdType{1, 2, 3}
+		provider := &MGCPProvider{meas: server, powerID: &ids[0], feedInID: &ids[1], consumedID: &ids[2], debug: true}
+		for name, call := range map[string]func(float64) error{
+			"power": provider.PublishPower, "feed-in": provider.PublishEnergyFeedIn, "consumed": provider.PublishEnergyConsumed,
+		} {
+			if err := call(12.5); err != nil {
+				t.Fatalf("%s: %v", name, err)
+			}
+		}
+		if updates := server.snapshotUpdates(); len(updates) != 3 {
+			t.Fatalf("updates = %d, want 3", len(updates))
+		}
+	})
+
+	t.Run("VAPD", func(t *testing.T) {
+		server := &recordingMeasurementServer{}
+		configuration := &recordingDeviceConfigurationServer{}
+		ids := []model.MeasurementIdType{1, 2}
+		peakID := model.DeviceConfigurationKeyIdType(3)
+		provider := &VAPDProvider{meas: server, devConf: configuration, powerID: &ids[0], yieldID: &ids[1], peakID: &peakID, debug: true}
+		if err := provider.PublishPower(100); err != nil {
+			t.Fatal(err)
+		}
+		if err := provider.PublishYield(200); err != nil {
+			t.Fatal(err)
+		}
+		if err := provider.PublishPeakPower(300); err != nil {
+			t.Fatal(err)
+		}
+		if updates := server.snapshotUpdates(); len(updates) != 2 || configuration.calls != 1 {
+			t.Fatalf("measurement updates = %d, configuration calls = %d", len(updates), configuration.calls)
+		}
+	})
+
+	t.Run("VABD", func(t *testing.T) {
+		server := &recordingMeasurementServer{}
+		ids := []model.MeasurementIdType{1, 2, 3, 4}
+		provider := &VABDProvider{
+			meas: server, powerID: &ids[0], chargedID: &ids[1], dischargedID: &ids[2], socID: &ids[3], debug: true,
+		}
+		for name, call := range map[string]func(float64) error{
+			"power": provider.PublishPower, "charged": provider.PublishEnergyCharged,
+			"discharged": provider.PublishEnergyDischarged, "state of charge": provider.PublishStateOfCharge,
+		} {
+			if err := call(50); err != nil {
+				t.Fatalf("%s: %v", name, err)
+			}
+		}
+		if updates := server.snapshotUpdates(); len(updates) != 4 {
+			t.Fatalf("updates = %d, want 4", len(updates))
+		}
+	})
+}
+
+func TestLegacyProviderWritesPropagateServerErrors(t *testing.T) {
+	want := errors.New("publish failed")
+	server := &recordingMeasurementServer{fail: want}
+	id := model.MeasurementIdType(1)
+	provider := &MGCPProvider{meas: server, powerID: &id}
+	if err := provider.PublishPower(1); !errors.Is(err, want) {
+		t.Fatalf("PublishPower error = %v, want %v", err, want)
+	}
+
+	configuration := &recordingDeviceConfigurationServer{fail: want}
+	keyID := model.DeviceConfigurationKeyIdType(2)
+	pv := &VAPDProvider{devConf: configuration, peakID: &keyID}
+	if err := pv.PublishPeakPower(1); !errors.Is(err, want) {
+		t.Fatalf("PublishPeakPower error = %v, want %v", err, want)
+	}
+}
+
+func TestProviderSupportEventsPublishOnlyMatchingUpdates(t *testing.T) {
+	tests := []struct {
+		name string
+		want eebus.EventType
+		call func(*eebus.EventBus, eebusapi.EventType)
+	}{
+		{"MGCP", eebus.EventTypeMGCPConsumerUpdated, func(bus *eebus.EventBus, event eebusapi.EventType) {
+			(&MGCPProvider{bus: bus}).handleEvent("ab:cd", nil, nil, event)
+		}},
+		{"VAPD", eebus.EventTypeVAPDConsumerUpdated, func(bus *eebus.EventBus, event eebusapi.EventType) {
+			(&VAPDProvider{bus: bus}).handleEvent("ab:cd", nil, nil, event)
+		}},
+		{"VABD", eebus.EventTypeVABDConsumerUpdated, func(bus *eebus.EventBus, event eebusapi.EventType) {
+			(&VABDProvider{bus: bus}).handleEvent("ab:cd", nil, nil, event)
+		}},
+	}
+	matching := []eebusapi.EventType{mgcpUseCaseSupportUpdate, vapdUseCaseSupportUpdate, vabdUseCaseSupportUpdate}
+	for index, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			bus := eebus.NewEventBus()
+			channel := bus.Subscribe()
+			defer bus.Unsubscribe(channel)
+			test.call(bus, "unrelated")
+			select {
+			case event := <-channel:
+				t.Fatalf("unrelated event published %+v", event)
+			default:
+			}
+			test.call(bus, matching[index])
+			select {
+			case event := <-channel:
+				if event.Type != test.want || event.SKI != "ABCD" {
+					t.Fatalf("event = %+v, want %q for normalized SKI", event, test.want)
+				}
+			case <-time.After(time.Second):
+				t.Fatal("timeout waiting for provider event")
+			}
+			test.call(nil, matching[index])
+		})
+	}
+}
+
+func TestProviderSnapshotDiagnosticsStates(t *testing.T) {
+	now := time.Now()
+	server := &recordingMeasurementServer{}
+	id := model.MeasurementIdType(1)
+	provider := &MGCPProvider{meas: server, powerID: &id, feedInID: &id, consumedID: &id}
+
+	if diagnostics := provider.Diagnostics(now); diagnostics.State != ProviderSnapshotEmpty {
+		t.Fatalf("empty diagnostics = %+v", diagnostics)
+	}
+	if err := provider.PublishGridSnapshot(GridSnapshot{PowerW: 1, Validity: ProviderValidity{ObservedAt: now, ValidUntil: now.Add(time.Hour)}}); err != nil {
+		t.Fatal(err)
+	}
+	if diagnostics := provider.Diagnostics(now); diagnostics.State != ProviderSnapshotCurrent || diagnostics.ObservedAt != now {
+		t.Fatalf("current diagnostics = %+v", diagnostics)
+	}
+	if diagnostics := provider.Diagnostics(now.Add(2 * time.Hour)); diagnostics.State != ProviderSnapshotExpired {
+		t.Fatalf("expired diagnostics = %+v", diagnostics)
+	}
+	if err := provider.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if diagnostics := provider.Diagnostics(now); diagnostics.State != ProviderSnapshotClosed {
+		t.Fatalf("closed diagnostics = %+v", diagnostics)
+	}
+}
+
+func TestSerializedPublisherRejectsMissingDependenciesAndInvalidates(t *testing.T) {
+	publisher := &serializedMeasurementPublisher{}
+	id := model.MeasurementIdType(1)
+	if err := publisher.publishValues(nil, errMGCPNotInitialized, providerMeasurementValue{id: &id}); !errors.Is(err, errMGCPNotInitialized) {
+		t.Fatalf("nil server error = %v", err)
+	}
+	server := &recordingMeasurementServer{}
+	if err := publisher.publishValues(server, errMGCPNotInitialized, providerMeasurementValue{}); !errors.Is(err, errMGCPNotInitialized) {
+		t.Fatalf("nil ID error = %v", err)
+	}
+	if err := publisher.invalidate(nil, errMGCPNotInitialized, &id); !errors.Is(err, errMGCPNotInitialized) {
+		t.Fatalf("nil invalidate server error = %v", err)
+	}
+	if err := publisher.invalidate(server, errMGCPNotInitialized, nil); !errors.Is(err, errMGCPNotInitialized) {
+		t.Fatalf("nil invalidate ID error = %v", err)
+	}
+	if err := publisher.invalidate(server, errMGCPNotInitialized, &id); err != nil {
+		t.Fatalf("invalidate: %v", err)
+	}
+	updates := server.snapshotUpdates()
+	if len(updates) != 1 || updates[0][0].Data.ValueState == nil || *updates[0][0].Data.ValueState != model.MeasurementValueStateTypeError {
+		t.Fatalf("invalidate updates = %+v", updates)
+	}
+}

--- a/eebus-bridge/internal/usecases/roomheatingsysfn_test.go
+++ b/eebus-bridge/internal/usecases/roomheatingsysfn_test.go
@@ -41,9 +41,12 @@ func newRoomHeatingSysFnFeature(
 	)
 	operation := mocks.NewOperationsInterface(t)
 	operation.On("Write").Return(writable)
+	operation.On("Read").Return(true).Maybe()
 	feature.On("Operations").Return(map[model.FunctionType]spineapi.OperationsInterface{
 		model.FunctionTypeHvacSystemFunctionListData: operation,
 	})
+	feature.On("Address").Return(&model.FeatureAddressType{}).Maybe()
+	feature.On("String").Return("remote room HVAC").Maybe()
 	return feature
 }
 
@@ -86,5 +89,41 @@ func TestRoomHeatingSysFnWriteRejectsModeNotInRelation(t *testing.T) {
 	err := (&RoomHeatingSystemFunction{}).WriteOperationMode(context.Background(), entity, "cool")
 	if !errors.Is(err, ErrRoomHeatingSysFnInvalidMode) {
 		t.Fatalf("WriteOperationMode() error = %v, want ErrRoomHeatingSysFnInvalidMode", err)
+	}
+}
+
+func TestRoomHeatingSysFnWriteUpdatesOperationMode(t *testing.T) {
+	feature := newRoomHeatingSysFnFeature(t, 0, true)
+	local, entity, written := dhwSysFnWriteHarness(t, feature)
+	room := &RoomHeatingSystemFunction{localEntity: local}
+
+	if err := room.WriteOperationMode(context.Background(), entity, "auto"); err != nil {
+		t.Fatalf("WriteOperationMode() error = %v", err)
+	}
+	entries := written.cmd.HvacSystemFunctionListData.HvacSystemFunctionData
+	if len(entries) != 1 || entries[0].CurrentOperationModeId == nil || *entries[0].CurrentOperationModeId != 2 {
+		t.Fatalf("written system function data = %+v", entries)
+	}
+}
+
+func TestRoomHeatingSysFnWriteGuardsAndRejection(t *testing.T) {
+	notWritable := newRoomHeatingSysFnFeature(t, 0, false)
+	entity := mocks.NewEntityRemoteInterface(t)
+	entity.On("FeatureOfTypeAndRole", model.FeatureTypeTypeHvac, model.RoleTypeServer).Return(notWritable)
+	if err := (&RoomHeatingSystemFunction{}).WriteOperationMode(context.Background(), entity, "on"); !errors.Is(err, ErrRoomHeatingSysFnNotWritable) {
+		t.Fatalf("not-writable error = %v", err)
+	}
+
+	feature := newRoomHeatingSysFnFeature(t, 0, true)
+	local, rejectingEntity, _ := dhwSysFnWriteHarnessWithErrno(t, feature, 4)
+	room := &RoomHeatingSystemFunction{localEntity: local}
+	if err := room.WriteOperationMode(context.Background(), rejectingEntity, "on"); !errors.Is(err, ErrRoomHeatingSysFnRejected) {
+		t.Fatalf("rejection error = %v", err)
+	}
+
+	missingLocalEntity := mocks.NewEntityRemoteInterface(t)
+	missingLocalEntity.On("FeatureOfTypeAndRole", model.FeatureTypeTypeHvac, model.RoleTypeServer).Return(feature)
+	if err := (&RoomHeatingSystemFunction{}).WriteOperationMode(context.Background(), missingLocalEntity, "on"); !errors.Is(err, ErrRoomHeatingSysFnDataUnavailable) {
+		t.Fatalf("missing-local error = %v", err)
 	}
 }

--- a/eebus-bridge/internal/usecases/wrapper_guards_additional_test.go
+++ b/eebus-bridge/internal/usecases/wrapper_guards_additional_test.go
@@ -1,0 +1,172 @@
+package usecases
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	eebusapi "github.com/enbility/eebus-go/api"
+	ucapi "github.com/enbility/eebus-go/usecases/api"
+	cemohpcf "github.com/enbility/eebus-go/usecases/cem/ohpcf"
+	eglpc "github.com/enbility/eebus-go/usecases/eg/lpc"
+	"github.com/volschin/eebus-bridge/internal/eebus"
+)
+
+func TestLPCBeforeSetupReturnsInitializationDefaults(t *testing.T) {
+	w := NewLPCWrapper(nil, nil, false)
+	w.Setup(nil)
+	if w.UseCase() != nil || w.IsHeartbeatRunning() || w.IsHeartbeatWithinDuration(nil) {
+		t.Fatal("LPC wrapper reported initialized state before Setup")
+	}
+	if got := w.CompatibleEntityForScenario("ab:cd", 1); got.Entity != nil || got.Ambiguous() {
+		t.Fatalf("scenario resolution = %+v, want empty", got)
+	}
+
+	checks := []struct {
+		name string
+		call func() error
+	}{
+		{"consumption limit", func() error { _, err := w.ConsumptionLimit(nil); return err }},
+		{"write consumption limit", func() error { return w.WriteConsumptionLimit(nil, ucapi.LoadLimit{}) }},
+		{"failsafe power", func() error { _, err := w.FailsafeConsumptionActivePowerLimit(nil); return err }},
+		{"write failsafe power", func() error { return w.WriteFailsafeConsumptionActivePowerLimit(nil, 1) }},
+		{"failsafe duration", func() error { _, err := w.FailsafeDurationMinimum(nil); return err }},
+		{"write failsafe duration", func() error { return w.WriteFailsafeDurationMinimum(nil, time.Hour) }},
+		{"start heartbeat", func() error { return w.StartHeartbeat("ab:cd") }},
+		{"stop heartbeat", w.StopHeartbeat},
+	}
+	for _, check := range checks {
+		t.Run(check.name, func(t *testing.T) {
+			if err := check.call(); !errors.Is(err, errLPCNotInitialized) {
+				t.Fatalf("error = %v, want %v", err, errLPCNotInitialized)
+			}
+		})
+	}
+}
+
+func TestOHPCFBeforeSetupReturnsInitializationErrors(t *testing.T) {
+	w := NewOHPCFWrapper(nil, nil, false)
+	w.Setup(nil)
+	if w.UseCase() != nil {
+		t.Fatal("OHPCF wrapper returned a use case before Setup")
+	}
+	if got := w.CompatibleEntity("ab:cd"); got.Entity != nil || got.Ambiguous() {
+		t.Fatalf("entity resolution = %+v, want empty", got)
+	}
+	checks := []struct {
+		name string
+		call func() error
+	}{
+		{"available", func() error { _, err := w.OptionalPowerConsumptionAvailable(nil); return err }},
+		{"estimate", func() error { _, err := w.RequestedPowerEstimate(nil); return err }},
+		{"maximum", func() error { _, err := w.RequestedPowerMax(nil); return err }},
+		{"stoppable", func() error { _, err := w.ConsumptionIsStoppable(nil); return err }},
+		{"pausable", func() error { _, err := w.ConsumptionIsPausable(nil); return err }},
+		{"state", func() error { _, err := w.ConsumptionState(nil); return err }},
+		{"start time", func() error { _, err := w.ConsumptionStartTime(nil); return err }},
+		{"minimal run", func() error { _, err := w.MinimalRunDuration(nil); return err }},
+		{"minimal pause", func() error { _, err := w.MinimalPauseDuration(nil); return err }},
+		{"schedule", func() error { return w.Schedule(nil, time.Now()) }},
+		{"pause", func() error { return w.Pause(nil) }},
+		{"resume", func() error { return w.Resume(nil) }},
+		{"abort", func() error { return w.Abort(nil) }},
+	}
+	for _, check := range checks {
+		t.Run(check.name, func(t *testing.T) {
+			if err := check.call(); !errors.Is(err, errOHPCFNotInitialized) {
+				t.Fatalf("error = %v, want %v", err, errOHPCFNotInitialized)
+			}
+		})
+	}
+}
+
+func TestOHPCFRoutesEveryDataAndSupportEvent(t *testing.T) {
+	tests := []struct {
+		name string
+		in   eebusapi.EventType
+		want eebus.EventType
+	}{
+		{"support", cemohpcf.UseCaseSupportUpdate, eebus.EventTypeOHPCFUseCaseSupportUpdated},
+		{"stoppable", cemohpcf.DataUpdateConsumptionIsStoppable, eebus.EventTypeOHPCFConsumptionStoppableUpdated},
+		{"pausable", cemohpcf.DataUpdateConsumptionIsPausable, eebus.EventTypeOHPCFConsumptionPausableUpdated},
+		{"start time", cemohpcf.DataUpdateConsumptionStartTime, eebus.EventTypeOHPCFConsumptionStartTimeUpdated},
+		{"estimate", cemohpcf.DataUpdateRequestedPowerEstimate, eebus.EventTypeOHPCFRequestedPowerEstimateUpdated},
+		{"maximum", cemohpcf.DataUpdateRequestedPowerMax, eebus.EventTypeOHPCFRequestedPowerMaxUpdated},
+		{"minimal run", cemohpcf.DataUpdateMinimalRunDuration, eebus.EventTypeOHPCFMinimalRunDurationUpdated},
+		{"minimal pause", cemohpcf.DataUpdateMinimalPauseDuration, eebus.EventTypeOHPCFMinimalPauseDurationUpdated},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			bus := eebus.NewEventBus()
+			channel := bus.Subscribe()
+			defer bus.Unsubscribe(channel)
+			w := NewOHPCFWrapper(bus, nil, false)
+			w.HandleEvent("ab:cd", nil, nil, test.in)
+			select {
+			case event := <-channel:
+				if event.Type != test.want || event.SKI != "ABCD" {
+					t.Fatalf("event = %+v, want type %q", event, test.want)
+				}
+			case <-time.After(time.Second):
+				t.Fatal("timeout waiting for event")
+			}
+		})
+	}
+	w := NewOHPCFWrapper(nil, nil, true)
+	w.HandleEvent("ab:cd", nil, nil, cemohpcf.DataUpdateConsumptionState)
+	w.HandleEvent("ab:cd", nil, nil, "unknown")
+}
+
+func TestLPCRoutesEventsWithoutBusAndIgnoresUnknown(t *testing.T) {
+	w := NewLPCWrapper(nil, nil, true)
+	for _, event := range []eebusapi.EventType{
+		eglpc.DataUpdateLimit,
+		eglpc.DataUpdateFailsafeConsumptionActivePowerLimit,
+		eglpc.DataUpdateFailsafeDurationMinimum,
+		eglpc.DataUpdateHeartbeat,
+		eglpc.UseCaseSupportUpdate,
+		"unknown",
+	} {
+		w.HandleEvent("ab:cd", nil, nil, event)
+	}
+}
+
+func TestTemperatureMonitoringBeforeSetupAndSupportEvents(t *testing.T) {
+	tests := []struct {
+		name string
+		new  func(*eebus.EventBus, *eebus.DeviceRegistry, bool) *TemperatureMonitoringWrapper
+		want eebus.EventType
+	}{
+		{"DHW", NewDHWMonitoringWrapper, eebus.EventTypeDHWMonitoringSupportUpdated},
+		{"room", NewRoomMonitoringWrapper, eebus.EventTypeRoomMonitoringSupportUpdated},
+		{"outdoor", NewOutdoorMonitoringWrapper, eebus.EventTypeOutdoorMonitoringSupportUpdated},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			bus := eebus.NewEventBus()
+			channel := bus.Subscribe()
+			defer bus.Unsubscribe(channel)
+			w := test.new(bus, nil, true)
+			w.Setup(nil)
+			if w.UseCase() != nil {
+				t.Fatal("UseCase before Setup is not nil")
+			}
+			if _, err := w.Temperature("ab:cd"); !errors.Is(err, w.errNotInitialized) {
+				t.Fatalf("Temperature error = %v, want %v", err, w.errNotInitialized)
+			}
+			if got := w.CompatibleEntity("ab:cd"); got.Entity != nil || got.Ambiguous() {
+				t.Fatalf("CompatibleEntity = %+v, want empty", got)
+			}
+			w.HandleEvent("ab:cd", nil, nil, w.supportEvent)
+			select {
+			case event := <-channel:
+				if event.Type != test.want || event.SKI != "ABCD" {
+					t.Fatalf("event = %+v, want %q", event, test.want)
+				}
+			case <-time.After(time.Second):
+				t.Fatal("timeout waiting for support event")
+			}
+			w.HandleEvent("ab:cd", nil, nil, "unknown")
+		})
+	}
+}

--- a/scripts/check_go_patch_coverage.py
+++ b/scripts/check_go_patch_coverage.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""Fail when changed production Go statements are covered below a threshold."""
+
+from __future__ import annotations
+
+import argparse
+from collections import defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+import re
+import subprocess
+import sys
+from typing import Iterable
+
+
+MODULE_PREFIX = "github.com/volschin/eebus-bridge/"
+REPOSITORY_MODULE_PREFIX = "eebus-bridge/"
+EXCLUDED_PREFIXES = (
+    "eebus-bridge/gen/",
+    "eebus-bridge/cmd/eebus-contract-testserver/",
+)
+HUNK_RE = re.compile(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@")
+PROFILE_RE = re.compile(
+    r"^(?P<path>.+):(?P<start_line>\d+)\.(?P<start_col>\d+),"
+    r"(?P<end_line>\d+)\.(?P<end_col>\d+) "
+    r"(?P<statements>\d+) (?P<count>\d+)$"
+)
+
+
+@dataclass(frozen=True)
+class CoverageBlock:
+    path: str
+    start_line: int
+    end_line: int
+    statements: int
+    count: int
+
+
+@dataclass(frozen=True)
+class PatchCoverage:
+    covered: int
+    total: int
+    per_file: dict[str, tuple[int, int]]
+    uncovered: tuple[CoverageBlock, ...]
+
+    @property
+    def percentage(self) -> float:
+        return 100.0 if self.total == 0 else 100.0 * self.covered / self.total
+
+
+def is_productive_go_path(path: str) -> bool:
+    return (
+        path.startswith(REPOSITORY_MODULE_PREFIX)
+        and path.endswith(".go")
+        and not path.endswith("_test.go")
+        and not path.startswith(EXCLUDED_PREFIXES)
+    )
+
+
+def parse_changed_lines(diff: str) -> dict[str, set[int]]:
+    changed: dict[str, set[int]] = defaultdict(set)
+    current_path: str | None = None
+    for line in diff.splitlines():
+        if line.startswith("+++ "):
+            target = line[4:]
+            current_path = None if target == "/dev/null" else target.removeprefix("b/")
+            if current_path is not None and not is_productive_go_path(current_path):
+                current_path = None
+            continue
+        match = HUNK_RE.match(line)
+        if match is None or current_path is None:
+            continue
+        start = int(match.group(1))
+        count = int(match.group(2) or "1")
+        if count > 0:
+            changed[current_path].update(range(start, start + count))
+    return dict(changed)
+
+
+def repository_path(profile_path: str) -> str | None:
+    if profile_path.startswith(MODULE_PREFIX):
+        return REPOSITORY_MODULE_PREFIX + profile_path[len(MODULE_PREFIX) :]
+    if profile_path.startswith(REPOSITORY_MODULE_PREFIX):
+        return profile_path
+    return None
+
+
+def parse_coverage_profile(lines: Iterable[str]) -> list[CoverageBlock]:
+    blocks: list[CoverageBlock] = []
+    for raw_line in lines:
+        line = raw_line.strip()
+        if not line or line.startswith("mode:"):
+            continue
+        match = PROFILE_RE.match(line)
+        if match is None:
+            raise ValueError(f"invalid Go coverage profile line: {line}")
+        path = repository_path(match.group("path"))
+        if path is None or not is_productive_go_path(path):
+            continue
+        blocks.append(
+            CoverageBlock(
+                path=path,
+                start_line=int(match.group("start_line")),
+                end_line=int(match.group("end_line")),
+                statements=int(match.group("statements")),
+                count=int(match.group("count")),
+            )
+        )
+    return blocks
+
+
+def calculate_patch_coverage(
+    changed_lines: dict[str, set[int]], blocks: Iterable[CoverageBlock]
+) -> PatchCoverage:
+    covered = 0
+    total = 0
+    per_file_counts: dict[str, list[int]] = defaultdict(lambda: [0, 0])
+    uncovered: list[CoverageBlock] = []
+    for block in blocks:
+        lines = changed_lines.get(block.path)
+        if not lines or not any(block.start_line <= line <= block.end_line for line in lines):
+            continue
+        total += block.statements
+        per_file_counts[block.path][1] += block.statements
+        if block.count > 0:
+            covered += block.statements
+            per_file_counts[block.path][0] += block.statements
+        else:
+            uncovered.append(block)
+    return PatchCoverage(
+        covered=covered,
+        total=total,
+        per_file={path: (values[0], values[1]) for path, values in per_file_counts.items()},
+        uncovered=tuple(uncovered),
+    )
+
+
+def meets_threshold(result: PatchCoverage, threshold: float) -> bool:
+    return result.percentage + 1e-9 >= threshold
+
+
+def git_diff(base: str, head: str, repository: Path) -> str:
+    result = subprocess.run(
+        ["git", "diff", "--unified=0", "--no-ext-diff", base, head, "--", "*.go"],
+        cwd=repository,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+    )
+    return result.stdout
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--profile", required=True, type=Path, help="Go coverprofile path")
+    parser.add_argument("--base", required=True, help="Git base commit or tree")
+    parser.add_argument("--head", default="HEAD", help="Git head commit (default: HEAD)")
+    parser.add_argument("--repository", default=Path.cwd(), type=Path, help="Git repository root")
+    parser.add_argument("--threshold", default=90.0, type=float, help="required percentage")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    if not 0 <= args.threshold <= 100:
+        print("error: threshold must be between 0 and 100", file=sys.stderr)
+        return 2
+    try:
+        diff = git_diff(args.base, args.head, args.repository)
+        changed = parse_changed_lines(diff)
+        with args.profile.open(encoding="utf-8") as profile:
+            blocks = parse_coverage_profile(profile)
+    except (OSError, ValueError, subprocess.CalledProcessError) as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 2
+
+    result = calculate_patch_coverage(changed, blocks)
+    if result.total == 0:
+        print("Go patch coverage: no changed production Go statements; gate passed")
+        return 0
+
+    print(
+        f"Go patch coverage: {result.percentage:.1f}% "
+        f"({result.covered}/{result.total} statements), required {args.threshold:.1f}%"
+    )
+    for path, (file_covered, file_total) in sorted(result.per_file.items()):
+        print(f"  {path}: {100.0 * file_covered / file_total:.1f}% ({file_covered}/{file_total})")
+    if result.uncovered:
+        print("Uncovered changed blocks:")
+        for block in result.uncovered:
+            print(f"  {block.path}:{block.start_line}-{block.end_line} ({block.statements} statements)")
+    return 0 if meets_threshold(result, args.threshold) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_check_go_patch_coverage.py
+++ b/scripts/tests/test_check_go_patch_coverage.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import sys
+import unittest
+
+
+SCRIPT = Path(__file__).parents[1] / "check_go_patch_coverage.py"
+SPEC = importlib.util.spec_from_file_location("check_go_patch_coverage", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+coverage = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = coverage
+SPEC.loader.exec_module(coverage)
+
+
+class ChangedLinesTest(unittest.TestCase):
+    def test_parses_added_and_modified_lines_and_excludes_non_productive_files(self) -> None:
+        diff = """\
+diff --git a/eebus-bridge/internal/example.go b/eebus-bridge/internal/example.go
+--- a/eebus-bridge/internal/example.go
++++ b/eebus-bridge/internal/example.go
+@@ -10,2 +10,3 @@
++changed
+diff --git a/eebus-bridge/internal/example_test.go b/eebus-bridge/internal/example_test.go
+--- a/eebus-bridge/internal/example_test.go
++++ b/eebus-bridge/internal/example_test.go
+@@ -1 +1,2 @@
++test
+diff --git a/eebus-bridge/gen/proto/generated.go b/eebus-bridge/gen/proto/generated.go
+--- a/eebus-bridge/gen/proto/generated.go
++++ b/eebus-bridge/gen/proto/generated.go
+@@ -1 +1,2 @@
++generated
+"""
+        self.assertEqual(
+            coverage.parse_changed_lines(diff),
+            {"eebus-bridge/internal/example.go": {10, 11, 12}},
+        )
+
+    def test_zero_length_deletion_hunk_adds_no_lines(self) -> None:
+        diff = """\
+diff --git a/eebus-bridge/internal/example.go b/eebus-bridge/internal/example.go
+--- a/eebus-bridge/internal/example.go
++++ b/eebus-bridge/internal/example.go
+@@ -4,2 +4,0 @@
+"""
+        self.assertEqual(coverage.parse_changed_lines(diff), {})
+
+
+class CoverageProfileTest(unittest.TestCase):
+    def test_parses_module_paths_and_ignores_excluded_paths(self) -> None:
+        blocks = coverage.parse_coverage_profile(
+            [
+                "mode: set\n",
+                "github.com/volschin/eebus-bridge/internal/example.go:10.1,12.2 3 1\n",
+                "github.com/volschin/eebus-bridge/gen/proto/generated.go:1.1,2.2 2 0\n",
+                "github.com/volschin/eebus-bridge/cmd/eebus-contract-testserver/main.go:1.1,2.2 2 0\n",
+            ]
+        )
+        self.assertEqual(
+            blocks,
+            [coverage.CoverageBlock("eebus-bridge/internal/example.go", 10, 12, 3, 1)],
+        )
+
+    def test_rejects_invalid_profile_lines(self) -> None:
+        with self.assertRaises(ValueError):
+            coverage.parse_coverage_profile(["not a profile line"])
+
+
+class PatchCoverageTest(unittest.TestCase):
+    def test_counts_each_overlapping_block_once(self) -> None:
+        changed = {"eebus-bridge/internal/example.go": {11, 12, 20}}
+        blocks = [
+            coverage.CoverageBlock("eebus-bridge/internal/example.go", 10, 12, 3, 1),
+            coverage.CoverageBlock("eebus-bridge/internal/example.go", 20, 20, 2, 0),
+            coverage.CoverageBlock("eebus-bridge/internal/example.go", 30, 30, 5, 0),
+        ]
+        result = coverage.calculate_patch_coverage(changed, blocks)
+        self.assertEqual((result.covered, result.total), (3, 5))
+        self.assertAlmostEqual(result.percentage, 60.0)
+        self.assertEqual(result.per_file, {"eebus-bridge/internal/example.go": (3, 5)})
+        self.assertEqual(result.uncovered, (blocks[1],))
+        self.assertFalse(coverage.meets_threshold(result, 90.0))
+        self.assertTrue(coverage.meets_threshold(result, 60.0))
+
+    def test_no_changed_statements_passes_at_one_hundred_percent(self) -> None:
+        result = coverage.calculate_patch_coverage({}, [])
+        self.assertEqual(result.total, 0)
+        self.assertEqual(result.percentage, 100.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- raise productive handwritten Go statement coverage to 83.340% (4172/5006)
- add meaningful CLI, application, EEBUS, gRPC, and use-case tests without changing production Go code
- add a CI gate that keeps total coverage at or above 83% and requires at least 90% coverage for changed production Go statements
- exclude generated protobuf code, test files, and the contract-test server from coverage calculations
- document scope, measurement method, implementation, and final package results

## Validation

- go test -count=1 ./...
- go test -count=1 -race ./...
- go vet ./...
- go test -count=1 -tags=integration -v ./internal/grpc/ -run TestIntegration
- productive coverage: 83.340% (4172/5006)
- Python patch-coverage checker unit tests
- Ruff validation for the checker
- workflow YAML parsing

## Production code

No productive Go files are changed by this pull request.