### PR TITLE
fix: preserve OHPCF availability without active process

### DIFF
--- a/custom_components/eebus/device_session.py
+++ b/custom_components/eebus/device_session.py
@@ -112,6 +112,7 @@ class DeviceSession:
             "OHPCF control",
             stub.ControlCompressorFlexibility,
             proto_stubs.ControlCompressorRequest(ski=self._ski, action=action),
+            validation=True,
         )
 
     async def write_dhw_setpoint(self, value_celsius: float) -> WriteOutcome:

--- a/custom_components/eebus/select.py
+++ b/custom_components/eebus/select.py
@@ -7,6 +7,7 @@ from typing import Any
 from homeassistant.components.select import SelectEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .coordinator import EebusCoordinator
@@ -66,7 +67,7 @@ class EebusCompressorFlexibilitySelect(EebusEntity, SelectEntity):
 
     @property
     def available(self) -> bool:
-        """Available only while the compressor advertises a flexibility offer."""
+        """Available while the OHPCF capability and its base state are readable."""
         data = self.coordinator.data
         return bool(
             super().available
@@ -107,14 +108,35 @@ class EebusCompressorFlexibilitySelect(EebusEntity, SelectEntity):
 
         flex = self._flex()
         if option == OPTION_ON:
-            action = (
-                proto_stubs.OHPCFAction.OHPCF_ACTION_RESUME
-                if flex is not None and flex.state == _OHPCF_PAUSED_STATE
-                else proto_stubs.OHPCFAction.OHPCF_ACTION_SCHEDULE
-            )
+            if flex is not None and flex.state == _OHPCF_PAUSED_STATE:
+                action = proto_stubs.OHPCFAction.OHPCF_ACTION_RESUME
+            elif flex is not None and flex.available:
+                action = proto_stubs.OHPCFAction.OHPCF_ACTION_SCHEDULE
+            else:
+                raise ServiceValidationError(
+                    "No optional compressor-consumption process is available to schedule"
+                )
         elif option == OPTION_PAUSED:
+            if (
+                flex is None
+                or flex.state != "COMPRESSOR_STATE_RUNNING"
+                or not flex.is_pausable
+            ):
+                raise ServiceValidationError(
+                    "Only a running, pausable compressor process can be paused"
+                )
             action = proto_stubs.OHPCFAction.OHPCF_ACTION_PAUSE
-        else:
+        elif option == OPTION_OFF:
+            if (
+                flex is None
+                or flex.state not in _OHPCF_ON_STATES | {_OHPCF_PAUSED_STATE}
+                or not flex.is_stoppable
+            ):
+                raise ServiceValidationError(
+                    "Only an active or scheduled stoppable compressor process can be aborted"
+                )
             action = proto_stubs.OHPCFAction.OHPCF_ACTION_ABORT
+        else:
+            raise ServiceValidationError(f"Unsupported compressor option: {option}")
         await self.coordinator.async_control_compressor(action)
         await self.coordinator.async_request_refresh()

--- a/custom_components/eebus/tests/test_device_session.py
+++ b/custom_components/eebus/tests/test_device_session.py
@@ -130,11 +130,14 @@ def test_set_lpc_active_reads_current_limit_then_writes():
     assert outcome == WriteOutcome(status_code=None)
 
 
-def test_control_compressor_calls_ohpcf_stub_without_validation():
+def test_control_compressor_classifies_precondition_as_validation_error():
     session = DeviceSession("test-ski", AsyncMock(return_value="channel"))
     err_stub = AsyncMock()
     err = AioRpcError(
-        grpc.StatusCode.INTERNAL, Metadata(), Metadata(), details="data not available"
+        grpc.StatusCode.FAILED_PRECONDITION,
+        Metadata(),
+        Metadata(),
+        details="process is not pausable",
     )
     err_stub.ControlCompressorFlexibility = AsyncMock(side_effect=err)
     with patch.object(proto_stubs, "ohpcf_service_stub", return_value=err_stub):
@@ -144,8 +147,10 @@ def test_control_compressor_calls_ohpcf_stub_without_validation():
             )
         )
 
