### PR TITLE
Fix stale OHPCF state after missed notifications

### DIFF
--- a/docs/badges/go-coverage.svg
+++ b/docs/badges/go-coverage.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="172" height="28" role="img" aria-label="Go coverage: 84.3%">
-  <title>Go coverage: 84.3%</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="172" height="28" role="img" aria-label="Go coverage: 84.4%">
+  <title>Go coverage: 84.4%</title>
   <linearGradient id="s" x2="0" y2="100%">
     <stop offset="0" stop-color="#fff" stop-opacity=".15"/>
     <stop offset="1" stop-opacity=".15"/>
@@ -12,6 +12,6 @@
   </g>
   <g fill="#fff" text-anchor="middle" font-family="Verdana,DejaVu Sans,sans-serif" font-size="10" font-weight="700">
     <text x="56" y="18">GO COVERAGE</text>
-    <text x="142" y="18">84.3%</text>
+    <text x="142" y="18">84.4%</text>
   </g>
 </svg>

--- a/eebus-bridge/cmd/eebus-contract-testserver/main.go
+++ b/eebus-bridge/cmd/eebus-contract-testserver/main.go
@@ -122,6 +122,8 @@ func (fakePayloadSource) AttachOHPCFPayload(event *pb.OHPCFEvent, _ string, _ ee
 	return true
 }
 
