### PR TITLE
feat: migrate DHW boost writes upstream

### DIFF
--- a/docs/badges/go-coverage.svg
+++ b/docs/badges/go-coverage.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="172" height="28" role="img" aria-label="Go coverage: 84.2%">
-  <title>Go coverage: 84.2%</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="172" height="28" role="img" aria-label="Go coverage: 84.3%">
+  <title>Go coverage: 84.3%</title>
   <linearGradient id="s" x2="0" y2="100%">
     <stop offset="0" stop-color="#fff" stop-opacity=".15"/>
     <stop offset="1" stop-opacity=".15"/>
@@ -12,6 +12,6 @@
   </g>
   <g fill="#fff" text-anchor="middle" font-family="Verdana,DejaVu Sans,sans-serif" font-size="10" font-weight="700">
     <text x="56" y="18">GO COVERAGE</text>
-    <text x="142" y="18">84.2%</text>
+    <text x="142" y="18">84.3%</text>
   </g>
 </svg>

--- a/eebus-bridge/cmd/eebus-bridge/app.go
+++ b/eebus-bridge/cmd/eebus-bridge/app.go
@@ -312,9 +312,9 @@ func NewApplication(cfg *config.Config) (*Application, error) {
 		}
 		dhwTemperature := usecases.NewDHWTemperature(localEntity, bus, registry, cfg.Logging.DebugEvents)
 		dhwSystemFunctionMonitoring := usecases.NewDHWSystemFunctionMonitoring(bus, registry, cfg.Logging.DebugEvents)
