### PR TITLE
fix: preserve reconciliation polling during stream updates

### DIFF
--- a/custom_components/eebus/coordinator.py
+++ b/custom_components/eebus/coordinator.py
@@ -221,8 +221,15 @@ class EebusCoordinator(DataUpdateCoordinator[DeviceState]):
             raise cancellation
 
     def _publish_state(self, state: DeviceState) -> None:
-        """Publish one already-reduced immutable state atomically."""
-        self.async_set_updated_data(state)
+        """Publish push data without postponing the reconciliation poll.
+
+        ``DataUpdateCoordinator.async_set_updated_data`` resets the coordinator's
+        update interval.  EEBUS normally pushes more often than ``POLL_INTERVAL``,
+        so using it here could postpone the full snapshot reconciliation forever.
+        """
+        self.data = state
+        self.last_update_success = True
+        self.async_update_listeners()
 
     def _publish_session_state(self, generation: object, state: DeviceState) -> None:
         """Ignore staged or superseded session observations outside commit."""

--- a/custom_components/eebus/tests/test_coordinator.py
+++ b/custom_components/eebus/tests/test_coordinator.py
@@ -64,6 +64,23 @@ def test_poll_interval_is_slow_reconciliation() -> None:
     assert POLL_INTERVAL == timedelta(minutes=5)
 
 
+def test_stream_publish_does_not_postpone_reconciliation_poll() -> None:
+    """Frequent push updates must not reset the coordinator's poll interval."""
+    coordinator = EebusCoordinator.__new__(EebusCoordinator)
+    coordinator.data = None
+    coordinator.last_update_success = False
+    coordinator.async_set_updated_data = MagicMock()
+    coordinator.async_update_listeners = MagicMock()
+    state = DeviceState(connection=ConnectionState(connected=True))
+
+    coordinator._publish_state(state)
+
+    assert coordinator.data is state
+    assert coordinator.last_update_success is True
+    coordinator.async_update_listeners.assert_called_once_with()
+    coordinator.async_set_updated_data.assert_not_called()
+
+
 async def test_ensure_channel_delegates_to_manager() -> None:
     coordinator = EebusCoordinator.__new__(EebusCoordinator)
     channel = MagicMock()


### PR DESCRIPTION
## Summary

- publish EEBUS stream state without resetting Home Assistant's coordinator interval
- keep the independent five-minute snapshot reconciliation active during frequent push traffic
- add a regression test ensuring push updates do not use the timer-resetting API

## Root cause

`DataUpdateCoordinator.async_set_updated_data()` resets the next scheduled refresh. EEBUS normally emits stream updates more often than the five-minute polling interval, so continuous push traffic could postpone snapshot reconciliation indefinitely. A field marked temporarily unavailable could therefore remain unavailable until the integration was reloaded.

## Verification

- `PYTHONPATH=. .venv/bin/pytest -q` — 265 passed
- `.venv/bin/python -m mypy custom_components/eebus` — passed
- `.venv/bin/uvx ruff check custom_components/` — passed