-    # validation=False for this method: INTERNAL is not classified as validation_error.
-    assert outcome.validation_error is None
+    assert (
+        outcome.validation_error
+        == "OHPCF control failed: process is not pausable"
+    )
     assert outcome.error is err
 
 

--- a/custom_components/eebus/tests/test_ohpcf.py
+++ b/custom_components/eebus/tests/test_ohpcf.py
@@ -1,6 +1,7 @@
 """Tests for OHPCF state conversion and controls."""
 
 import asyncio
+from dataclasses import replace
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
@@ -116,6 +117,18 @@ def test_select_is_unavailable_when_retained_offer_is_stale() -> None:
     assert EebusCompressorFlexibilitySelect(coordinator).available is False
 
 
+def test_select_remains_available_when_no_process_is_offered() -> None:
+    flex = replace(
+        _flex("COMPRESSOR_STATE_STOPPED"),
+        available=False,
+        is_pausable=False,
+        is_stoppable=False,
+    )
+    select = _select_with(flex)
+    assert select.available is True
+    assert select.current_option == "off"
+
+
 def test_select_option_on_schedules_or_resumes() -> None:
     select = _select_with(_flex())
     asyncio.run(select.async_select_option("on"))
@@ -123,6 +136,43 @@ def test_select_option_on_schedules_or_resumes() -> None:
     select = _select_with(_flex("COMPRESSOR_STATE_PAUSED"))
     asyncio.run(select.async_select_option("on"))
     select.coordinator.async_control_compressor.assert_awaited_once_with(proto_stubs.OHPCFAction.OHPCF_ACTION_RESUME)
+
+
+def test_select_only_sends_permitted_pause_and_abort_actions() -> None:
+    select = _select_with(_flex("COMPRESSOR_STATE_RUNNING"))
+    asyncio.run(select.async_select_option("paused"))
+    select.coordinator.async_control_compressor.assert_awaited_once_with(
+        proto_stubs.OHPCFAction.OHPCF_ACTION_PAUSE
+    )
+
+    select = _select_with(
+        replace(_flex("COMPRESSOR_STATE_RUNNING"), is_stoppable=True)
+    )
+    asyncio.run(select.async_select_option("off"))
+    select.coordinator.async_control_compressor.assert_awaited_once_with(
+        proto_stubs.OHPCFAction.OHPCF_ACTION_ABORT
+    )
+
+
+@pytest.mark.parametrize(
+    ("flex", "option"),
+    [
+        (replace(_flex(), available=False), "on"),
+        (_flex("COMPRESSOR_STATE_SCHEDULED"), "paused"),
+        (replace(_flex("COMPRESSOR_STATE_RUNNING"), is_pausable=False), "paused"),
+        (_flex("COMPRESSOR_STATE_RUNNING"), "off"),
+        (replace(_flex("COMPRESSOR_STATE_STOPPED"), is_stoppable=True), "off"),
+        (_flex(), "invalid"),
+    ],
+)
+def test_select_rejects_actions_disallowed_by_ohpcf(
+    flex: CompressorFlexibilityState, option: str
+) -> None:
+    select = _select_with(flex)
+    with pytest.raises(ServiceValidationError):
+        asyncio.run(select.async_select_option(option))
+    select.coordinator.async_control_compressor.assert_not_awaited()
+    select.coordinator.async_request_refresh.assert_not_awaited()
 
 
 def test_status_sensor_maps_raw_state() -> None:

--- a/docs/badges/go-coverage.svg
+++ b/docs/badges/go-coverage.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="172" height="28" role="img" aria-label="Go coverage: 83.3%">
-  <title>Go coverage: 83.3%</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="172" height="28" role="img" aria-label="Go coverage: 83.4%">
+  <title>Go coverage: 83.4%</title>
   <linearGradient id="s" x2="0" y2="100%">
     <stop offset="0" stop-color="#fff" stop-opacity=".15"/>
     <stop offset="1" stop-opacity=".15"/>
@@ -12,6 +12,6 @@
   </g>
   <g fill="#fff" text-anchor="middle" font-family="Verdana,DejaVu Sans,sans-serif" font-size="10" font-weight="700">
     <text x="56" y="18">GO COVERAGE</text>
-    <text x="142" y="18">83.3%</text>
+    <text x="142" y="18">83.4%</text>
   </g>
 </svg>

