### PR TITLE
fix: harden room heating Phase 0 contracts

### DIFF
--- a/docs/badges/go-coverage.svg
+++ b/docs/badges/go-coverage.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="172" height="28" role="img" aria-label="Go coverage: 84.4%">
-  <title>Go coverage: 84.4%</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="172" height="28" role="img" aria-label="Go coverage: 84.9%">
+  <title>Go coverage: 84.9%</title>
   <linearGradient id="s" x2="0" y2="100%">
     <stop offset="0" stop-color="#fff" stop-opacity=".15"/>
     <stop offset="1" stop-opacity=".15"/>
@@ -12,6 +12,6 @@
   </g>
   <g fill="#fff" text-anchor="middle" font-family="Verdana,DejaVu Sans,sans-serif" font-size="10" font-weight="700">
     <text x="56" y="18">GO COVERAGE</text>
-    <text x="142" y="18">84.4%</text>
+    <text x="142" y="18">84.9%</text>
   </g>
 </svg>

--- a/docs/room-heating-eebus-go-migration-spec.md
+++ b/docs/room-heating-eebus-go-migration-spec.md
@@ -1,7 +1,7 @@
 # Room Heating auf eebus-go migrieren — Spec Proposal
 
 **Datum:** 2026-07-22
-**Status:** Proposal
+**Status:** In Umsetzung — Phase 0 begonnen
 **Scope:** Schrittweise Ablösung der bridge-lokalen Implementierungen für
 Configuration/Monitoring of Room Heating durch die bereits im gepinnten
 `eebus-go`-Fork enthaltenen Upstream-PRs, ohne Änderung des bestehenden gRPC-
@@ -516,6 +516,19 @@ Exit:
 - Kein öffentlicher Vertrag wurde geändert.
 - Die §4.7-Semantik ist als Invariante getestet und dient allen folgenden
   „identisch zu vorher“-Exits als Referenz.
+
+Umsetzungsstand 2026-07-22:
+
+- [x] §4.7 lokal gehärtet: Mode-Typen werden dedupliziert, verschiedene IDs
+  desselben Typs sind nicht schreibbar, und mehrere verschiedene
+  `roomAirTemperature`-Setpoints liefern Data-Unavailable.
+- [x] Automatisierte Contract-Tests für State/Presence, Range, Step, Relation,
+  Result/Reject, Cancellation, internen Timeout, Reconnect-Refresh und das
+  bestehende gRPC-Fehlermapping ergänzt.
+- [ ] Reproduzierbaren VR940-Capture mit Firmware, Ausgangswerten,
+  `auto`/`on`/`off`, Setpoint-Read-back und Restore durchführen.
+- [ ] Upstream-CRHT/CRHSF-Write ohne zusätzliches Feature-Binding am VR940
+  prüfen.
 
 ### Phase 1 — MRHSF übernimmt Reads und State-Events
 

--- a/docs/room-heating-eebus-go-migration-spec.md
+++ b/docs/room-heating-eebus-go-migration-spec.md
@@ -525,8 +525,16 @@ Umsetzungsstand 2026-07-22:
 - [x] Automatisierte Contract-Tests für State/Presence, Range, Step, Relation,
   Result/Reject, Cancellation, internen Timeout, Reconnect-Refresh und das
   bestehende gRPC-Fehlermapping ergänzt.
-- [ ] Reproduzierbaren VR940-Capture mit Firmware, Ausgangswerten,
-  `auto`/`on`/`off`, Setpoint-Read-back und Restore durchführen.
+- [x] Reproduzierbaren VR940-Capture mit Ausgangswerten, `auto`/`on`/`off`,
+  Setpoint-Read-back und Restore durchgeführt (2026-07-22, Stack 93,
+  `climate.eebus_682f708c_raumheizung`): Baseline `off`/21,0 °C
+  (Range 5–30 °C, Step 0,5 °C, `hvac_modes` = `auto`/`heat`/`off`);
+  Transitions `auto` → `heat` → `off` → `auto` je mit Read-back bestätigt;
+  Setpoint 21,0 → 21,5 °C geschrieben und zurückgelesen; Baseline
+  (`off`/21,0 °C) wiederhergestellt. Firmware/Modell konnten nicht erfasst
+  werden — das HA-Device-Registry-Objekt liefert `manufacturer`, `model`,
+  `sw_version` und `hw_version` als `None` (separat zu klären, nicht Teil
+  dieser Phase).
 - [ ] Upstream-CRHT/CRHSF-Write ohne zusätzliches Feature-Binding am VR940
   prüfen.
 

--- a/eebus-bridge/internal/grpc/errors_test.go
+++ b/eebus-bridge/internal/grpc/errors_test.go
@@ -48,6 +48,35 @@ func TestEquivalentDeviceWriteRejectionsAreFailedPrecondition(t *testing.T) {
 	}
 }
 
