### PR TITLE
feat: migrate DHW operation-mode writes upstream

### DIFF
--- a/docs/badges/go-coverage.svg
+++ b/docs/badges/go-coverage.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="172" height="28" role="img" aria-label="Go coverage: 84.4%">
-  <title>Go coverage: 84.4%</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="172" height="28" role="img" aria-label="Go coverage: 84.3%">
+  <title>Go coverage: 84.3%</title>
   <linearGradient id="s" x2="0" y2="100%">
     <stop offset="0" stop-color="#fff" stop-opacity=".15"/>
     <stop offset="1" stop-opacity=".15"/>
@@ -12,6 +12,6 @@
   </g>
   <g fill="#fff" text-anchor="middle" font-family="Verdana,DejaVu Sans,sans-serif" font-size="10" font-weight="700">
     <text x="56" y="18">GO COVERAGE</text>
-    <text x="142" y="18">84.4%</text>
+    <text x="142" y="18">84.3%</text>
   </g>
 </svg>

--- a/docs/badges/go-coverage.svg
+++ b/docs/badges/go-coverage.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="172" height="28" role="img" aria-label="Go coverage: 84.3%">
-  <title>Go coverage: 84.3%</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="172" height="28" role="img" aria-label="Go coverage: 84.4%">
+  <title>Go coverage: 84.4%</title>
   <linearGradient id="s" x2="0" y2="100%">
     <stop offset="0" stop-color="#fff" stop-opacity=".15"/>
     <stop offset="1" stop-opacity=".15"/>
@@ -12,6 +12,6 @@
   </g>
   <g fill="#fff" text-anchor="middle" font-family="Verdana,DejaVu Sans,sans-serif" font-size="10" font-weight="700">
     <text x="56" y="18">GO COVERAGE</text>
-    <text x="142" y="18">84.3%</text>
+    <text x="142" y="18">84.4%</text>
   </g>
 </svg>

--- a/eebus-bridge/cmd/eebus-bridge/app.go
+++ b/eebus-bridge/cmd/eebus-bridge/app.go
@@ -312,9 +312,8 @@ func NewApplication(cfg *config.Config) (*Application, error) {
 		}
 		dhwTemperature := usecases.NewDHWTemperature(localEntity, bus, registry, cfg.Logging.DebugEvents)
 		dhwSystemFunctionMonitoring := usecases.NewDHWSystemFunctionMonitoring(bus, registry, cfg.Logging.DebugEvents)