--- a/eebus-bridge/internal/grpc/device_state_contract_test.go
+++ b/eebus-bridge/internal/grpc/device_state_contract_test.go
@@ -292,6 +292,25 @@ func TestOHPCFEnvelopeAvailabilityTracksTheUpdatedField(t *testing.T) {
 	if missing.GetOhpcf().GetFlexibility() == nil {
 		t.Fatalf("legacy-stream clients must keep the partial payload: %v", missing)
 	}
+	absentPermissionController := controller
+	absentPermissionController.stoppableErr = eebusapi.ErrDataNotAvailable
+	absentPermissionService := NewDeviceService(
+		nil,
+		bus,
+		"local",
+		registry,
+		nil,
+		WithDeviceStatePayloads(DeviceStatePayloadSources{
+			OHPCF: NewOHPCFService(nil, bus, registry, WithOHPCFController(absentPermissionController)),
+		}),
+	)
+	absentPermission := absentPermissionService.deviceStateEnvelope(eebus.Event{
+		SKI: testValidSKI, Type: eebus.EventTypeOHPCFConsumptionStoppableUpdated, OccurredAt: time.Now(),
+	})
+	if absentPermission.GetAvailability() != pb.EventAvailability_EVENT_AVAILABILITY_AVAILABLE ||
+		absentPermission.GetOhpcf().GetFlexibility().GetIsStoppable() {
+		t.Fatalf("absent optional stoppable permission = %v", absentPermission)
+	}
 	missingStateSource := controller
 	missingStateSource.availableErr = errors.New("availability cache miss")
 	missingStateService := NewDeviceService(

--- a/eebus-bridge/internal/grpc/ohpcf_service.go
+++ b/eebus-bridge/internal/grpc/ohpcf_service.go
@@ -30,14 +30,10 @@ const (
 	ohpcfReadStartTime
 )
 
-// ohpcfCoreReadMask covers only fields the compressor reports regardless of
-// whether it currently has an active optional-consumption offer. Minimal
-// run/pause duration, like power estimate/max and start time, are
-// offer-specific and legitimately absent while idle (cf.
-// isOHPCFOptionalAbsent) — requiring them here made the capability read as
-// TemporarilyUnavailable, and thus every idle "off" flexibility reading
-// invisible to HA, whenever the compressor had no active offer.
-const ohpcfCoreReadMask = ohpcfReadAvailable | ohpcfReadStoppable | ohpcfReadPausable | ohpcfReadState
+// ohpcfCoreReadMask contains the two values OHPCF defines even when no optional
+// consumption process exists: availability=false and state=stopped. All other
+// fields describe an offered process and may legitimately be absent while idle.
+const ohpcfCoreReadMask = ohpcfReadAvailable | ohpcfReadState
 
 // OHPCFService exposes the bridge's OHPCF (heat-pump compressor flexibility)
 // CEM-client use case over gRPC: read the compressor's optional-consumption offer
@@ -106,7 +102,7 @@ func (s *OHPCFService) GetCompressorFlexibility(_ context.Context, req *pb.Devic
 		return nil, err
 	}
 	flexibility, reads, _ := s.buildFlexibility(entity)
-	if reads == 0 {
+	if reads&ohpcfCoreReadMask != ohpcfCoreReadMask {
 		if s.registry != nil {
 			s.registry.RecordCapabilityRead(req.Ski, eebus.CapabilityOHPCF, eebusapi.ErrDataNotAvailable)
 		}
@@ -132,6 +128,9 @@ func (s *OHPCFService) ControlCompressorFlexibility(_ context.Context, req *pb.C
 	if err != nil {
 		return nil, err
 	}
+	if err := s.validateOHPCFAction(entity, req.Action); err != nil {
+		return nil, err
+	}
 
 	switch req.Action {
 	case pb.OHPCFAction_OHPCF_ACTION_SCHEDULE:
@@ -153,6 +152,65 @@ func (s *OHPCFService) ControlCompressorFlexibility(_ context.Context, req *pb.C
 		return nil, mapUsecaseError("controlling compressor flexibility", err, standardUsecaseErrorClasses)
 	}
 	return &pb.Empty{}, nil
+}
+
+func (s *OHPCFService) validateOHPCFAction(
+	entity spineapi.EntityRemoteInterface,
+	action pb.OHPCFAction,
+) error {
+	switch action {
+	case pb.OHPCFAction_OHPCF_ACTION_SCHEDULE:
+		available, err := s.ohpcf.OptionalPowerConsumptionAvailable(entity)
+		if err != nil {
+			return mapUsecaseError("validating compressor schedule", err, standardUsecaseErrorClasses)
+		}
+		if !available {
+			return status.Error(codes.FailedPrecondition, "compressor schedule requires an available optional-consumption process")
+		}
+	case pb.OHPCFAction_OHPCF_ACTION_PAUSE:
+		state, err := s.ohpcf.ConsumptionState(entity)
+		if err != nil {
+			return mapUsecaseError("validating compressor pause", err, standardUsecaseErrorClasses)
+		}
+		if state != ucapi.CompressorPowerConsumptionStateRunning {
+			return status.Error(codes.FailedPrecondition, "compressor pause requires a running process")
+		}
+		pausable, err := s.ohpcf.ConsumptionIsPausable(entity)
+		if err != nil && !isOHPCFOptionalAbsent(err) {
+			return mapUsecaseError("validating compressor pause", err, standardUsecaseErrorClasses)
+		}
+		if !pausable {
+			return status.Error(codes.FailedPrecondition, "compressor process is not pausable")
+		}
+	case pb.OHPCFAction_OHPCF_ACTION_RESUME:
+		state, err := s.ohpcf.ConsumptionState(entity)
+		if err != nil {
+			return mapUsecaseError("validating compressor resume", err, standardUsecaseErrorClasses)
+		}
+		if state != ucapi.CompressorPowerConsumptionStatePaused {
+			return status.Error(codes.FailedPrecondition, "compressor resume requires a paused process")
+		}
+	case pb.OHPCFAction_OHPCF_ACTION_ABORT:
+		state, err := s.ohpcf.ConsumptionState(entity)
+		if err != nil {
+			return mapUsecaseError("validating compressor abort", err, standardUsecaseErrorClasses)
+		}
+		if state != ucapi.CompressorPowerConsumptionStateScheduled &&
+			state != ucapi.CompressorPowerConsumptionStateRunning &&
+			state != ucapi.CompressorPowerConsumptionStatePaused {
+			return status.Error(codes.FailedPrecondition, "compressor abort requires an active or scheduled process")
+		}
+		stoppable, err := s.ohpcf.ConsumptionIsStoppable(entity)
+		if err != nil && !isOHPCFOptionalAbsent(err) {
+			return mapUsecaseError("validating compressor abort", err, standardUsecaseErrorClasses)
+		}
+		if !stoppable {
+			return status.Error(codes.FailedPrecondition, "compressor process is not stoppable")
+		}
+	default:
+		return status.Error(codes.InvalidArgument, "action is required (schedule/pause/resume/abort)")
+	}
+	return nil
 }
 
 func (s *OHPCFService) SubscribeOHPCFEvents(req *pb.DeviceRequest, stream pb.OHPCFService_SubscribeOHPCFEventsServer) error {
@@ -266,10 +324,14 @@ func (s *OHPCFService) buildFlexibility(entity spineapi.EntityRemoteInterface) (
 	if stoppable, err := s.ohpcf.ConsumptionIsStoppable(entity); err == nil {
 		f.IsStoppable = stoppable
 		reads |= ohpcfReadStoppable
+	} else if isOHPCFOptionalAbsent(err) {
+		clears |= ohpcfReadStoppable
 	}
 	if pausable, err := s.ohpcf.ConsumptionIsPausable(entity); err == nil {
 		f.IsPausable = pausable
 		reads |= ohpcfReadPausable
+	} else if isOHPCFOptionalAbsent(err) {
+		clears |= ohpcfReadPausable
 	}
 	if st, err := s.ohpcf.ConsumptionState(entity); err == nil {
 		f.State = convertCompressorState(st)

--- a/eebus-bridge/internal/grpc/ohpcf_service_additional_test.go
+++ b/eebus-bridge/internal/grpc/ohpcf_service_additional_test.go
@@ -59,6 +59,55 @@ func (f failingOHPCFController) Pause(spineapi.EntityRemoteInterface) error  { r
 func (f failingOHPCFController) Resume(spineapi.EntityRemoteInterface) error { return f.err }
 func (f failingOHPCFController) Abort(spineapi.EntityRemoteInterface) error  { return f.err }
 
+type noProcessOHPCFController struct {
+	failingOHPCFController
+}
+
+func (noProcessOHPCFController) OptionalPowerConsumptionAvailable(spineapi.EntityRemoteInterface) (bool, error) {
+	return false, nil
+}
+func (noProcessOHPCFController) ConsumptionState(spineapi.EntityRemoteInterface) (ucapi.CompressorPowerConsumptionStateType, error) {
+	return ucapi.CompressorPowerConsumptionStateStopped, nil
+}
+
+type controlOHPCFController struct {
+	failingOHPCFController
+	available bool
+	state     ucapi.CompressorPowerConsumptionStateType
+	stoppable bool
+	pausable  bool
+	calls     []string
+}
+
+func (c *controlOHPCFController) OptionalPowerConsumptionAvailable(spineapi.EntityRemoteInterface) (bool, error) {
+	return c.available, nil
+}
+func (c *controlOHPCFController) ConsumptionState(spineapi.EntityRemoteInterface) (ucapi.CompressorPowerConsumptionStateType, error) {
+	return c.state, nil
+}
+func (c *controlOHPCFController) ConsumptionIsStoppable(spineapi.EntityRemoteInterface) (bool, error) {
+	return c.stoppable, nil
+}
+func (c *controlOHPCFController) ConsumptionIsPausable(spineapi.EntityRemoteInterface) (bool, error) {
+	return c.pausable, nil
+}
+func (c *controlOHPCFController) Schedule(spineapi.EntityRemoteInterface, time.Time) error {
+	c.calls = append(c.calls, "schedule")
+	return nil
+}
+func (c *controlOHPCFController) Pause(spineapi.EntityRemoteInterface) error {
+	c.calls = append(c.calls, "pause")
+	return nil
+}
+func (c *controlOHPCFController) Resume(spineapi.EntityRemoteInterface) error {
+	c.calls = append(c.calls, "resume")
+	return nil
+}
+func (c *controlOHPCFController) Abort(spineapi.EntityRemoteInterface) error {
+	c.calls = append(c.calls, "abort")
+	return nil
+}
+
 func TestOHPCFServiceGetFlexibilityContracts(t *testing.T) {
 	ctx := context.Background()
 	empty := NewOHPCFService(nil, eebus.NewEventBus(), eebus.NewDeviceRegistry())
@@ -98,6 +147,47 @@ func TestOHPCFServiceGetFlexibilityContracts(t *testing.T) {
 	}
 }
 
+func TestOHPCFNoProcessRemainsAvailableInReadsEventsAndSnapshots(t *testing.T) {
+	ctx := context.Background()
+	entity := mocks.NewEntityRemoteInterface(t)
+	registry := eebus.NewDeviceRegistry()
+	registry.AddDevice(testValidSKI, eebus.DeviceInfo{})
+	controller := noProcessOHPCFController{failingOHPCFController{
+		entity: entity,
+		err:    eebusapi.ErrDataNotAvailable,
+	}}
+	service := NewOHPCFService(nil, eebus.NewEventBus(), registry, WithOHPCFController(controller))
+
+	result, err := service.GetCompressorFlexibility(ctx, &pb.DeviceRequest{Ski: testValidSKI})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.GetAvailable() || result.GetState() != pb.CompressorPowerConsumptionState_COMPRESSOR_STATE_STOPPED ||
+		result.GetIsStoppable() || result.GetIsPausable() || result.RequestedPowerEstimateW != nil ||
+		result.RequestedPowerMaxW != nil || result.StartTime != nil {
+		t.Fatalf("no-process flexibility = %+v", result)
+	}
+
+	event := &pb.OHPCFEvent{}
+	if !service.AttachOHPCFPayload(event, testValidSKI, eebus.EventTypeOHPCFConsumptionStateUpdated) {
+		t.Fatalf("no-process state event was marked unavailable: %+v", event)
+	}
+	permissionEvent := &pb.OHPCFEvent{}
+	if !service.AttachOHPCFPayload(permissionEvent, testValidSKI, eebus.EventTypeOHPCFConsumptionStoppableUpdated) {
+		t.Fatalf("absent optional permission was marked unavailable: %+v", permissionEvent)
+	}
+
+	snapshot, err := NewDeviceSnapshotAssembler(registry, DeviceStatePayloadSources{OHPCF: service}).Build(testValidSKI, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if snapshot.GetCompressorFlexibilityState() != pb.SnapshotValueState_SNAPSHOT_VALUE_STATE_AVAILABLE ||
+		snapshot.GetCompressorFlexibility().GetAvailable() ||
+		snapshot.GetCompressorFlexibility().GetState() != pb.CompressorPowerConsumptionState_COMPRESSOR_STATE_STOPPED {
+		t.Fatalf("no-process snapshot = %+v", snapshot)
+	}
+}
+
 func TestOHPCFServiceControlContracts(t *testing.T) {
 	ctx := context.Background()
 	entity := mocks.NewEntityRemoteInterface(t)
@@ -115,16 +205,96 @@ func TestOHPCFServiceControlContracts(t *testing.T) {
 	}
 
 	start := timestamppb.New(time.Now().Add(time.Minute))
-	for _, request := range []*pb.ControlCompressorRequest{
-		{Ski: testValidSKI, Action: pb.OHPCFAction_OHPCF_ACTION_SCHEDULE},
-		{Ski: testValidSKI, Action: pb.OHPCFAction_OHPCF_ACTION_SCHEDULE, StartTime: start},
-		{Ski: testValidSKI, Action: pb.OHPCFAction_OHPCF_ACTION_PAUSE},
-		{Ski: testValidSKI, Action: pb.OHPCFAction_OHPCF_ACTION_RESUME},
-		{Ski: testValidSKI, Action: pb.OHPCFAction_OHPCF_ACTION_ABORT},
-	} {
-		if _, err := service.ControlCompressorFlexibility(ctx, request); err != nil {
-			t.Fatalf("action %s: %v", request.Action, err)
-		}
+	allowed := []struct {
+		name       string
+		controller *controlOHPCFController
+		request    *pb.ControlCompressorRequest
+		wantCall   string
+	}{
+		{
+			name: "schedule available process", controller: &controlOHPCFController{
+				failingOHPCFController: failingOHPCFController{entity: entity}, available: true,
+			},
+			request: &pb.ControlCompressorRequest{Ski: testValidSKI, Action: pb.OHPCFAction_OHPCF_ACTION_SCHEDULE, StartTime: start}, wantCall: "schedule",
+		},
+		{
+			name: "pause running pausable process", controller: &controlOHPCFController{
+				failingOHPCFController: failingOHPCFController{entity: entity}, state: ucapi.CompressorPowerConsumptionStateRunning, pausable: true,
+			},
+			request: &pb.ControlCompressorRequest{Ski: testValidSKI, Action: pb.OHPCFAction_OHPCF_ACTION_PAUSE}, wantCall: "pause",
+		},
+		{
+			name: "resume paused process", controller: &controlOHPCFController{
+				failingOHPCFController: failingOHPCFController{entity: entity}, state: ucapi.CompressorPowerConsumptionStatePaused,
+			},
+			request: &pb.ControlCompressorRequest{Ski: testValidSKI, Action: pb.OHPCFAction_OHPCF_ACTION_RESUME}, wantCall: "resume",
+		},
+		{
+			name: "abort running stoppable process", controller: &controlOHPCFController{
+				failingOHPCFController: failingOHPCFController{entity: entity}, state: ucapi.CompressorPowerConsumptionStateRunning, stoppable: true,
+			},
+			request: &pb.ControlCompressorRequest{Ski: testValidSKI, Action: pb.OHPCFAction_OHPCF_ACTION_ABORT}, wantCall: "abort",
+		},
+	}
+	for _, test := range allowed {
+		t.Run(test.name, func(t *testing.T) {
+			service := NewOHPCFService(nil, eebus.NewEventBus(), nil, WithOHPCFController(test.controller))
+			if _, err := service.ControlCompressorFlexibility(ctx, test.request); err != nil {
+				t.Fatal(err)
+			}
+			if len(test.controller.calls) != 1 || test.controller.calls[0] != test.wantCall {
+				t.Fatalf("write calls = %v, want [%s]", test.controller.calls, test.wantCall)
+			}
+		})
+	}
+
+	rejected := []struct {
+		name       string
+		controller *controlOHPCFController
+		action     pb.OHPCFAction
+	}{
+		{
+			name: "schedule without offer", controller: &controlOHPCFController{
+				failingOHPCFController: failingOHPCFController{entity: entity}, available: false,
+			}, action: pb.OHPCFAction_OHPCF_ACTION_SCHEDULE,
+		},
+		{
+			name: "pause non-running process", controller: &controlOHPCFController{
+				failingOHPCFController: failingOHPCFController{entity: entity}, state: ucapi.CompressorPowerConsumptionStateScheduled, pausable: true,
+			}, action: pb.OHPCFAction_OHPCF_ACTION_PAUSE,
+		},
+		{
+			name: "pause process without permission", controller: &controlOHPCFController{
+				failingOHPCFController: failingOHPCFController{entity: entity}, state: ucapi.CompressorPowerConsumptionStateRunning,
+			}, action: pb.OHPCFAction_OHPCF_ACTION_PAUSE,
+		},
+		{
+			name: "resume non-paused process", controller: &controlOHPCFController{
+				failingOHPCFController: failingOHPCFController{entity: entity}, state: ucapi.CompressorPowerConsumptionStateRunning,
+			}, action: pb.OHPCFAction_OHPCF_ACTION_RESUME,
+		},
+		{
+			name: "abort process without permission", controller: &controlOHPCFController{
+				failingOHPCFController: failingOHPCFController{entity: entity}, state: ucapi.CompressorPowerConsumptionStateRunning,
+			}, action: pb.OHPCFAction_OHPCF_ACTION_ABORT,
+		},
+		{
+			name: "abort stopped process", controller: &controlOHPCFController{
+				failingOHPCFController: failingOHPCFController{entity: entity}, state: ucapi.CompressorPowerConsumptionStateStopped, stoppable: true,
+			}, action: pb.OHPCFAction_OHPCF_ACTION_ABORT,
+		},
+	}
+	for _, test := range rejected {
+		t.Run(test.name, func(t *testing.T) {
+			service := NewOHPCFService(nil, eebus.NewEventBus(), nil, WithOHPCFController(test.controller))
+			_, err := service.ControlCompressorFlexibility(ctx, &pb.ControlCompressorRequest{Ski: testValidSKI, Action: test.action})
+			if status.Code(err) != codes.FailedPrecondition {
+				t.Fatalf("status = %s, error=%v", status.Code(err), err)
+			}
+			if len(test.controller.calls) != 0 {
+				t.Fatalf("rejected action reached device: %v", test.controller.calls)
+			}
+		})
 	}
 
 	notInitialized := NewOHPCFService(nil, eebus.NewEventBus(), nil)

--- a/eebus-bridge/internal/grpc/ohpcf_service_additional_test.go
+++ b/eebus-bridge/internal/grpc/ohpcf_service_additional_test.go
@@ -72,24 +72,28 @@ func (noProcessOHPCFController) ConsumptionState(spineapi.EntityRemoteInterface)
 
 type controlOHPCFController struct {
 	failingOHPCFController
-	available bool
-	state     ucapi.CompressorPowerConsumptionStateType
-	stoppable bool
-	pausable  bool
-	calls     []string
+	available    bool
+	availableErr error
+	state        ucapi.CompressorPowerConsumptionStateType
+	stateErr     error
+	stoppable    bool
+	stoppableErr error
+	pausable     bool
+	pausableErr  error
+	calls        []string
 }
 
 func (c *controlOHPCFController) OptionalPowerConsumptionAvailable(spineapi.EntityRemoteInterface) (bool, error) {
-	return c.available, nil
+	return c.available, c.availableErr
 }
 func (c *controlOHPCFController) ConsumptionState(spineapi.EntityRemoteInterface) (ucapi.CompressorPowerConsumptionStateType, error) {
-	return c.state, nil
+	return c.state, c.stateErr
 }
 func (c *controlOHPCFController) ConsumptionIsStoppable(spineapi.EntityRemoteInterface) (bool, error) {
-	return c.stoppable, nil
+	return c.stoppable, c.stoppableErr
 }
 func (c *controlOHPCFController) ConsumptionIsPausable(spineapi.EntityRemoteInterface) (bool, error) {
-	return c.pausable, nil
+	return c.pausable, c.pausableErr
 }
 func (c *controlOHPCFController) Schedule(spineapi.EntityRemoteInterface, time.Time) error {
 	c.calls = append(c.calls, "schedule")
@@ -293,6 +297,51 @@ func TestOHPCFServiceControlContracts(t *testing.T) {
 			}
 			if len(test.controller.calls) != 0 {
 				t.Fatalf("rejected action reached device: %v", test.controller.calls)
+			}
+		})
+	}
+
+	readFailures := []struct {
+		name       string
+		controller *controlOHPCFController
+		action     pb.OHPCFAction
+		wantCode   codes.Code
+	}{
+		{
+			name: "schedule availability read unavailable", controller: &controlOHPCFController{
+				failingOHPCFController: failingOHPCFController{entity: entity}, availableErr: eebusapi.ErrDataNotAvailable,
+			}, action: pb.OHPCFAction_OHPCF_ACTION_SCHEDULE, wantCode: codes.Unavailable,
+		},
+		{
+			name: "pause state read unavailable", controller: &controlOHPCFController{
+				failingOHPCFController: failingOHPCFController{entity: entity}, stateErr: eebusapi.ErrDataNotAvailable,
+			}, action: pb.OHPCFAction_OHPCF_ACTION_PAUSE, wantCode: codes.Unavailable,
+		},
+		{
+			name: "pause permission read fails", controller: &controlOHPCFController{
+				failingOHPCFController: failingOHPCFController{entity: entity}, state: ucapi.CompressorPowerConsumptionStateRunning, pausableErr: errors.New("permission read failed"),
+			}, action: pb.OHPCFAction_OHPCF_ACTION_PAUSE, wantCode: codes.Internal,
+		},
+		{
+			name: "resume state read unavailable", controller: &controlOHPCFController{
+				failingOHPCFController: failingOHPCFController{entity: entity}, stateErr: eebusapi.ErrDataNotAvailable,
+			}, action: pb.OHPCFAction_OHPCF_ACTION_RESUME, wantCode: codes.Unavailable,
+		},
+		{
+			name: "abort permission read fails", controller: &controlOHPCFController{
+				failingOHPCFController: failingOHPCFController{entity: entity}, state: ucapi.CompressorPowerConsumptionStateRunning, stoppableErr: errors.New("permission read failed"),
+			}, action: pb.OHPCFAction_OHPCF_ACTION_ABORT, wantCode: codes.Internal,
+		},
+	}
+	for _, test := range readFailures {
+		t.Run(test.name, func(t *testing.T) {
+			service := NewOHPCFService(nil, eebus.NewEventBus(), nil, WithOHPCFController(test.controller))
+			_, err := service.ControlCompressorFlexibility(ctx, &pb.ControlCompressorRequest{Ski: testValidSKI, Action: test.action})
+			if status.Code(err) != test.wantCode {
+				t.Fatalf("status = %s, want %s, error=%v", status.Code(err), test.wantCode, err)
+			}
+			if len(test.controller.calls) != 0 {
+				t.Fatalf("failed precondition read reached device: %v", test.controller.calls)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- treat the OHPCF no-process state (`available=false`, `state=STOPPED`) as a valid readable capability
- treat absent offer-specific permissions as false instead of making the aggregate temporarily unavailable
- validate schedule/pause/resume/abort against the OHPCF process state and permissions in both the bridge and Home Assistant
- cover direct reads, consolidated events, initial snapshots, HA entity availability, and control preconditions with regression tests

## Verification

- `go test ./...`
- `uv run python -m pytest -q` (273 passed)
- `uv run ruff check custom_components/eebus/select.py custom_components/eebus/device_session.py custom_components/eebus/tests/test_ohpcf.py custom_components/eebus/tests/test_device_session.py`
- `git diff --check`