+func (fakePayloadSource) RefreshCompressorFlexibility(string) {}
+
 type fakeTrust struct {
 	bus      *eebus.EventBus
 	registry *eebus.DeviceRegistry

--- a/eebus-bridge/internal/grpc/device_service.go
+++ b/eebus-bridge/internal/grpc/device_service.go
@@ -69,6 +69,7 @@ type HVACPayloadSource interface {
 
 type OHPCFPayloadSource interface {
 	AttachOHPCFPayload(*pb.OHPCFEvent, string, eebus.EventType) bool
+	RefreshCompressorFlexibility(string)
 }
 
 func WithDeviceStatePayloads(sources DeviceStatePayloadSources) DeviceServiceOption {

--- a/eebus-bridge/internal/grpc/device_snapshot.go
+++ b/eebus-bridge/internal/grpc/device_snapshot.go
@@ -177,6 +177,7 @@ func (a *DeviceSnapshotAssembler) Build(ski string, revision uint64) (*pb.Device
 		a.ohpcf.AttachOHPCFPayload(flexibility, ski, eebus.EventTypeOHPCFConsumptionStateUpdated)
 		result.CompressorFlexibility = flexibility.GetFlexibility()
 		result.CompressorFlexibilityState = valueState(eebus.CapabilityOHPCF, result.CompressorFlexibility != nil, true)
+		a.ohpcf.RefreshCompressorFlexibility(ski)
 	} else {
 		result.CompressorFlexibilityState = valueState(eebus.CapabilityOHPCF, false, false)
 	}

--- a/eebus-bridge/internal/grpc/device_snapshot_test.go
+++ b/eebus-bridge/internal/grpc/device_snapshot_test.go
@@ -82,6 +82,8 @@ func (*snapshotPayloads) AttachOHPCFPayload(event *pb.OHPCFEvent, _ string, _ ee
 	return true
 }
 
+func (*snapshotPayloads) RefreshCompressorFlexibility(string) {}
+
 func snapshotService(bus *eebus.EventBus, registry *eebus.DeviceRegistry, payloads *snapshotPayloads) *bridgegrpc.DeviceService {
 	payloads.registry = registry
 	sources := bridgegrpc.DeviceStatePayloadSources{

--- a/eebus-bridge/internal/grpc/device_state_contract_test.go
+++ b/eebus-bridge/internal/grpc/device_state_contract_test.go
@@ -77,6 +77,8 @@ func (completeDeviceStatePayloads) AttachOHPCFPayload(event *pb.OHPCFEvent, _ st
 	return true
 }
 
+func (completeDeviceStatePayloads) RefreshCompressorFlexibility(string) {}
+
 func TestEveryDeclaredEventTypeHasExplicitDeviceStateClassification(t *testing.T) {
 	_, filename, _, ok := runtime.Caller(0)
 	if !ok {

--- a/eebus-bridge/internal/grpc/ohpcf_service.go
+++ b/eebus-bridge/internal/grpc/ohpcf_service.go
@@ -63,6 +63,15 @@ type OHPCFController interface {
 	Abort(spineapi.EntityRemoteInterface) error
 }
 
+// ohpcfRefreshController is implemented by production controllers that can
+// actively reconcile their remote feature cache. Keeping this optional leaves
+// deterministic read/controller fakes and alternative adapters lightweight.
+type ohpcfRefreshController interface {
+	Refresh(spineapi.EntityRemoteInterface)
+}
+
+var _ ohpcfRefreshController = (*usecases.OHPCFWrapper)(nil)
+
 // OHPCFServiceOption customizes the OHPCF adapter at construction time.
 type OHPCFServiceOption func(*OHPCFService)
 
@@ -112,6 +121,27 @@ func (s *OHPCFService) GetCompressorFlexibility(_ context.Context, req *pb.Devic
 		s.registry.RecordCapabilityRead(req.Ski, eebus.CapabilityOHPCF, nil)
 	}
 	return flexibility, nil
+}
+
+// RefreshCompressorFlexibility starts a best-effort remote reconciliation for
+// snapshot reads. The resulting SPINE reply updates the cache and emits the
+// normal OHPCF state/data events; it does not make the current snapshot wait on
+// network I/O or discard its last coherent value.
+func (s *OHPCFService) RefreshCompressorFlexibility(ski string) {
+	if s.ohpcf == nil {
+		return
+	}
+	entity, err := s.resolveEntity(ski)
+	if err != nil {
+		return
+	}
+	s.refresh(entity)
+}
+
+func (s *OHPCFService) refresh(entity spineapi.EntityRemoteInterface) {
+	if refresher, ok := s.ohpcf.(ohpcfRefreshController); ok {
+		refresher.Refresh(entity)
+	}
 }
 
 func (s *OHPCFService) ControlCompressorFlexibility(_ context.Context, req *pb.ControlCompressorRequest) (*pb.Empty, error) {

--- a/eebus-bridge/internal/grpc/ohpcf_service_additional_test.go
+++ b/eebus-bridge/internal/grpc/ohpcf_service_additional_test.go
@@ -187,6 +187,18 @@ func TestOHPCFSnapshotActivelyReconcilesStoppedRemoteCache(t *testing.T) {
 	if controller.refreshes != 1 || controller.refreshedEntity != entity {
 		t.Fatalf("snapshot refresh = (%d, %v), want (1, requested entity)", controller.refreshes, controller.refreshedEntity)
 	}
+
+	NewOHPCFService(nil, eebus.NewEventBus(), registry).RefreshCompressorFlexibility(testValidSKI)
+	unresolved := &refreshingOHPCFController{}
+	NewOHPCFService(
+		nil,
+		eebus.NewEventBus(),
+		registry,
+		WithOHPCFController(unresolved),
+	).RefreshCompressorFlexibility(testValidSKI)
+	if unresolved.refreshes != 0 {
+		t.Fatalf("unresolved entity triggered %d refreshes, want 0", unresolved.refreshes)
+	}
 }
 
 func TestOHPCFNoProcessRemainsAvailableInReadsEventsAndSnapshots(t *testing.T) {

--- a/eebus-bridge/internal/grpc/ohpcf_service_additional_test.go
+++ b/eebus-bridge/internal/grpc/ohpcf_service_additional_test.go
@@ -83,6 +83,17 @@ type controlOHPCFController struct {
 	calls        []string
 }
 
+type refreshingOHPCFController struct {
+	noProcessOHPCFController
+	refreshes       int
+	refreshedEntity spineapi.EntityRemoteInterface
+}
+
+func (c *refreshingOHPCFController) Refresh(entity spineapi.EntityRemoteInterface) {
+	c.refreshes++
+	c.refreshedEntity = entity
+}
+
 func (c *controlOHPCFController) OptionalPowerConsumptionAvailable(spineapi.EntityRemoteInterface) (bool, error) {
 	return c.available, c.availableErr
 }
@@ -148,6 +159,33 @@ func TestOHPCFServiceGetFlexibilityContracts(t *testing.T) {
 	}))
 	if _, err := failing.GetCompressorFlexibility(ctx, &pb.DeviceRequest{Ski: testValidSKI}); status.Code(err) != codes.Unavailable {
 		t.Fatalf("all-failed status = %s, error=%v", status.Code(err), err)
+	}
+}
+
+func TestOHPCFSnapshotActivelyReconcilesStoppedRemoteCache(t *testing.T) {
+	entity := mocks.NewEntityRemoteInterface(t)
+	registry := eebus.NewDeviceRegistry()
+	registry.AddDevice(testValidSKI, eebus.DeviceInfo{})
+	controller := &refreshingOHPCFController{
+		noProcessOHPCFController: noProcessOHPCFController{failingOHPCFController{
+			entity: entity,
+			err:    eebusapi.ErrDataNotAvailable,
+		}},
+	}
+	service := NewOHPCFService(nil, eebus.NewEventBus(), registry, WithOHPCFController(controller))
+
+	snapshot, err := NewDeviceSnapshotAssembler(
+		registry,
+		DeviceStatePayloadSources{OHPCF: service},
+	).Build(testValidSKI, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if snapshot.GetCompressorFlexibility().GetState() != pb.CompressorPowerConsumptionState_COMPRESSOR_STATE_STOPPED {
+		t.Fatalf("cached snapshot state = %s, want stopped", snapshot.GetCompressorFlexibility().GetState())
+	}
+	if controller.refreshes != 1 || controller.refreshedEntity != entity {
+		t.Fatalf("snapshot refresh = (%d, %v), want (1, requested entity)", controller.refreshes, controller.refreshedEntity)
 	}
 }
 

--- a/eebus-bridge/internal/usecases/ohpcf.go
+++ b/eebus-bridge/internal/usecases/ohpcf.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	eebusapi "github.com/enbility/eebus-go/api"
+	"github.com/enbility/eebus-go/features/client"
 	ucapi "github.com/enbility/eebus-go/usecases/api"
 	cemohpcf "github.com/enbility/eebus-go/usecases/cem/ohpcf"
 	spineapi "github.com/enbility/spine-go/api"
@@ -123,6 +124,26 @@ func (w *OHPCFWrapper) OptionalPowerConsumptionAvailable(entity spineapi.EntityR
 		return false, errOHPCFNotInitialized
 	}
 	return w.uc.OptionalPowerConsumptionAvailable(entity)
+}
+
+// Refresh requests the current SmartEnergyManagementPs data from the remote
+// compressor. The reply updates the spine-go feature cache asynchronously and
+// is surfaced through HandleEvent, so callers keep serving the last coherent
+// cache value while the reconciliation request is in flight.
+func (w *OHPCFWrapper) Refresh(entity spineapi.EntityRemoteInterface) {
+	if w.uc == nil || w.localEntity == nil || entity == nil {
+		return
+	}
+	feature, err := client.NewSmartEnergyManagementPs(w.localEntity, entity)
+	if err != nil {
+		if w.debug {
+			log.Printf("[OHPCF] refresh setup failed: %v", err)
+		}
+		return
+	}
+	if _, err := feature.RequestData(); err != nil && w.debug {
+		log.Printf("[OHPCF] refresh request failed: %v", err)
+	}
 }
 
 // CompatibleEntity returns the first remote entity that actually supports the

--- a/eebus-bridge/internal/usecases/ohpcf_refresh_test.go
+++ b/eebus-bridge/internal/usecases/ohpcf_refresh_test.go
@@ -1,0 +1,103 @@
+package usecases
+
+import (
+	"testing"
+
+	cemohpcf "github.com/enbility/eebus-go/usecases/cem/ohpcf"
+	spineapi "github.com/enbility/spine-go/api"
+	spinemocks "github.com/enbility/spine-go/mocks"
+	"github.com/enbility/spine-go/model"
+	"github.com/enbility/spine-go/spine"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestOHPCFRefreshRequestsSmartEnergyManagementData(t *testing.T) {
+	localEntity := spinemocks.NewEntityLocalInterface(t)
+	remoteEntity := spinemocks.NewEntityRemoteInterface(t)
+	remoteDevice := spinemocks.NewDeviceRemoteInterface(t)
+	localFeature := spinemocks.NewFeatureLocalInterface(t)
+	remoteFeature := spinemocks.NewFeatureRemoteInterface(t)
+	counter := model.MsgCounterType(1)
+
+	localEntity.EXPECT().Device().Return(nil)
+	localEntity.EXPECT().FeatureOfTypeAndRole(
+		model.FeatureTypeTypeSmartEnergyManagementPs,
+		model.RoleTypeClient,
+	).Return(localFeature)
+	remoteEntity.EXPECT().Device().Return(remoteDevice).Twice()
+	remoteDevice.EXPECT().FeatureByEntityTypeAndRole(
+		remoteEntity,
+		model.FeatureTypeTypeSmartEnergyManagementPs,
+		model.RoleTypeServer,
+	).Return(remoteFeature)
+	remoteFeature.EXPECT().Operations().Return(map[model.FunctionType]spineapi.OperationsInterface{
+		model.FunctionTypeSmartEnergyManagementPsData: spine.NewOperations(true, false, false, false),
+	})
+	remoteFeature.EXPECT().String().Return("remote SmartEnergyManagementPs feature").Maybe()
+	localFeature.EXPECT().RequestRemoteData(
+		model.FunctionTypeSmartEnergyManagementPsData,
+		mock.Anything,
+		mock.Anything,
+		mock.Anything,
+	).Return(&counter, nil)
+
+	wrapper := OHPCFWrapper{uc: &cemohpcf.OHPCF{}, localEntity: localEntity}
+	wrapper.Refresh(remoteEntity)
+}
+
+func TestOHPCFRefreshHandlesUnavailableSetupAndRequest(t *testing.T) {
+	t.Run("before setup", func(t *testing.T) {
+		new(OHPCFWrapper).Refresh(nil)
+	})
+
+	t.Run("feature setup fails", func(t *testing.T) {
+		localEntity := spinemocks.NewEntityLocalInterface(t)
+		remoteEntity := spinemocks.NewEntityRemoteInterface(t)
+		localEntity.EXPECT().Device().Return(nil)
+		remoteEntity.EXPECT().Device().Return(nil)
+		localEntity.EXPECT().FeatureOfTypeAndRole(
+			model.FeatureTypeTypeSmartEnergyManagementPs,
+			model.RoleTypeClient,
+		).Return(nil)
+		localEntity.EXPECT().FeatureOfTypeAndRole(
+			model.FeatureTypeTypeGeneric,
+			model.RoleTypeClient,
+		).Return(nil)
+
+		wrapper := OHPCFWrapper{uc: &cemohpcf.OHPCF{}, localEntity: localEntity, debug: true}
+		wrapper.Refresh(remoteEntity)
+	})
+
+	t.Run("request fails", func(t *testing.T) {
+		localEntity := spinemocks.NewEntityLocalInterface(t)
+		remoteEntity := spinemocks.NewEntityRemoteInterface(t)
+		remoteDevice := spinemocks.NewDeviceRemoteInterface(t)
+		localFeature := spinemocks.NewFeatureLocalInterface(t)
+		remoteFeature := spinemocks.NewFeatureRemoteInterface(t)
+
+		localEntity.EXPECT().Device().Return(nil)
+		localEntity.EXPECT().FeatureOfTypeAndRole(
+			model.FeatureTypeTypeSmartEnergyManagementPs,
+			model.RoleTypeClient,
+		).Return(localFeature)
+		remoteEntity.EXPECT().Device().Return(remoteDevice).Twice()
+		remoteDevice.EXPECT().FeatureByEntityTypeAndRole(
+			remoteEntity,
+			model.FeatureTypeTypeSmartEnergyManagementPs,
+			model.RoleTypeServer,
+		).Return(remoteFeature)
+		remoteFeature.EXPECT().Operations().Return(map[model.FunctionType]spineapi.OperationsInterface{
+			model.FunctionTypeSmartEnergyManagementPsData: spine.NewOperations(true, false, false, false),
+		})
+		remoteFeature.EXPECT().String().Return("remote SmartEnergyManagementPs feature").Maybe()
+		localFeature.EXPECT().RequestRemoteData(
+			model.FunctionTypeSmartEnergyManagementPsData,
+			mock.Anything,
+			mock.Anything,
+			mock.Anything,
+		).Return(nil, model.NewErrorType(model.ErrorNumberTypeCommandRejected, "rejected"))
+
+		wrapper := OHPCFWrapper{uc: &cemohpcf.OHPCF{}, localEntity: localEntity, debug: true}
+		wrapper.Refresh(remoteEntity)
+	})
+}


### PR DESCRIPTION
## Summary

- actively request current `SmartEnergyManagementPs` data after each device snapshot
- keep serving the last coherent OHPCF cache value while the asynchronous refresh is in flight
- feed the refresh reply through the existing OHPCF event pipeline so missed notifications self-heal on the next five-minute reconciliation
- keep the standalone OHPCF read RPC passive to avoid turning fast diagnostic readers into a SPINE polling loop

## Regression covered

A retained `COMPRESSOR_STATE_STOPPED` snapshot now triggers exactly one refresh for the resolved compressor entity. This covers the observed case where a restart changed the state to `AVAILABLE` because reconnect requested fresh remote data.

## Validation

- `go test ./...`
- `go vet ./...`
- `go test -race ./...`
- `git diff --check`