-		// eebus-go CDSF owns negotiation, feature setup and boost writes. The
-		// facade keeps operation-mode writes on the proven legacy strategy.
-		// MDSF remains the sole owner of reads and user-visible state events.
+		// eebus-go CDSF owns negotiation, feature setup and writes. MDSF remains
+		// the sole owner of reads and user-visible state events.
 		dhwSystemFunctionConfiguration := usecases.NewUpstreamDHWSystemFunctionConfiguration(
 			localEntity,
 			cfg.Logging.DebugEvents,

--- a/eebus-bridge/internal/usecases/dhwsysfn_adapter.go
+++ b/eebus-bridge/internal/usecases/dhwsysfn_adapter.go
@@ -111,15 +111,36 @@ func (w *DHWSystemFunctionMonitoring) State(entity spineapi.EntityRemoteInterfac
 		OperationMode:  string(current),
 		AvailableModes: uniqueOperationModes(modes),
 	}
-	if status, err := w.uc.OverrunStatus(entity); err == nil {
-		state.BoostStatus = string(status)
-	} else if active, activeErr := w.uc.IsOverrunActive(entity); activeErr == nil {
-		state.BoostStatus = string(model.HvacOverrunStatusTypeInactive)
-		if active {
-			state.BoostStatus = string(model.HvacOverrunStatusTypeActive)
-		}
-	}
+	status, statusErr := w.uc.OverrunStatus(entity)
+	active, activeErr := w.uc.IsOverrunActive(entity)
+	state.BoostStatus = resolvedDHWBoostStatus(status, statusErr, active, activeErr)
 	return state, nil
+}
+
+func resolvedDHWBoostStatus(
+	status model.HvacOverrunStatusType,
+	statusErr error,
+	active bool,
+	activeErr error,
+) string {
+	if activeErr == nil {
+		if active {
+			if statusErr == nil && (status == model.HvacOverrunStatusTypeActive ||
+				status == model.HvacOverrunStatusTypeRunning) {
+				return string(status)
+			}
+			return string(model.HvacOverrunStatusTypeActive)
+		}
+		if statusErr == nil && (status == model.HvacOverrunStatusTypeInactive ||
+			status == model.HvacOverrunStatusTypeFinished) {
+			return string(status)
+		}
+		return string(model.HvacOverrunStatusTypeInactive)
+	}
+	if statusErr == nil {
+		return string(status)
+	}
+	return ""
 }
 
 func uniqueOperationModes(modes []ucapi.HvacOperationModeType) []string {

--- a/eebus-bridge/internal/usecases/dhwsysfn_adapter_test.go
+++ b/eebus-bridge/internal/usecases/dhwsysfn_adapter_test.go
@@ -180,10 +180,52 @@ func TestDHWSystemFunctionMonitoringUsesReportedOverrunStatus(t *testing.T) {
 	uc.EXPECT().OperationModes(entity).Return([]ucapi.HvacOperationModeType{ucapi.HvacOperationModeTypeAuto}, nil)
 	uc.EXPECT().CurrentOperationMode(entity).Return(ucapi.HvacOperationModeTypeAuto, nil)
 	uc.EXPECT().OverrunStatus(entity).Return(model.HvacOverrunStatusTypeActive, nil)
+	uc.EXPECT().IsOverrunActive(entity).Return(true, nil)
 
 	state, err := (&DHWSystemFunctionMonitoring{uc: uc}).State(entity)
 	if err != nil || state.BoostStatus != "active" {
 		t.Fatalf("State() = %+v, %v", state, err)
+	}
+}
+
+func TestDHWSystemFunctionMonitoringUsesInactiveSignalOverStaleActiveStatus(t *testing.T) {
+	uc := ucmocks.NewMaMDSFInterface(t)
+	entity := spinemocks.NewEntityRemoteInterface(t)
+	uc.EXPECT().OperationModes(entity).Return([]ucapi.HvacOperationModeType{ucapi.HvacOperationModeTypeAuto}, nil)
+	uc.EXPECT().CurrentOperationMode(entity).Return(ucapi.HvacOperationModeTypeAuto, nil)
+	uc.EXPECT().OverrunStatus(entity).Return(model.HvacOverrunStatusTypeActive, nil)
+	uc.EXPECT().IsOverrunActive(entity).Return(false, nil)
+
+	state, err := (&DHWSystemFunctionMonitoring{uc: uc}).State(entity)
+	if err != nil || state.BoostStatus != "inactive" {
+		t.Fatalf("State() = %+v, %v", state, err)
+	}
+}
+
+func TestResolvedDHWBoostStatusReconcilesDetailedAndActiveSignals(t *testing.T) {
+	unavailable := errors.New("unavailable")
+	tests := []struct {
+		name      string
+		status    model.HvacOverrunStatusType
+		statusErr error
+		active    bool
+		activeErr error
+		want      string
+	}{
+		{"matching running", model.HvacOverrunStatusTypeRunning, nil, true, nil, "running"},
+		{"stale finished while active", model.HvacOverrunStatusTypeFinished, nil, true, nil, "active"},
+		{"matching finished", model.HvacOverrunStatusTypeFinished, nil, false, nil, "finished"},
+		{"stale running while inactive", model.HvacOverrunStatusTypeRunning, nil, false, nil, "inactive"},
+		{"detailed status fallback", model.HvacOverrunStatusTypeRunning, nil, false, unavailable, "running"},
+		{"no status available", "", unavailable, false, unavailable, ""},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := resolvedDHWBoostStatus(test.status, test.statusErr, test.active, test.activeErr)
+			if got != test.want {
+				t.Fatalf("resolvedDHWBoostStatus() = %q, want %q", got, test.want)
+			}
+		})
 	}
 }
 

--- a/eebus-bridge/internal/usecases/dhwsysfn_configuration.go
+++ b/eebus-bridge/internal/usecases/dhwsysfn_configuration.go
@@ -74,9 +74,8 @@ func newCDSFConfigurationFacade(
 }
 
 // NewUpstreamDHWSystemFunctionConfiguration selects eebus-go CDSF for use-case