+func TestRoomHeatingErrorMappingContract(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		code codes.Code
+	}{
+		{name: "temperature out of range", err: usecases.ErrRoomHeatingOutOfRange, code: codes.InvalidArgument},
+		{name: "temperature off step", err: usecases.ErrRoomHeatingInvalidStep, code: codes.InvalidArgument},
+		{name: "mode outside relation", err: usecases.ErrRoomHeatingSysFnInvalidMode, code: codes.InvalidArgument},
+		{name: "temperature not writable", err: usecases.ErrRoomHeatingNotWritable, code: codes.FailedPrecondition},
+		{name: "temperature rejected", err: usecases.ErrRoomHeatingRejected, code: codes.FailedPrecondition},
+		{name: "mode not writable", err: usecases.ErrRoomHeatingSysFnNotWritable, code: codes.FailedPrecondition},
+		{name: "mode rejected", err: usecases.ErrRoomHeatingSysFnRejected, code: codes.FailedPrecondition},
+		{name: "temperature unavailable", err: usecases.ErrRoomHeatingDataUnavailable, code: codes.Unavailable},
+		{name: "mode unavailable", err: usecases.ErrRoomHeatingSysFnDataUnavailable, code: codes.Unavailable},
+		{name: "caller canceled", err: context.Canceled, code: codes.Canceled},
+		{name: "caller deadline", err: context.DeadlineExceeded, code: codes.DeadlineExceeded},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := mapRoomHeatingError("writing room heating", fmt.Errorf("wrapped: %w", test.err))
+			if code := status.Code(err); code != test.code {
+				t.Fatalf("code = %v, want %v (err: %v)", code, test.code, err)
+			}
+		})
+	}
+}
+
 func TestUnknownInternalErrorIsSanitized(t *testing.T) {
 	err := mapUsecaseError("reading data", errors.New("token=super-secret"), usecaseErrorClasses{})
 	if status.Code(err) != codes.Internal || strings.Contains(err.Error(), "super-secret") {

--- a/eebus-bridge/internal/usecases/client_usecase_lifecycle_additional_test.go
+++ b/eebus-bridge/internal/usecases/client_usecase_lifecycle_additional_test.go
@@ -252,3 +252,76 @@ func TestClientUsecaseRefreshAndResolutionGuards(t *testing.T) {
 		t.Fatal("uninitialized use case resolved an entity")
 	}
 }
+
+func TestRoomHeatingReconnectReestablishesRelationsAndRefreshesCaches(t *testing.T) {
+	tests := []struct {
+		name      string
+		feature   model.FeatureTypeType
+		functions []model.FunctionType
+		connect   func(spineapi.EntityLocalInterface, spineapi.EntityRemoteInterface)
+	}{
+		{
+			name:    "temperature",
+			feature: model.FeatureTypeTypeSetpoint,
+			functions: []model.FunctionType{
+				model.FunctionTypeSetpointDescriptionListData,
+				model.FunctionTypeSetpointConstraintsListData,
+				model.FunctionTypeSetpointListData,
+			},
+			connect: func(local spineapi.EntityLocalInterface, remote spineapi.EntityRemoteInterface) {
+				(&RoomHeatingTemperature{localEntity: local}).connect(remote)
+			},
+		},
+		{
+			name:    "system function",
+			feature: model.FeatureTypeTypeHvac,
+			functions: []model.FunctionType{
+				model.FunctionTypeHvacSystemFunctionDescriptionListData,
+				model.FunctionTypeHvacSystemFunctionListData,
+				model.FunctionTypeHvacOperationModeDescriptionListData,
+				model.FunctionTypeHvacSystemFunctionOperationModeRelationListData,
+			},
+			connect: func(local spineapi.EntityLocalInterface, remote spineapi.EntityRemoteInterface) {
+				(&RoomHeatingSystemFunction{localEntity: local}).connect(remote)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			address := &model.FeatureAddressType{}
+			operation := mocks.NewOperationsInterface(t)
+			operation.On("Read").Return(true)
+			operations := make(map[model.FunctionType]spineapi.OperationsInterface, len(test.functions))
+			for _, function := range test.functions {
+				operations[function] = operation
+			}
+			remoteFeature := mocks.NewFeatureRemoteInterface(t)
+			remoteFeature.On("Address").Return(address)
+			remoteFeature.On("Operations").Return(operations)
+			remoteFeature.On("String").Return("remote room-heating feature").Maybe()
+
+			localFeature := mocks.NewFeatureLocalInterface(t)
+			localFeature.On("HasSubscriptionToRemote", address).Return(false)
+			localFeature.On("SubscribeToRemote", address).
+				Return(ptr(model.MsgCounterType(1)), (*model.ErrorType)(nil)).Once()
+			localFeature.On("HasBindingToRemote", address).Return(false)
+			localFeature.On("BindToRemote", address).
+				Return(ptr(model.MsgCounterType(2)), (*model.ErrorType)(nil)).Once()
+			for _, function := range test.functions {
+				localFeature.On("RequestRemoteData", function, nil, nil, remoteFeature).
+					Return(ptr(model.MsgCounterType(3)), (*model.ErrorType)(nil)).Once()
+			}
+
+			remoteEntity := mocks.NewEntityRemoteInterface(t)
+			remoteEntity.On("FeatureOfTypeAndRole", test.feature, model.RoleTypeServer).Return(remoteFeature)
+			localEntity := mocks.NewEntityLocalInterface(t)
+			localEntity.On("FeatureOfTypeAndRole", test.feature, model.RoleTypeClient).Return(localFeature)
+
+			test.connect(localEntity, remoteEntity)
+			localFeature.AssertNumberOfCalls(t, "RequestRemoteData", len(test.functions))
+			localFeature.AssertCalled(t, "SubscribeToRemote", address)
+			localFeature.AssertCalled(t, "BindToRemote", address)
+		})
+	}
+}

--- a/eebus-bridge/internal/usecases/hvac_cache.go
+++ b/eebus-bridge/internal/usecases/hvac_cache.go
@@ -41,22 +41,44 @@ func operationModesForSystem(
 	var modeIDs []model.HvacOperationModeIdType
 	for _, relation := range data.HvacSystemFunctionOperationModeRelationData {
 		if relation.SystemFunctionId != nil && *relation.SystemFunctionId == systemID {
-			modeIDs = relation.OperationModeId
-			break
+			modeIDs = append(modeIDs, relation.OperationModeId...)
 		}
 	}
 	if len(modeIDs) == 0 {
 		return nil, nil, false
 	}
 	modes := make([]string, 0, len(modeIDs))
-	idForType := make(map[string]model.HvacOperationModeIdType, len(modeIDs))
+	idsForType := make(map[string][]model.HvacOperationModeIdType, len(modeIDs))
 	for _, id := range modeIDs {
 		modeType, ok := operationModeType(feature, id)
 		if !ok {
 			return nil, nil, false
 		}
-		modes = append(modes, string(modeType))
-		idForType[string(modeType)] = id
+		typeName := string(modeType)
+		ids := idsForType[typeName]
+		duplicateID := false
+		for _, knownID := range ids {
+			if knownID == id {
+				duplicateID = true
+				break
+			}
+		}
+		if duplicateID {
+			continue
+		}
+		if len(ids) == 0 {
+			modes = append(modes, typeName)
+		}
+		idsForType[typeName] = append(ids, id)
+	}
+
+	// A type remains readable when a device advertises it through multiple
+	// IDs, but it is not safe to choose one of those IDs for a write.
+	idForType := make(map[string]model.HvacOperationModeIdType, len(idsForType))
+	for modeType, ids := range idsForType {
+		if len(ids) == 1 {
+			idForType[modeType] = ids[0]
+		}
 	}
 	return modes, idForType, true
 }

--- a/eebus-bridge/internal/usecases/hvac_cache_test.go
+++ b/eebus-bridge/internal/usecases/hvac_cache_test.go
@@ -1,6 +1,7 @@
 package usecases
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/enbility/spine-go/mocks"
@@ -69,5 +70,72 @@ func TestOperationModesForSystemFailsClosedOnUnresolvedModeType(t *testing.T) {
 
 	if _, _, ok := operationModesForSystem(feature, 3); ok {
 		t.Fatal("operationModesForSystem() accepted an unresolved mode type")
+	}
+}
+
+func TestOperationModesForSystemDeduplicatesTypesAndWithholdsAmbiguousWriteIDs(t *testing.T) {
+	tests := []struct {
+		name      string
+		relations [][]model.HvacOperationModeIdType
+		wantModes []string
+		wantIDs   map[string]model.HvacOperationModeIdType
+	}{
+		{
+			name:      "unique types",
+			relations: [][]model.HvacOperationModeIdType{{0, 1, 2}},
+			wantModes: []string{"off", "on", "auto"},
+			wantIDs:   map[string]model.HvacOperationModeIdType{"off": 0, "on": 1, "auto": 2},
+		},
+		{
+			name:      "same ID repeated",
+			relations: [][]model.HvacOperationModeIdType{{0, 1, 1, 2}},
+			wantModes: []string{"off", "on", "auto"},
+			wantIDs:   map[string]model.HvacOperationModeIdType{"off": 0, "on": 1, "auto": 2},
+		},
+		{
+			name:      "same type has distinct IDs",
+			relations: [][]model.HvacOperationModeIdType{{0, 1}, {3, 2}},
+			wantModes: []string{"off", "on", "auto"},
+			wantIDs:   map[string]model.HvacOperationModeIdType{"off": 0, "auto": 2},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			feature := mocks.NewFeatureRemoteInterface(t)
+			relationData := make([]model.HvacSystemFunctionOperationModeRelationDataType, 0, len(test.relations))
+			for _, ids := range test.relations {
+				relationData = append(relationData, model.HvacSystemFunctionOperationModeRelationDataType{
+					SystemFunctionId: ptr(model.HvacSystemFunctionIdType(3)),
+					OperationModeId:  ids,
+				})
+			}
+			feature.On("DataCopy", model.FunctionTypeHvacSystemFunctionOperationModeRelationListData).Return(
+				&model.HvacSystemFunctionOperationModeRelationListDataType{
+					HvacSystemFunctionOperationModeRelationData: relationData,
+				},
+			)
+			feature.On("DataCopy", model.FunctionTypeHvacOperationModeDescriptionListData).Return(
+				&model.HvacOperationModeDescriptionListDataType{
+					HvacOperationModeDescriptionData: []model.HvacOperationModeDescriptionDataType{
+						{OperationModeId: ptr(model.HvacOperationModeIdType(0)), OperationModeType: ptr(model.HvacOperationModeTypeTypeOff)},
+						{OperationModeId: ptr(model.HvacOperationModeIdType(1)), OperationModeType: ptr(model.HvacOperationModeTypeTypeOn)},
+						{OperationModeId: ptr(model.HvacOperationModeIdType(2)), OperationModeType: ptr(model.HvacOperationModeTypeTypeAuto)},
+						{OperationModeId: ptr(model.HvacOperationModeIdType(3)), OperationModeType: ptr(model.HvacOperationModeTypeTypeOn)},
+					},
+				},
+			)
+
+			modes, ids, ok := operationModesForSystem(feature, 3)
+			if !ok {
+				t.Fatal("operationModesForSystem() failed")
+			}
+			if !reflect.DeepEqual(modes, test.wantModes) {
+				t.Errorf("modes = %v, want %v", modes, test.wantModes)
+			}
+			if !reflect.DeepEqual(ids, test.wantIDs) {
+				t.Errorf("write IDs = %v, want %v", ids, test.wantIDs)
+			}
+		})
 	}
 }