-		// eebus-go CDSF owns negotiation and feature setup; the facade keeps
-		// both writes on the proven legacy strategies. MDSF remains the sole
-		// owner of reads and user-visible state events.
+		// eebus-go CDSF owns negotiation, feature setup and boost writes. The
+		// facade keeps operation-mode writes on the proven legacy strategy.
+		// MDSF remains the sole owner of reads and user-visible state events.
 		dhwSystemFunctionConfiguration := usecases.NewUpstreamDHWSystemFunctionConfiguration(
 			localEntity,
 			cfg.Logging.DebugEvents,

--- a/eebus-bridge/internal/usecases/dhwsysfn_adapter.go
+++ b/eebus-bridge/internal/usecases/dhwsysfn_adapter.go
@@ -147,8 +147,8 @@ type dhwSystemFunctionWriter interface {
 	WriteOperationMode(context.Context, spineapi.EntityRemoteInterface, string) error
 }
 
-// DHWSystemFunctionAdapter combines MDSF reads/events with the proven local
-// CDSF write implementation. Writeability is advertised only when CDSF was
+// DHWSystemFunctionAdapter combines MDSF reads/events with the selected CDSF
+// configuration strategies. Writeability is advertised only when CDSF was
 // independently negotiated for the same device.
 type DHWSystemFunctionAdapter struct {
 	monitoring    dhwSystemFunctionReader

--- a/eebus-bridge/internal/usecases/dhwsysfn_configuration.go
+++ b/eebus-bridge/internal/usecases/dhwsysfn_configuration.go
@@ -74,9 +74,9 @@ func newCDSFConfigurationFacade(
 }
 
 // NewUpstreamDHWSystemFunctionConfiguration selects eebus-go CDSF for use-case
-// negotiation and feature setup while retaining both bridge-local write
-// strategies. A nil event callback deliberately keeps MDSF as the sole owner of
-// DHW state and support events.
+// negotiation, feature setup and boost writes while retaining the bridge-local
+// operation-mode strategy. A nil event callback deliberately keeps MDSF as the
+// sole owner of DHW state and support events.
 func NewUpstreamDHWSystemFunctionConfiguration(
 	localEntity spineapi.EntityLocalInterface,
 	debug bool,
@@ -111,15 +111,20 @@ func newUpstreamDHWSystemFunctionConfiguration(
 		request:          request,
 		inspector:        inspector,
 	}
-	facade := newCDSFConfigurationFacade(caCDSFEntityResolver{client: client}, inspector, transport, transport)
+	boostTransport := &upstreamDHWBoostWriter{
+		client:    client,
+		inspector: inspector,
+		request:   request,
+	}
+	facade := newCDSFConfigurationFacade(caCDSFEntityResolver{client: client}, inspector, boostTransport, transport)
 	facade.useCase = client
 	return facade
 }
 
 // NewLegacyDHWSystemFunctionConfiguration selects the local CDSF use case for
-// negotiation and both legacy write strategies. Phase 1 can replace the entity
-// resolver without changing the adapter or gRPC service; later phases can swap
-// the boost and operation-mode writers independently.
+// negotiation and both legacy write strategies. It remains the release-level
+// rollback composition while the upstream boost and operation-mode strategies
+// are validated independently.
 func NewLegacyDHWSystemFunctionConfiguration(useCase *DHWSystemFunction) *CDSFConfigurationFacade {
 	if useCase == nil {
 		return &CDSFConfigurationFacade{}

--- a/eebus-bridge/internal/usecases/dhwsysfn_upstream_boost.go
+++ b/eebus-bridge/internal/usecases/dhwsysfn_upstream_boost.go
@@ -1,0 +1,83 @@
+package usecases
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	eebusapi "github.com/enbility/eebus-go/api"
+	spineapi "github.com/enbility/spine-go/api"
+	"github.com/enbility/spine-go/model"
+)
+
+// upstreamDHWBoostWriter delegates the one-time-DHW command to eebus-go CDSF
+// while retaining bridge-specific context handling and post-write convergence.
+// It never falls back to the legacy writer after an upstream call.
+type upstreamDHWBoostWriter struct {
+	client    caCDSFClient
+	inspector dhwSystemFunctionCapabilityInspector
+	request   func(spineapi.EntityRemoteInterface, model.FunctionType)
+}
+
+func (w *upstreamDHWBoostWriter) WriteBoost(
+	ctx context.Context,
+	entity spineapi.EntityRemoteInterface,
+	active bool,
+) error {
+	if w == nil || w.client == nil || w.inspector == nil || entity == nil {
+		return ErrDHWSysFnDataUnavailable
+	}
+	state, err := w.inspector.State(entity)
+	if err != nil {
+		return err
+	}
+	if !state.BoostWritable {
+		return ErrDHWSysFnNotWritable
+	}
+
+	label := "DHW boost stop"
+	if active {
+		label = "DHW boost start"
+	}
+	err = awaitDHWWrite(ctx, label, func(callback dhwResultCallback) (*model.MsgCounterType, error) {
+		var counter *model.MsgCounterType
+		var writeErr error
+		if active {
+			counter, writeErr = w.client.StartOneTimeDhw(entity, callback)
+		} else {
+			counter, writeErr = w.client.StopOneTimeDhw(entity, callback)
+		}
+		return counter, mapUpstreamDHWWriteError(writeErr)
+	})
+	if err != nil {
+		return err
+	}
+	if w.request != nil {
+		w.request(entity, model.FunctionTypeHvacOverrunListData)
+	}
+	return nil
+}
+
+func mapUpstreamDHWWriteError(err error) error {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, eebusapi.ErrNotSupported) {
+		return fmt.Errorf("%w: %v", ErrDHWSysFnNotWritable, err)
+	}
+	for _, unavailable := range []error{
+		eebusapi.ErrMetadataNotAvailable,
+		eebusapi.ErrDataNotAvailable,
+		eebusapi.ErrDataInvalid,
+		eebusapi.ErrDataForMetadataKeyNotFound,
+		eebusapi.ErrEntityNotFound,
+		eebusapi.ErrMissingData,
+		eebusapi.ErrDeviceDisconnected,
+		eebusapi.ErrNoCompatibleEntity,
+	} {
+		if errors.Is(err, unavailable) {
+			return fmt.Errorf("%w: %v", ErrDHWSysFnDataUnavailable, err)
+		}
+	}
+	return err
+}

--- a/eebus-bridge/internal/usecases/dhwsysfn_upstream_boost_test.go
+++ b/eebus-bridge/internal/usecases/dhwsysfn_upstream_boost_test.go
@@ -1,0 +1,192 @@
+package usecases
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	eebusapi "github.com/enbility/eebus-go/api"
+	ucmocks "github.com/enbility/eebus-go/usecases/mocks"
+	spineapi "github.com/enbility/spine-go/api"
+	spinemocks "github.com/enbility/spine-go/mocks"
+	"github.com/enbility/spine-go/model"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestUpstreamCDSFSelectsUpstreamBoostAndLegacyModeStrategies(t *testing.T) {
+	client := ucmocks.NewCaCDSFInterface(t)
+	facade := newUpstreamDHWSystemFunctionConfiguration(client, nil, nil)
+
+	if _, ok := facade.boostWriter.(*upstreamDHWBoostWriter); !ok {
+		t.Fatalf("boost writer = %T, want *upstreamDHWBoostWriter", facade.boostWriter)
+	}
+	if _, ok := facade.operationModeWriter.(*legacyDHWSystemFunctionWriter); !ok {
+		t.Fatalf("operation-mode writer = %T, want *legacyDHWSystemFunctionWriter", facade.operationModeWriter)
+	}
+}
+
+func TestUpstreamDHWBoostWriterStartsStopsAndRefreshes(t *testing.T) {
+	entity := spinemocks.NewEntityRemoteInterface(t)
+	client := ucmocks.NewCaCDSFInterface(t)
+	counter := model.MsgCounterType(17)
+	client.EXPECT().StartOneTimeDhw(entity, mock.Anything).RunAndReturn(
+		func(_ spineapi.EntityRemoteInterface, callback func(model.ResultDataType, model.MsgCounterType)) (*model.MsgCounterType, error) {
+			callback(model.ResultDataType{}, counter)
+			return &counter, nil
+		},
+	)
+	client.EXPECT().StopOneTimeDhw(entity, mock.Anything).RunAndReturn(
+		func(_ spineapi.EntityRemoteInterface, callback func(model.ResultDataType, model.MsgCounterType)) (*model.MsgCounterType, error) {
+			callback(model.ResultDataType{}, counter)
+			return &counter, nil
+		},
+	)
+
+	refreshes := 0
+	writer := &upstreamDHWBoostWriter{
+		client:    client,
+		inspector: facadeCapabilityInspector{state: DHWSystemFunctionState{BoostWritable: true}},
+		request: func(gotEntity spineapi.EntityRemoteInterface, function model.FunctionType) {
+			refreshes++
+			if gotEntity != entity || function != model.FunctionTypeHvacOverrunListData {
+				t.Fatalf("refresh = (%v, %s), want selected entity and HvacOverrunListData", gotEntity, function)
+			}
+		},
+	}
+
+	if err := writer.WriteBoost(context.Background(), entity, true); err != nil {
+		t.Fatalf("start WriteBoost() error = %v", err)
+	}
+	if err := writer.WriteBoost(context.Background(), entity, false); err != nil {
+		t.Fatalf("stop WriteBoost() error = %v", err)
+	}
+	if refreshes != 2 {
+		t.Fatalf("refresh count = %d, want one per accepted transition", refreshes)
+	}
+}
+
+func TestUpstreamDHWBoostWriterReturnsDeviceRejectionWithoutRefresh(t *testing.T) {
+	entity := spinemocks.NewEntityRemoteInterface(t)
+	client := ucmocks.NewCaCDSFInterface(t)
+	counter := model.MsgCounterType(18)
+	description := model.DescriptionType("boost blocked")
+	client.EXPECT().StartOneTimeDhw(entity, mock.Anything).RunAndReturn(
+		func(_ spineapi.EntityRemoteInterface, callback func(model.ResultDataType, model.MsgCounterType)) (*model.MsgCounterType, error) {
+			callback(model.ResultDataType{
+				ErrorNumber: ptr(model.ErrorNumberTypeCommandRejected),
+				Description: &description,
+			}, counter)
+			return &counter, nil
+		},
+	)
+
+	refreshes := 0
+	writer := &upstreamDHWBoostWriter{
+		client:    client,
+		inspector: facadeCapabilityInspector{state: DHWSystemFunctionState{BoostWritable: true}},
+		request: func(spineapi.EntityRemoteInterface, model.FunctionType) {
+			refreshes++
+		},
+	}
+	err := writer.WriteBoost(context.Background(), entity, true)
+	if !errors.Is(err, ErrDHWSysFnRejected) || !strings.Contains(err.Error(), string(description)) {
+		t.Fatalf("WriteBoost() error = %v, want device rejection", err)
+	}
+	if refreshes != 0 {
+		t.Fatalf("refresh count = %d, want zero after rejection", refreshes)
+	}
+}
+
+func TestUpstreamDHWBoostWriterHonoursCancellationWithoutRefresh(t *testing.T) {
+	entity := spinemocks.NewEntityRemoteInterface(t)
+	client := ucmocks.NewCaCDSFInterface(t)
+	counter := model.MsgCounterType(19)
+	client.EXPECT().StartOneTimeDhw(entity, mock.Anything).Return(&counter, nil)
+
+	refreshes := 0
+	writer := &upstreamDHWBoostWriter{
+		client:    client,
+		inspector: facadeCapabilityInspector{state: DHWSystemFunctionState{BoostWritable: true}},
+		request: func(spineapi.EntityRemoteInterface, model.FunctionType) {
+			refreshes++
+		},
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := writer.WriteBoost(ctx, entity, true); !errors.Is(err, context.Canceled) {
+		t.Fatalf("WriteBoost() error = %v, want context.Canceled", err)
+	}
+	if refreshes != 0 {
+		t.Fatalf("refresh count = %d, want zero after cancellation", refreshes)
+	}
+}
+
+func TestUpstreamDHWBoostWriterMapsSendFailuresWithoutFallbackOrRefresh(t *testing.T) {
+	sendErr := errors.New("send failed")
+	for _, test := range []struct {
+		name string
+		err  error
+		want error
+	}{
+		{name: "not writable", err: eebusapi.ErrNotSupported, want: ErrDHWSysFnNotWritable},
+		{name: "cache unavailable", err: eebusapi.ErrDataNotAvailable, want: ErrDHWSysFnDataUnavailable},
+		{name: "transport error", err: sendErr, want: sendErr},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			entity := spinemocks.NewEntityRemoteInterface(t)
+			client := ucmocks.NewCaCDSFInterface(t)
+			client.EXPECT().StartOneTimeDhw(entity, mock.Anything).Return(nil, test.err).Once()
+			refreshes := 0
+			writer := &upstreamDHWBoostWriter{
+				client:    client,
+				inspector: facadeCapabilityInspector{state: DHWSystemFunctionState{BoostWritable: true}},
+				request: func(spineapi.EntityRemoteInterface, model.FunctionType) {
+					refreshes++
+				},
+			}
+
+			if err := writer.WriteBoost(context.Background(), entity, true); !errors.Is(err, test.want) {
+				t.Fatalf("WriteBoost() error = %v, want %v", err, test.want)
+			}
+			if refreshes != 0 {
+				t.Fatalf("refresh count = %d, want zero after send failure", refreshes)
+			}
+		})
+	}
+}
+
+func TestUpstreamDHWBoostWriterFailsClosedBeforeSending(t *testing.T) {
+	entity := spinemocks.NewEntityRemoteInterface(t)
+	client := ucmocks.NewCaCDSFInterface(t)
+	writer := &upstreamDHWBoostWriter{
+		client:    client,
+		inspector: facadeCapabilityInspector{state: DHWSystemFunctionState{BoostWritable: false}},
+	}
+	if err := writer.WriteBoost(context.Background(), entity, true); !errors.Is(err, ErrDHWSysFnNotWritable) {
+		t.Fatalf("WriteBoost() error = %v, want ErrDHWSysFnNotWritable", err)
+	}
+
+	inspectionErr := errors.New("inspection failed")
+	writer.inspector = facadeCapabilityInspector{err: inspectionErr}
+	if err := writer.WriteBoost(context.Background(), entity, true); !errors.Is(err, inspectionErr) {
+		t.Fatalf("WriteBoost() inspection error = %v, want %v", err, inspectionErr)
+	}
+
+	for name, incomplete := range map[string]*upstreamDHWBoostWriter{
+		"nil writer":    nil,
+		"nil client":    {inspector: facadeCapabilityInspector{}},
+		"nil inspector": {client: client},
+		"nil entity":    {client: client, inspector: facadeCapabilityInspector{}},
+	} {
+		t.Run(name, func(t *testing.T) {
+			var gotEntity spineapi.EntityRemoteInterface = entity
+			if name == "nil entity" {
+				gotEntity = nil
+			}
+			if err := incomplete.WriteBoost(context.Background(), gotEntity, true); !errors.Is(err, ErrDHWSysFnDataUnavailable) {
+				t.Fatalf("WriteBoost() error = %v, want ErrDHWSysFnDataUnavailable", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- move DHW boost start and stop writes to the upstream eebus-go CDSF implementation
- keep DHW operation-mode writes on the extracted legacy strategy
- wait for device results with cancellation and timeout handling, map rejections, and refresh HvacOverrunListData after acceptance
- fail closed when CDSF scenarios 2 or 3 or cached write capability are missing

## Selected strategies

- Boost start/stop: upstream CDSF StartOneTimeDhw and StopOneTimeDhw
- Operation mode: legacy bridge-local writer
- Request-level fallback: none

## Verification

- go vet ./...
- golangci-lint v2.12.2: 0 issues
- go test -race ./...
- go test -tags=integration -v ./internal/grpc/ -run TestIntegration
- Go patch coverage: 100.0% (46/46 changed statements)
- total Go coverage: 84.3%
- generated drift check
- govulncheck with Go 1.26.5: no vulnerabilities found

## Hardware validation still required before release

- [ ] 10 consecutive boost start/stop cycles on the target VR940
- [ ] HA state converges after every transition without periodic polling
- [ ] 3 reconnect/restart cycles preserve boost capability and writeability