-// negotiation, feature setup and boost writes while retaining the bridge-local
-// operation-mode strategy. A nil event callback deliberately keeps MDSF as the
-// sole owner of DHW state and support events.
+// negotiation, feature setup and DHW writes. A nil event callback deliberately
+// keeps MDSF as the sole owner of DHW state and support events.
 func NewUpstreamDHWSystemFunctionConfiguration(
 	localEntity spineapi.EntityLocalInterface,
 	debug bool,
@@ -106,17 +105,17 @@ func newUpstreamDHWSystemFunctionConfiguration(
 		client: client,
 		cached: cachedDHWSystemFunctionCapabilityInspector{},
 	}
-	transport := &legacyDHWSystemFunctionWriter{
-		localHvacFeature: localHvacFeature,
-		request:          request,
-		inspector:        inspector,
-	}
 	boostTransport := &upstreamDHWBoostWriter{
 		client:    client,
 		inspector: inspector,
 		request:   request,
 	}
-	facade := newCDSFConfigurationFacade(caCDSFEntityResolver{client: client}, inspector, boostTransport, transport)
+	modeTransport := &upstreamDHWOperationModeWriter{
+		client:    client,
+		inspector: inspector,
+		request:   request,
+	}
+	facade := newCDSFConfigurationFacade(caCDSFEntityResolver{client: client}, inspector, boostTransport, modeTransport)
 	facade.useCase = client
 	return facade
 }

--- a/eebus-bridge/internal/usecases/dhwsysfn_configuration_test.go
+++ b/eebus-bridge/internal/usecases/dhwsysfn_configuration_test.go
@@ -344,6 +344,14 @@ func TestLegacyDHWWriterFailsClosedBeforeTransport(t *testing.T) {
 		t.Fatalf("WriteOperationMode() error = %v, want %v", err, inspectionErr)
 	}
 