--- a/eebus-bridge/internal/usecases/hvac_write_flow.go
+++ b/eebus-bridge/internal/usecases/hvac_write_flow.go
@@ -9,6 +9,8 @@ import (
 	"github.com/enbility/spine-go/model"
 )
 
+var hvacWriteTimeout = dhwWriteTimeout
+
 func writeHvacCommand(
 	ctx context.Context,
 	entity spineapi.EntityRemoteInterface,
@@ -36,7 +38,7 @@ func writeHvacCommand(
 		return fmt.Errorf("waiting for %s result: %w", label, err)
 	}
 
-	timer := time.NewTimer(dhwWriteTimeout)
+	timer := time.NewTimer(hvacWriteTimeout)
 	defer timer.Stop()
 	select {
 	case response := <-result:

--- a/eebus-bridge/internal/usecases/hvac_write_test.go
+++ b/eebus-bridge/internal/usecases/hvac_write_test.go
@@ -25,14 +25,26 @@ func hvacWriteHarnessWithErrno(
 	remote *mocks.FeatureRemoteInterface,
 	errno model.ErrorNumberType,
 ) (*mocks.EntityLocalInterface, *mocks.EntityRemoteInterface, *writtenHvacCommand) {
+	return hvacWriteHarnessWithResult(t, remote, &errno)
+}
+
+func hvacWriteHarnessWithResult(
+	t *testing.T,
+	remote *mocks.FeatureRemoteInterface,
+	errno *model.ErrorNumberType,
+) (*mocks.EntityLocalInterface, *mocks.EntityRemoteInterface, *writtenHvacCommand) {
 	t.Helper()
 	localAddress := &model.FeatureAddressType{}
 	local := mocks.NewFeatureLocalInterface(t)
 	local.On("Address").Return(localAddress)
-	local.On("AddResponseCallback", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
-		callback := args.Get(1).(func(spineapi.ResponseMessage))
-		callback(spineapi.ResponseMessage{Data: &model.ResultDataType{ErrorNumber: ptr(errno)}})
-	}).Return(nil)
+	response := local.On("AddResponseCallback", mock.Anything, mock.Anything)
+	if errno != nil {
+		response.Run(func(args mock.Arguments) {
+			callback := args.Get(1).(func(spineapi.ResponseMessage))
+			callback(spineapi.ResponseMessage{Data: &model.ResultDataType{ErrorNumber: errno}})
+		})
+	}
+	response.Return(nil)
 	local.On("RequestRemoteData", mock.Anything, mock.Anything, mock.Anything, remote).
 		Return(ptr(model.MsgCounterType(10)), (*model.ErrorType)(nil)).Maybe()
 

--- a/eebus-bridge/internal/usecases/roomheatingsysfn_test.go
+++ b/eebus-bridge/internal/usecases/roomheatingsysfn_test.go
@@ -3,7 +3,9 @@ package usecases
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
+	"time"
 
 	spineapi "github.com/enbility/spine-go/api"
 	"github.com/enbility/spine-go/mocks"
@@ -14,6 +16,23 @@ func newRoomHeatingSysFnFeature(
 	t *testing.T,
 	currentModeID model.HvacOperationModeIdType,
 	writable bool,
+) *mocks.FeatureRemoteInterface {
+	return newRoomHeatingSysFnFeatureWithModes(t, currentModeID, writable,
+		[]model.HvacOperationModeDescriptionDataType{
+			{OperationModeId: ptr(model.HvacOperationModeIdType(0)), OperationModeType: ptr(model.HvacOperationModeTypeTypeOff)},
+			{OperationModeId: ptr(model.HvacOperationModeIdType(1)), OperationModeType: ptr(model.HvacOperationModeTypeTypeOn)},
+			{OperationModeId: ptr(model.HvacOperationModeIdType(2)), OperationModeType: ptr(model.HvacOperationModeTypeTypeAuto)},
+		},
+		[]model.HvacOperationModeIdType{0, 1, 2},
+	)
+}
+
+func newRoomHeatingSysFnFeatureWithModes(
+	t *testing.T,
+	currentModeID model.HvacOperationModeIdType,
+	writable bool,
+	descriptions []model.HvacOperationModeDescriptionDataType,
+	modeIDs []model.HvacOperationModeIdType,
 ) *mocks.FeatureRemoteInterface {
 	t.Helper()
 	feature := mocks.NewFeatureRemoteInterface(t)
@@ -28,15 +47,11 @@ func newRoomHeatingSysFnFeature(
 		}},
 	)
 	feature.On("DataCopy", model.FunctionTypeHvacOperationModeDescriptionListData).Return(
-		&model.HvacOperationModeDescriptionListDataType{HvacOperationModeDescriptionData: []model.HvacOperationModeDescriptionDataType{
-			{OperationModeId: ptr(model.HvacOperationModeIdType(0)), OperationModeType: ptr(model.HvacOperationModeTypeTypeOff)},
-			{OperationModeId: ptr(model.HvacOperationModeIdType(1)), OperationModeType: ptr(model.HvacOperationModeTypeTypeOn)},
-			{OperationModeId: ptr(model.HvacOperationModeIdType(2)), OperationModeType: ptr(model.HvacOperationModeTypeTypeAuto)},
-		}},
+		&model.HvacOperationModeDescriptionListDataType{HvacOperationModeDescriptionData: descriptions},
 	)
 	feature.On("DataCopy", model.FunctionTypeHvacSystemFunctionOperationModeRelationListData).Return(
 		&model.HvacSystemFunctionOperationModeRelationListDataType{HvacSystemFunctionOperationModeRelationData: []model.HvacSystemFunctionOperationModeRelationDataType{
-			{SystemFunctionId: ptr(model.HvacSystemFunctionIdType(0)), OperationModeId: []model.HvacOperationModeIdType{0, 1, 2}},
+			{SystemFunctionId: ptr(model.HvacSystemFunctionIdType(0)), OperationModeId: modeIDs},
 		}},
 	)
 	operation := mocks.NewOperationsInterface(t)
@@ -48,6 +63,37 @@ func newRoomHeatingSysFnFeature(
 	feature.On("Address").Return(&model.FeatureAddressType{}).Maybe()
 	feature.On("String").Return("remote room HVAC").Maybe()
 	return feature
+}
+
+func TestRoomHeatingSysFnAmbiguousModeTypeIsReadableButNotWritable(t *testing.T) {
+	feature := newRoomHeatingSysFnFeatureWithModes(t, 1, true,
+		[]model.HvacOperationModeDescriptionDataType{
+			{OperationModeId: ptr(model.HvacOperationModeIdType(0)), OperationModeType: ptr(model.HvacOperationModeTypeTypeOff)},
+			{OperationModeId: ptr(model.HvacOperationModeIdType(1)), OperationModeType: ptr(model.HvacOperationModeTypeTypeOn)},
+			{OperationModeId: ptr(model.HvacOperationModeIdType(2)), OperationModeType: ptr(model.HvacOperationModeTypeTypeAuto)},
+			{OperationModeId: ptr(model.HvacOperationModeIdType(3)), OperationModeType: ptr(model.HvacOperationModeTypeTypeOn)},
+		},
+		[]model.HvacOperationModeIdType{0, 1, 3, 2},
+	)
+	entity := mocks.NewEntityRemoteInterface(t)
+	entity.On("FeatureOfTypeAndRole", model.FeatureTypeTypeHvac, model.RoleTypeServer).Return(feature)
+
+	state, err := (&RoomHeatingSystemFunction{}).State(entity)
+	if err != nil {
+		t.Fatalf("State() error = %v", err)
+	}
+	wantModes := []string{"off", "on", "auto"}
+	if len(state.AvailableModes) != len(wantModes) {
+		t.Fatalf("AvailableModes = %v, want %v", state.AvailableModes, wantModes)
+	}
+	for index := range wantModes {
+		if state.AvailableModes[index] != wantModes[index] {
+			t.Fatalf("AvailableModes = %v, want %v", state.AvailableModes, wantModes)
+		}
+	}
+	if err := (&RoomHeatingSystemFunction{}).WriteOperationMode(context.Background(), entity, "on"); !errors.Is(err, ErrRoomHeatingSysFnInvalidMode) {
+		t.Fatalf("WriteOperationMode() error = %v, want ErrRoomHeatingSysFnInvalidMode", err)
+	}
 }
 
 func TestRoomHeatingSysFnStateResolvesCurrentAndAvailableModes(t *testing.T) {
@@ -125,5 +171,19 @@ func TestRoomHeatingSysFnWriteGuardsAndRejection(t *testing.T) {
 	missingLocalEntity.On("FeatureOfTypeAndRole", model.FeatureTypeTypeHvac, model.RoleTypeServer).Return(feature)
 	if err := (&RoomHeatingSystemFunction{}).WriteOperationMode(context.Background(), missingLocalEntity, "on"); !errors.Is(err, ErrRoomHeatingSysFnDataUnavailable) {
 		t.Fatalf("missing-local error = %v", err)
+	}
+}
+
+func TestRoomHeatingSysFnWriteTimesOutWithoutDeviceResult(t *testing.T) {
+	feature := newRoomHeatingSysFnFeature(t, 0, true)
+	local, entity, _ := hvacWriteHarnessWithResult(t, feature, nil)
+	room := &RoomHeatingSystemFunction{localEntity: local}
+	previousTimeout := hvacWriteTimeout
+	hvacWriteTimeout = time.Millisecond
+	t.Cleanup(func() { hvacWriteTimeout = previousTimeout })
+
+	err := room.WriteOperationMode(context.Background(), entity, "on")
+	if err == nil || !strings.Contains(err.Error(), "timed out waiting for room heating operation mode result") {
+		t.Fatalf("WriteOperationMode() error = %v, want result timeout", err)
 	}
 }

--- a/eebus-bridge/internal/usecases/roomheatingtemp.go
+++ b/eebus-bridge/internal/usecases/roomheatingtemp.go
@@ -223,11 +223,18 @@ func roomHeatingSetpointID(feature spineapi.FeatureRemoteInterface) (model.Setpo
 	if !ok || data == nil {
 		return 0, false
 	}
+	ids := make(map[model.SetpointIdType]struct{})
 	for _, description := range data.SetpointDescriptionData {
 		if description.SetpointId != nil && description.ScopeType != nil &&
 			*description.ScopeType == model.ScopeTypeTypeRoomAirTemperature {
-			return *description.SetpointId, true
+			ids[*description.SetpointId] = struct{}{}
 		}
+	}
+	if len(ids) != 1 {
+		return 0, false
+	}
+	for id := range ids {
+		return id, true
 	}
 	return 0, false
 }

--- a/eebus-bridge/internal/usecases/roomheatingtemp_test.go
+++ b/eebus-bridge/internal/usecases/roomheatingtemp_test.go
@@ -3,12 +3,86 @@ package usecases
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
+	"time"
 
 	spineapi "github.com/enbility/spine-go/api"
 	"github.com/enbility/spine-go/mocks"
 	"github.com/enbility/spine-go/model"
+	"github.com/stretchr/testify/mock"
 )
+
+func newRoomHeatingWriteFeature(t *testing.T) *mocks.FeatureRemoteInterface {
+	t.Helper()
+	feature := mocks.NewFeatureRemoteInterface(t)
+	feature.On("DataCopy", model.FunctionTypeSetpointDescriptionListData).Return(
+		&model.SetpointDescriptionListDataType{SetpointDescriptionData: []model.SetpointDescriptionDataType{
+			{SetpointId: ptr(model.SetpointIdType(1)), ScopeType: ptr(model.ScopeTypeTypeRoomAirTemperature)},
+		}},
+	)
+	feature.On("DataCopy", model.FunctionTypeSetpointListData).Return(
+		&model.SetpointListDataType{SetpointData: []model.SetpointDataType{
+			{SetpointId: ptr(model.SetpointIdType(0)), Value: model.NewScaledNumberType(12)},
+			{SetpointId: ptr(model.SetpointIdType(1)), Value: model.NewScaledNumberType(21)},
+		}},
+	)
+	feature.On("DataCopy", model.FunctionTypeSetpointConstraintsListData).Return(
+		&model.SetpointConstraintsListDataType{SetpointConstraintsData: []model.SetpointConstraintsDataType{
+			{
+				SetpointId:       ptr(model.SetpointIdType(1)),
+				SetpointRangeMin: model.NewScaledNumberType(5),
+				SetpointRangeMax: model.NewScaledNumberType(30),
+				SetpointStepSize: model.NewScaledNumberType(0.5),
+			},
+		}},
+	)
+	operation := mocks.NewOperationsInterface(t)
+	operation.On("Write").Return(true)
+	operation.On("Read").Return(true).Maybe()
+	feature.On("Operations").Return(map[model.FunctionType]spineapi.OperationsInterface{
+		model.FunctionTypeSetpointListData: operation,
+	})
+	feature.On("Address").Return(&model.FeatureAddressType{})
+	feature.On("String").Return("remote room setpoint").Maybe()
+	return feature
+}
+
+func roomHeatingWriteHarness(
+	t *testing.T,
+	remote *mocks.FeatureRemoteInterface,
+	errno *model.ErrorNumberType,
+) (*mocks.EntityLocalInterface, *mocks.EntityRemoteInterface, **model.SetpointListDataType) {
+	t.Helper()
+	localAddress := &model.FeatureAddressType{}
+	local := mocks.NewFeatureLocalInterface(t)
+	local.On("Address").Return(localAddress)
+	response := local.On("AddResponseCallback", mock.Anything, mock.Anything)
+	if errno != nil {
+		response.Run(func(args mock.Arguments) {
+			callback := args.Get(1).(func(spineapi.ResponseMessage))
+			callback(spineapi.ResponseMessage{Data: &model.ResultDataType{ErrorNumber: errno}})
+		})
+	}
+	response.Return(nil)
+	local.On("RequestRemoteData", mock.Anything, mock.Anything, mock.Anything, remote).
+		Return(ptr(model.MsgCounterType(10)), (*model.ErrorType)(nil)).Maybe()
+
+	var written *model.SetpointListDataType
+	counter := model.MsgCounterType(9)
+	sender := mocks.NewSenderInterface(t)
+	sender.On("Write", localAddress, mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+		written = args.Get(2).(model.CmdType).SetpointListData
+	}).Return(&counter, nil)
+	device := mocks.NewDeviceRemoteInterface(t)
+	device.On("Sender").Return(sender)
+	entity := mocks.NewEntityRemoteInterface(t)
+	entity.On("FeatureOfTypeAndRole", model.FeatureTypeTypeSetpoint, model.RoleTypeServer).Return(remote)
+	entity.On("Device").Return(device)
+	localEntity := mocks.NewEntityLocalInterface(t)
+	localEntity.On("FeatureOfTypeAndRole", model.FeatureTypeTypeSetpoint, model.RoleTypeClient).Return(local)
+	return localEntity, entity, &written
+}
 
 func TestRoomHeatingStateUsesScopedSetpointAndDeviceConstraints(t *testing.T) {
 	feature := mocks.NewFeatureRemoteInterface(t)
@@ -72,6 +146,127 @@ func TestRoomHeatingStateFailsClosedWithoutConstraints(t *testing.T) {
 	}
 }
 
+func TestRoomHeatingStateFailsClosedOnIncompleteValueOrConstraints(t *testing.T) {
+	validValue := model.NewScaledNumberType(21)
+	validMinimum := model.NewScaledNumberType(5)
+	validMaximum := model.NewScaledNumberType(30)
+	validStep := model.NewScaledNumberType(0.5)
+	tests := []struct {
+		name    string
+		value   *model.ScaledNumberType
+		minimum *model.ScaledNumberType
+		maximum *model.ScaledNumberType
+		step    *model.ScaledNumberType
+	}{
+		{name: "missing value", minimum: validMinimum, maximum: validMaximum, step: validStep},
+		{name: "missing minimum", value: validValue, maximum: validMaximum, step: validStep},
+		{name: "missing maximum", value: validValue, minimum: validMinimum, step: validStep},
+		{name: "missing step", value: validValue, minimum: validMinimum, maximum: validMaximum},
+		{name: "zero step", value: validValue, minimum: validMinimum, maximum: validMaximum, step: model.NewScaledNumberType(0)},
+		{name: "inverted range", value: validValue, minimum: validMaximum, maximum: validMinimum, step: validStep},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			feature := mocks.NewFeatureRemoteInterface(t)
+			feature.On("DataCopy", model.FunctionTypeSetpointDescriptionListData).Return(
+				&model.SetpointDescriptionListDataType{SetpointDescriptionData: []model.SetpointDescriptionDataType{
+					{SetpointId: ptr(model.SetpointIdType(1)), ScopeType: ptr(model.ScopeTypeTypeRoomAirTemperature)},
+				}},
+			)
+			feature.On("DataCopy", model.FunctionTypeSetpointListData).Return(
+				&model.SetpointListDataType{SetpointData: []model.SetpointDataType{
+					{SetpointId: ptr(model.SetpointIdType(1)), Value: test.value},
+				}},
+			).Maybe()
+			feature.On("DataCopy", model.FunctionTypeSetpointConstraintsListData).Return(
+				&model.SetpointConstraintsListDataType{SetpointConstraintsData: []model.SetpointConstraintsDataType{
+					{
+						SetpointId:       ptr(model.SetpointIdType(1)),
+						SetpointRangeMin: test.minimum,
+						SetpointRangeMax: test.maximum,
+						SetpointStepSize: test.step,
+					},
+				}},
+			).Maybe()
+			entity := mocks.NewEntityRemoteInterface(t)
+			entity.On("FeatureOfTypeAndRole", model.FeatureTypeTypeSetpoint, model.RoleTypeServer).Return(feature)
+
+			_, err := (&RoomHeatingTemperature{}).State(entity)
+			if !errors.Is(err, ErrRoomHeatingDataUnavailable) {
+				t.Fatalf("State() error = %v, want ErrRoomHeatingDataUnavailable", err)
+			}
+		})
+	}
+}
+
+func TestRoomHeatingSetpointIDRequiresOneDistinctScopedCandidate(t *testing.T) {
+	tests := []struct {
+		name         string
+		descriptions []model.SetpointDescriptionDataType
+		wantID       model.SetpointIdType
+		wantOK       bool
+	}{
+		{name: "missing"},
+		{
+			name: "one room-air setpoint",
+			descriptions: []model.SetpointDescriptionDataType{
+				{SetpointId: ptr(model.SetpointIdType(1)), ScopeType: ptr(model.ScopeTypeTypeRoomAirTemperature)},
+				{SetpointId: ptr(model.SetpointIdType(2)), ScopeType: ptr(model.ScopeTypeTypeDhwTemperature)},
+			},
+			wantID: 1,
+			wantOK: true,
+		},
+		{
+			name: "duplicate description for same ID",
+			descriptions: []model.SetpointDescriptionDataType{
+				{SetpointId: ptr(model.SetpointIdType(1)), ScopeType: ptr(model.ScopeTypeTypeRoomAirTemperature)},
+				{SetpointId: ptr(model.SetpointIdType(1)), ScopeType: ptr(model.ScopeTypeTypeRoomAirTemperature)},
+			},
+			wantID: 1,
+			wantOK: true,
+		},
+		{
+			name: "distinct room-air setpoints are ambiguous",
+			descriptions: []model.SetpointDescriptionDataType{
+				{SetpointId: ptr(model.SetpointIdType(1)), ScopeType: ptr(model.ScopeTypeTypeRoomAirTemperature)},
+				{SetpointId: ptr(model.SetpointIdType(2)), ScopeType: ptr(model.ScopeTypeTypeRoomAirTemperature)},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			feature := mocks.NewFeatureRemoteInterface(t)
+			feature.On("DataCopy", model.FunctionTypeSetpointDescriptionListData).Return(
+				&model.SetpointDescriptionListDataType{SetpointDescriptionData: test.descriptions},
+			)
+
+			id, ok := roomHeatingSetpointID(feature)
+			if ok != test.wantOK || id != test.wantID {
+				t.Fatalf("roomHeatingSetpointID() = (%d, %t), want (%d, %t)", id, ok, test.wantID, test.wantOK)
+			}
+		})
+	}
+}
+
+func TestRoomHeatingStateFailsClosedOnAmbiguousScopedSetpoints(t *testing.T) {
+	feature := mocks.NewFeatureRemoteInterface(t)
+	feature.On("DataCopy", model.FunctionTypeSetpointDescriptionListData).Return(
+		&model.SetpointDescriptionListDataType{SetpointDescriptionData: []model.SetpointDescriptionDataType{
+			{SetpointId: ptr(model.SetpointIdType(1)), ScopeType: ptr(model.ScopeTypeTypeRoomAirTemperature)},
+			{SetpointId: ptr(model.SetpointIdType(2)), ScopeType: ptr(model.ScopeTypeTypeRoomAirTemperature)},
+		}},
+	)
+	entity := mocks.NewEntityRemoteInterface(t)
+	entity.On("FeatureOfTypeAndRole", model.FeatureTypeTypeSetpoint, model.RoleTypeServer).Return(feature)
+
+	_, err := (&RoomHeatingTemperature{}).State(entity)
+	if !errors.Is(err, ErrRoomHeatingDataUnavailable) {
+		t.Fatalf("State() error = %v, want ErrRoomHeatingDataUnavailable", err)
+	}
+}
+
 func TestRoomHeatingWriteRejectsOutOfRangeValue(t *testing.T) {
 	feature := mocks.NewFeatureRemoteInterface(t)
 	feature.On("DataCopy", model.FunctionTypeSetpointDescriptionListData).Return(
@@ -105,5 +300,110 @@ func TestRoomHeatingWriteRejectsOutOfRangeValue(t *testing.T) {
 	err := (&RoomHeatingTemperature{}).Write(context.Background(), entity, 35)
 	if !errors.Is(err, ErrRoomHeatingOutOfRange) {
 		t.Fatalf("Write() error = %v, want ErrRoomHeatingOutOfRange", err)
+	}
+}
+
+func TestRoomHeatingWriteRejectsOffStepValue(t *testing.T) {
+	feature := mocks.NewFeatureRemoteInterface(t)
+	feature.On("DataCopy", model.FunctionTypeSetpointDescriptionListData).Return(
+		&model.SetpointDescriptionListDataType{SetpointDescriptionData: []model.SetpointDescriptionDataType{
+			{SetpointId: ptr(model.SetpointIdType(1)), ScopeType: ptr(model.ScopeTypeTypeRoomAirTemperature)},
+		}},
+	)
+	feature.On("DataCopy", model.FunctionTypeSetpointListData).Return(
+		&model.SetpointListDataType{SetpointData: []model.SetpointDataType{
+			{SetpointId: ptr(model.SetpointIdType(1)), Value: model.NewScaledNumberType(21)},
+		}},
+	)
+	feature.On("DataCopy", model.FunctionTypeSetpointConstraintsListData).Return(
+		&model.SetpointConstraintsListDataType{SetpointConstraintsData: []model.SetpointConstraintsDataType{
+			{
+				SetpointId:       ptr(model.SetpointIdType(1)),
+				SetpointRangeMin: model.NewScaledNumberType(5),
+				SetpointRangeMax: model.NewScaledNumberType(30),
+				SetpointStepSize: model.NewScaledNumberType(0.5),
+			},
+		}},
+	)
+	operation := mocks.NewOperationsInterface(t)
+	operation.On("Write").Return(true)
+	feature.On("Operations").Return(map[model.FunctionType]spineapi.OperationsInterface{
+		model.FunctionTypeSetpointListData: operation,
+	})
+	entity := mocks.NewEntityRemoteInterface(t)
+	entity.On("FeatureOfTypeAndRole", model.FeatureTypeTypeSetpoint, model.RoleTypeServer).Return(feature)
+
+	err := (&RoomHeatingTemperature{}).Write(context.Background(), entity, 21.25)
+	if !errors.Is(err, ErrRoomHeatingInvalidStep) {
+		t.Fatalf("Write() error = %v, want ErrRoomHeatingInvalidStep", err)
+	}
+}
+
+func TestRoomHeatingWritePreservesFullListAndAwaitsAcceptance(t *testing.T) {
+	feature := newRoomHeatingWriteFeature(t)
+	errno := model.ErrorNumberType(0)
+	local, entity, written := roomHeatingWriteHarness(t, feature, &errno)
+
+	if err := (&RoomHeatingTemperature{localEntity: local}).Write(context.Background(), entity, 21.5); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+	if *written == nil || len((*written).SetpointData) != 2 {
+		t.Fatalf("written SetpointListData = %+v, want two entries", *written)
+	}
+	if value := (*written).SetpointData[0].Value.GetValue(); value != 12 {
+		t.Errorf("unrelated setpoint = %v, want 12", value)
+	}
+	if value := (*written).SetpointData[1].Value.GetValue(); value != 21.5 {
+		t.Errorf("room setpoint = %v, want 21.5", value)
+	}
+}
+
+func TestRoomHeatingWriteResultAndWaitFailures(t *testing.T) {
+	tests := []struct {
+		name      string
+		errno     *model.ErrorNumberType
+		configure func(*testing.T) context.Context
+		check     func(error) bool
+	}{
+		{
+			name:  "device rejection",
+			errno: ptr(model.ErrorNumberType(4)),
+			configure: func(*testing.T) context.Context {
+				return context.Background()
+			},
+			check: func(err error) bool { return errors.Is(err, ErrRoomHeatingRejected) },
+		},
+		{
+			name: "caller cancellation",
+			configure: func(t *testing.T) context.Context {
+				ctx, cancel := context.WithCancel(context.Background())
+				cancel()
+				return ctx
+			},
+			check: func(err error) bool { return errors.Is(err, context.Canceled) },
+		},
+		{
+			name: "internal result timeout",
+			configure: func(t *testing.T) context.Context {
+				previousTimeout := setpointWriteTimeout
+				setpointWriteTimeout = time.Millisecond
+				t.Cleanup(func() { setpointWriteTimeout = previousTimeout })
+				return context.Background()
+			},
+			check: func(err error) bool {
+				return err != nil && strings.Contains(err.Error(), "timed out waiting for room heating setpoint result")
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			feature := newRoomHeatingWriteFeature(t)
+			local, entity, _ := roomHeatingWriteHarness(t, feature, test.errno)
+			err := (&RoomHeatingTemperature{localEntity: local}).Write(test.configure(t), entity, 21.5)
+			if !test.check(err) {
+				t.Fatalf("Write() error = %v", err)
+			}
+		})
 	}
 }

--- a/eebus-bridge/internal/usecases/setpoint_flow.go
+++ b/eebus-bridge/internal/usecases/setpoint_flow.go
@@ -19,6 +19,8 @@ type setpointState struct {
 	Writable bool
 }
 
+var setpointWriteTimeout = dhwWriteTimeout
+
 func readSetpointState(
 	entity spineapi.EntityRemoteInterface,
 	setpointID func(spineapi.FeatureRemoteInterface) (model.SetpointIdType, bool),
@@ -123,7 +125,7 @@ func writeSetpointValue(
 		return fmt.Errorf("waiting for %s result: %w", label, err)
 	}
 
-	timer := time.NewTimer(dhwWriteTimeout)
+	timer := time.NewTimer(setpointWriteTimeout)
 	defer timer.Stop()
 	select {
 	case response := <-result:


### PR DESCRIPTION
## Summary

- deduplicate advertised room-heating mode types while withholding ambiguous type-to-ID mappings from writes
- fail closed when more than one distinct `roomAirTemperature` setpoint is advertised
- characterize the legacy CRHT/CRHSF contracts for presence, range/step validation, relations, results, rejection, cancellation, timeout, reconnect refresh, and gRPC error mapping
- mark Phase 0 as started in the migration specification and record its remaining hardware gates

No MRHSF/CRHSF/CRHT ownership, protobuf, gRPC, or Home Assistant contract changes are included.

## Verification

- `go vet ./...`
- `go test ./...`
- `go test -race ./...`
- `git diff --check`

## Remaining Phase 0 hardware gates

- capture the VR940 firmware/entity/baseline, exercise `auto`/`on`/`off` and setpoint read-back, and restore the original values
- verify upstream CRHT/CRHSF configuration writes without an additional feature binding

These deliberate live-device checks are left open and are not represented as completed by this PR.