+	writer.inspector = facadeCapabilityInspector{}
+	if err := writer.WriteBoost(context.Background(), nil, true); !errors.Is(err, ErrDHWSysFnNotWritable) {
+		t.Fatalf("WriteBoost() non-writable error = %v, want ErrDHWSysFnNotWritable", err)
+	}
+	if err := writer.WriteOperationMode(context.Background(), nil, "off"); !errors.Is(err, ErrDHWSysFnNotWritable) {
+		t.Fatalf("WriteOperationMode() non-writable error = %v, want ErrDHWSysFnNotWritable", err)
+	}
+
 	writer.inspector = facadeCapabilityInspector{state: DHWSystemFunctionState{BoostWritable: true, ModeWritable: true}}
 	if err := writer.WriteBoost(context.Background(), nil, true); !errors.Is(err, ErrDHWSysFnDataUnavailable) {
 		t.Fatalf("WriteBoost() missing transport error = %v, want ErrDHWSysFnDataUnavailable", err)

--- a/eebus-bridge/internal/usecases/dhwsysfn_upstream_boost_test.go
+++ b/eebus-bridge/internal/usecases/dhwsysfn_upstream_boost_test.go
@@ -14,15 +14,15 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
-func TestUpstreamCDSFSelectsUpstreamBoostAndLegacyModeStrategies(t *testing.T) {
+func TestUpstreamCDSFSelectsUpstreamWriteStrategies(t *testing.T) {
 	client := ucmocks.NewCaCDSFInterface(t)
 	facade := newUpstreamDHWSystemFunctionConfiguration(client, nil, nil)
 
 	if _, ok := facade.boostWriter.(*upstreamDHWBoostWriter); !ok {
 		t.Fatalf("boost writer = %T, want *upstreamDHWBoostWriter", facade.boostWriter)
 	}
-	if _, ok := facade.operationModeWriter.(*legacyDHWSystemFunctionWriter); !ok {
-		t.Fatalf("operation-mode writer = %T, want *legacyDHWSystemFunctionWriter", facade.operationModeWriter)
+	if _, ok := facade.operationModeWriter.(*upstreamDHWOperationModeWriter); !ok {
+		t.Fatalf("operation-mode writer = %T, want *upstreamDHWOperationModeWriter", facade.operationModeWriter)
 	}
 }
 

--- a/eebus-bridge/internal/usecases/dhwsysfn_upstream_mode.go
+++ b/eebus-bridge/internal/usecases/dhwsysfn_upstream_mode.go
@@ -1,0 +1,62 @@
+package usecases
+
+import (
+	"context"
+	"fmt"
+
+	ucapi "github.com/enbility/eebus-go/usecases/api"
+	spineapi "github.com/enbility/spine-go/api"
+	"github.com/enbility/spine-go/model"
+)
+
+// upstreamDHWOperationModeWriter delegates operation-mode writes to eebus-go
+// CDSF while retaining bridge-specific validation, context handling and
+// post-write convergence. It never falls back to the legacy writer after an
+// upstream call.
+type upstreamDHWOperationModeWriter struct {
+	client    caCDSFClient
+	inspector dhwSystemFunctionCapabilityInspector
+	request   func(spineapi.EntityRemoteInterface, model.FunctionType)
+}
+
+func (w *upstreamDHWOperationModeWriter) WriteOperationMode(
+	ctx context.Context,
+	entity spineapi.EntityRemoteInterface,
+	mode string,
+) error {
+	if w == nil || w.client == nil || w.inspector == nil || entity == nil {
+		return ErrDHWSysFnDataUnavailable
+	}
+	state, err := w.inspector.State(entity)
+	if err != nil {
+		return err
+	}
+	if !state.ModeWritable {
+		return ErrDHWSysFnNotWritable
+	}
+
+	matches := 0
+	for _, available := range state.AvailableModes {
+		if available == mode {
+			matches++
+		}
+	}
+	if matches == 0 {
+		return fmt.Errorf("%w: %s", ErrDHWSysFnInvalidMode, mode)
+	}
+	if matches != 1 {
+		return ErrDHWSysFnDataUnavailable
+	}
+
+	err = awaitDHWWrite(ctx, "DHW operation mode", func(callback dhwResultCallback) (*model.MsgCounterType, error) {
+		counter, writeErr := w.client.WriteOperationMode(entity, ucapi.HvacOperationModeType(mode), callback)
+		return counter, mapUpstreamDHWWriteError(writeErr)
+	})
+	if err != nil {
+		return err
+	}
+	if w.request != nil {
+		w.request(entity, model.FunctionTypeHvacSystemFunctionListData)
+	}
+	return nil
+}

--- a/eebus-bridge/internal/usecases/dhwsysfn_upstream_mode_test.go
+++ b/eebus-bridge/internal/usecases/dhwsysfn_upstream_mode_test.go
@@ -1,0 +1,199 @@
+package usecases
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	eebusapi "github.com/enbility/eebus-go/api"
+	ucapi "github.com/enbility/eebus-go/usecases/api"
+	ucmocks "github.com/enbility/eebus-go/usecases/mocks"
+	spineapi "github.com/enbility/spine-go/api"
+	spinemocks "github.com/enbility/spine-go/mocks"
+	"github.com/enbility/spine-go/model"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestUpstreamDHWOperationModeWriterWritesAndRefreshes(t *testing.T) {
+	entity := spinemocks.NewEntityRemoteInterface(t)
+	client := ucmocks.NewCaCDSFInterface(t)
+	counter := model.MsgCounterType(21)
+	client.EXPECT().WriteOperationMode(entity, ucapi.HvacOperationModeTypeEco, mock.Anything).RunAndReturn(
+		func(_ spineapi.EntityRemoteInterface, _ ucapi.HvacOperationModeType, callback func(model.ResultDataType, model.MsgCounterType)) (*model.MsgCounterType, error) {
+			callback(model.ResultDataType{}, counter)
+			return &counter, nil
+		},
+	)
+
+	refreshes := 0
+	writer := &upstreamDHWOperationModeWriter{
+		client: client,
+		inspector: facadeCapabilityInspector{state: DHWSystemFunctionState{
+			ModeWritable:   true,
+			AvailableModes: []string{"auto", "eco", "off"},
+		}},
+		request: func(gotEntity spineapi.EntityRemoteInterface, function model.FunctionType) {
+			refreshes++
+			if gotEntity != entity || function != model.FunctionTypeHvacSystemFunctionListData {
+				t.Fatalf("refresh = (%v, %s), want selected entity and HvacSystemFunctionListData", gotEntity, function)
+			}
+		},
+	}
+
+	if err := writer.WriteOperationMode(context.Background(), entity, "eco"); err != nil {
+		t.Fatalf("WriteOperationMode() error = %v", err)
+	}
+	if refreshes != 1 {
+		t.Fatalf("refresh count = %d, want one after accepted write", refreshes)
+	}
+}
+
+func TestUpstreamDHWOperationModeWriterPrevalidatesRelationSafeModes(t *testing.T) {
+	entity := spinemocks.NewEntityRemoteInterface(t)
+	client := ucmocks.NewCaCDSFInterface(t)
+	writer := &upstreamDHWOperationModeWriter{
+		client: client,
+		inspector: facadeCapabilityInspector{state: DHWSystemFunctionState{
+			ModeWritable:   true,
+			AvailableModes: []string{"auto", "eco"},
+		}},
+	}
+
+	if err := writer.WriteOperationMode(context.Background(), entity, "off"); !errors.Is(err, ErrDHWSysFnInvalidMode) {
+		t.Fatalf("unrelated WriteOperationMode() error = %v, want ErrDHWSysFnInvalidMode", err)
+	}
+
+	writer.inspector = facadeCapabilityInspector{state: DHWSystemFunctionState{
+		ModeWritable:   true,
+		AvailableModes: []string{"auto", "eco", "eco"},
+	}}
+	if err := writer.WriteOperationMode(context.Background(), entity, "eco"); !errors.Is(err, ErrDHWSysFnDataUnavailable) {
+		t.Fatalf("ambiguous WriteOperationMode() error = %v, want ErrDHWSysFnDataUnavailable", err)
+	}
+}
+
+func TestUpstreamDHWOperationModeWriterReturnsDeviceRejectionWithoutRefresh(t *testing.T) {
+	entity := spinemocks.NewEntityRemoteInterface(t)
+	client := ucmocks.NewCaCDSFInterface(t)
+	counter := model.MsgCounterType(22)
+	description := model.DescriptionType("mode blocked")
+	client.EXPECT().WriteOperationMode(entity, ucapi.HvacOperationModeTypeOff, mock.Anything).RunAndReturn(
+		func(_ spineapi.EntityRemoteInterface, _ ucapi.HvacOperationModeType, callback func(model.ResultDataType, model.MsgCounterType)) (*model.MsgCounterType, error) {
+			callback(model.ResultDataType{
+				ErrorNumber: ptr(model.ErrorNumberTypeCommandRejected),
+				Description: &description,
+			}, counter)
+			return &counter, nil
+		},
+	)
+
+	refreshes := 0
+	writer := &upstreamDHWOperationModeWriter{
+		client: client,
+		inspector: facadeCapabilityInspector{state: DHWSystemFunctionState{
+			ModeWritable: true, AvailableModes: []string{"off"},
+		}},
+		request: func(spineapi.EntityRemoteInterface, model.FunctionType) { refreshes++ },
+	}
+	err := writer.WriteOperationMode(context.Background(), entity, "off")
+	if !errors.Is(err, ErrDHWSysFnRejected) || !strings.Contains(err.Error(), string(description)) {
+		t.Fatalf("WriteOperationMode() error = %v, want device rejection", err)
+	}
+	if refreshes != 0 {
+		t.Fatalf("refresh count = %d, want zero after rejection", refreshes)
+	}
+}
+
+func TestUpstreamDHWOperationModeWriterHonoursCancellationWithoutRefresh(t *testing.T) {
+	entity := spinemocks.NewEntityRemoteInterface(t)
+	client := ucmocks.NewCaCDSFInterface(t)
+	counter := model.MsgCounterType(23)
+	client.EXPECT().WriteOperationMode(entity, ucapi.HvacOperationModeTypeAuto, mock.Anything).Return(&counter, nil)
+
+	refreshes := 0
+	writer := &upstreamDHWOperationModeWriter{
+		client: client,
+		inspector: facadeCapabilityInspector{state: DHWSystemFunctionState{
+			ModeWritable: true, AvailableModes: []string{"auto"},
+		}},
+		request: func(spineapi.EntityRemoteInterface, model.FunctionType) { refreshes++ },
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := writer.WriteOperationMode(ctx, entity, "auto"); !errors.Is(err, context.Canceled) {
+		t.Fatalf("WriteOperationMode() error = %v, want context.Canceled", err)
+	}
+	if refreshes != 0 {
+		t.Fatalf("refresh count = %d, want zero after cancellation", refreshes)
+	}
+}
+
+func TestUpstreamDHWOperationModeWriterMapsSendFailuresWithoutFallbackOrRefresh(t *testing.T) {
+	sendErr := errors.New("send failed")
+	for _, test := range []struct {
+		name string
+		err  error
+		want error
+	}{
+		{name: "not writable", err: eebusapi.ErrNotSupported, want: ErrDHWSysFnNotWritable},
+		{name: "cache unavailable", err: eebusapi.ErrDataNotAvailable, want: ErrDHWSysFnDataUnavailable},
+		{name: "transport error", err: sendErr, want: sendErr},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			entity := spinemocks.NewEntityRemoteInterface(t)
+			client := ucmocks.NewCaCDSFInterface(t)
+			client.EXPECT().WriteOperationMode(entity, ucapi.HvacOperationModeTypeOn, mock.Anything).Return(nil, test.err).Once()
+			refreshes := 0
+			writer := &upstreamDHWOperationModeWriter{
+				client: client,
+				inspector: facadeCapabilityInspector{state: DHWSystemFunctionState{
+					ModeWritable: true, AvailableModes: []string{"on"},
+				}},
+				request: func(spineapi.EntityRemoteInterface, model.FunctionType) { refreshes++ },
+			}
+
+			if err := writer.WriteOperationMode(context.Background(), entity, "on"); !errors.Is(err, test.want) {
+				t.Fatalf("WriteOperationMode() error = %v, want %v", err, test.want)
+			}
+			if refreshes != 0 {
+				t.Fatalf("refresh count = %d, want zero after send failure", refreshes)
+			}
+		})
+	}
+}
+
+func TestUpstreamDHWOperationModeWriterFailsClosedBeforeSending(t *testing.T) {
+	entity := spinemocks.NewEntityRemoteInterface(t)
+	client := ucmocks.NewCaCDSFInterface(t)
+	writer := &upstreamDHWOperationModeWriter{
+		client:    client,
+		inspector: facadeCapabilityInspector{state: DHWSystemFunctionState{ModeWritable: false}},
+	}
+	if err := writer.WriteOperationMode(context.Background(), entity, "auto"); !errors.Is(err, ErrDHWSysFnNotWritable) {
+		t.Fatalf("WriteOperationMode() error = %v, want ErrDHWSysFnNotWritable", err)
+	}
+
+	inspectionErr := errors.New("inspection failed")
+	writer.inspector = facadeCapabilityInspector{err: inspectionErr}
+	if err := writer.WriteOperationMode(context.Background(), entity, "auto"); !errors.Is(err, inspectionErr) {
+		t.Fatalf("WriteOperationMode() inspection error = %v, want %v", err, inspectionErr)
+	}
+
+	for name, incomplete := range map[string]*upstreamDHWOperationModeWriter{
+		"nil writer":    nil,
+		"nil client":    {inspector: facadeCapabilityInspector{}},
+		"nil inspector": {client: client},
+		"nil entity":    {client: client, inspector: facadeCapabilityInspector{}},
+	} {
+		t.Run(name, func(t *testing.T) {
+			var gotEntity spineapi.EntityRemoteInterface = entity
+			if name == "nil entity" {
+				gotEntity = nil
+			}
+			if err := incomplete.WriteOperationMode(context.Background(), gotEntity, "auto"); !errors.Is(err, ErrDHWSysFnDataUnavailable) {
+				t.Fatalf("WriteOperationMode() error = %v, want ErrDHWSysFnDataUnavailable", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- move DHW operation-mode writes to the upstream eebus-go CDSF implementation
- prevalidate requested modes against relation-scoped advertised modes and fail closed on ambiguous related IDs
- await and map device results with the existing context-aware bridge contract
- refresh HvacSystemFunctionListData exactly once after an accepted write
- retain the legacy writer only as the explicit release-level rollback composition

## Selected strategies

- Boost start/stop: upstream CDSF StartOneTimeDhw and StopOneTimeDhw
- Operation mode: upstream CDSF WriteOperationMode
- Request-level fallback: none

## Verification

- go vet ./...
- go test -race ./...
- go test -tags=integration -v ./internal/grpc/ -run TestIntegration
- Go patch coverage: 100.0% (39/39 changed statements)
- total Go coverage: 84.4%

## Hardware validation still required before release

- [ ] select and read back every operation mode advertised by the target VR940
- [ ] complete at least 10 total mode transitions
- [ ] verify a globally present but unrelated mode is rejected
- [ ] verify non-writeable and device-rejected writes retain their existing gRPC codes
- [ ] complete 3 reconnect/restart cycles with mode capability and writeability preserved