### PR TITLE
feat: migrate room heating negotiation to CRHSF

### DIFF
--- a/docs/badges/go-coverage.svg
+++ b/docs/badges/go-coverage.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="172" height="28" role="img" aria-label="Go coverage: 85.0%">
-  <title>Go coverage: 85.0%</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="172" height="28" role="img" aria-label="Go coverage: 85.1%">
+  <title>Go coverage: 85.1%</title>
   <linearGradient id="s" x2="0" y2="100%">
     <stop offset="0" stop-color="#fff" stop-opacity=".15"/>
     <stop offset="1" stop-opacity=".15"/>
@@ -12,6 +12,6 @@
   </g>
   <g fill="#fff" text-anchor="middle" font-family="Verdana,DejaVu Sans,sans-serif" font-size="10" font-weight="700">
     <text x="56" y="18">GO COVERAGE</text>
-    <text x="142" y="18">85.0%</text>
+    <text x="142" y="18">85.1%</text>
   </g>
 </svg>

--- a/docs/room-heating-eebus-go-migration-spec.md
+++ b/docs/room-heating-eebus-go-migration-spec.md
@@ -1,7 +1,7 @@
 # Room Heating auf eebus-go migrieren — Spec Proposal
 
 **Datum:** 2026-07-22
-**Status:** In Umsetzung — Phase 1 begonnen
+**Status:** In Umsetzung — Phase 2 begonnen
 **Scope:** Schrittweise Ablösung der bridge-lokalen Implementierungen für
 Configuration/Monitoring of Room Heating durch die bereits im gepinnten
 `eebus-go`-Fork enthaltenen Upstream-PRs, ohne Änderung des bestehenden gRPC-
@@ -619,6 +619,27 @@ Exit:
   überein.
 - Upstream CRHSF füllt nach Start/Reconnect alle benötigten Caches.
 - Der Legacy-Writer arbeitet mit dem von CRHSF installierten HVAC-Client weiter.
+
+Umsetzungsstand 2026-07-22:
+
+- [x] `CRHSFConfigurationFacade` eingeführt und `crhsf.NewCRHSF` als alleinigen
+  Owner für Negotiation, HVAC-Client-Feature und Cache-Population registriert;
+  der lokale CRHSF-Use-Case wird nicht parallel registriert.
+- [x] Temporären read-only Bridge-Inspector beibehalten, weil der gepinnte
+  CRHSF noch keine öffentliche fail-closed `WriteCapabilities`-API anbietet.
+  Unvollständige Caches bleiben `UNAVAILABLE`, ein ausgehandeltes read-only
+  Gerät liefert dagegen konservativ `mode_writable=false`.
+- [x] Den Legacy-Writer als releaseweit einzige Write-Strategie ohne eigenen
+  `UseCaseBase`, Event-Subscriber oder Request-Fallback extrahiert. MRHSF bleibt
+  alleiniger Owner von Reads und benutzersichtbaren State-Events.
+- [x] MRHSF- und CRHSF-Entity werden weiterhin getrennt per normalisiertem SKI
+  aufgelöst und erst im bestehenden Adapter komponiert.
+- [x] Focused Unit- und Composition-Root-Tests für Use-Case-Auswahl,
+  Entity-Auflösung, Capability-Trennung und Writer-Delegation ergänzt.
+- [ ] Auf Zielhardware verifizieren, dass Upstream CRHSF nach Fresh Start und
+  Reconnect alle Caches füllt, `mode_writable` stabil bleibt und der
+  Legacy-Writer mit dem von CRHSF installierten HVAC-Client weiterhin
+  `auto`/`on`/`off` schreibt und zurückliest.
 
 ### Phase 3 — Upstream CRHSF übernimmt Mode-Writes
 

--- a/docs/room-heating-eebus-go-migration-spec.md
+++ b/docs/room-heating-eebus-go-migration-spec.md
@@ -636,10 +636,14 @@ Umsetzungsstand 2026-07-22:
   aufgelöst und erst im bestehenden Adapter komponiert.
 - [x] Focused Unit- und Composition-Root-Tests für Use-Case-Auswahl,
   Entity-Auflösung, Capability-Trennung und Writer-Delegation ergänzt.
-- [ ] Auf Zielhardware verifizieren, dass Upstream CRHSF nach Fresh Start und
-  Reconnect alle Caches füllt, `mode_writable` stabil bleibt und der
-  Legacy-Writer mit dem von CRHSF installierten HVAC-Client weiterhin
-  `auto`/`on`/`off` schreibt und zurückliest.
+- [x] Auf Zielhardware verifiziert (VR940, SKI `682f708c…`, Stack 93,
+  Image `crhsf-phase2`, 2026-07-22): Nach Fresh Start füllt Upstream CRHSF alle
+  Caches (`hvac_modes=[auto, heat, off]`, Setpoint 21.0 °C); der Legacy-Writer
+  schreibt und liest `auto`/`heat`/`off` sowie Setpoints 21.5/21.0 °C korrekt
+  zurück. Drei Bridge-Restarts reproduzieren Modi und Setpoint unverändert,
+  ein Write nach dem letzten Restart bleibt erfolgreich; keine
+  `ROOMHEATINGSYSFN`-Fehler oder Rejects im Log. Stack danach auf `:latest`
+  zurückgesetzt.
 
 ### Phase 3 — Upstream CRHSF übernimmt Mode-Writes
 

--- a/eebus-bridge/cmd/eebus-bridge/app.go
+++ b/eebus-bridge/cmd/eebus-bridge/app.go
@@ -323,9 +323,13 @@ func NewApplication(cfg *config.Config) (*Application, error) {
 		)
 		roomHeatingTemperature := usecases.NewRoomHeatingTemperature(localEntity, bus, registry, cfg.Logging.DebugEvents)
 		roomHeatingSystemFunctionMonitoring := usecases.NewRoomHeatingSystemFunctionMonitoring(bus, registry, cfg.Logging.DebugEvents)
-		// MRHSF owns reads and state events. The local CRHSF implementation stays
-		// registered only as the legacy configuration/write owner during Phase 1.
-		roomHeatingSystemFunctionConfiguration := usecases.NewRoomHeatingSystemFunction(localEntity, nil, registry, cfg.Logging.DebugEvents)
+		// MRHSF owns reads and state events. Upstream CRHSF owns negotiation and
+		// cache population; Phase 2 retains the read-only bridge capability
+		// inspector and legacy writer as release-wide strategies.
+		roomHeatingSystemFunctionConfiguration := usecases.NewUpstreamRoomHeatingSystemFunctionConfiguration(
+			localEntity,
+			cfg.Logging.DebugEvents,
+		)
 		roomHeatingSystemFunction := usecases.NewRoomHeatingSystemFunctionAdapter(
 			roomHeatingSystemFunctionMonitoring,
 			roomHeatingSystemFunctionConfiguration,
@@ -478,7 +482,7 @@ func NewApplication(cfg *config.Config) (*Application, error) {
 					bridgeSvc,
 					eebusUseCaseRegistration{name: "RoomHeatingTemperature", useCase: func() eebusapi.UseCaseInterface { return roomHeatingTemperature.UseCase() }},
 					eebusUseCaseRegistration{name: "MRHSF", useCase: func() eebusapi.UseCaseInterface { return roomHeatingSystemFunctionMonitoring.UseCase() }},
-					eebusUseCaseRegistration{name: "RoomHeatingSystemFunctionConfiguration", useCase: func() eebusapi.UseCaseInterface { return roomHeatingSystemFunctionConfiguration.UseCase() }},
+					eebusUseCaseRegistration{name: "CRHSF", useCase: func() eebusapi.UseCaseInterface { return roomHeatingSystemFunctionConfiguration.UseCase() }},
 				),
 				registerGRPC: func(srv *bridgegrpc.Server) {
 					pb.RegisterHVACServiceServer(srv.GRPCServer(), hvacService)

--- a/eebus-bridge/cmd/eebus-bridge/app_test.go
+++ b/eebus-bridge/cmd/eebus-bridge/app_test.go
@@ -217,7 +217,7 @@ func TestProductionCompositionRootIsInertUntilStartAndRegistersAllUseCases(t *te
 	require.NoError(t, app.prepareForStart())
 	assert.ElementsMatch(t, []string{
 		"LPC", "Monitoring", "DHWMonitoring", "MRT", "MOT", "DHWTemperature",
-		"MDSF", "DHWSystemFunctionConfiguration", "RoomHeatingTemperature", "MRHSF", "RoomHeatingSystemFunctionConfiguration", "OHPCF",
+		"MDSF", "DHWSystemFunctionConfiguration", "RoomHeatingTemperature", "MRHSF", "CRHSF", "OHPCF",
 		"MGCP", "VAPD", "VABD",
 	}, app.registeredUseCases)
 	providerModule := app.modules[len(app.modules)-1]

--- a/eebus-bridge/internal/usecases/roomheatingsysfn.go
+++ b/eebus-bridge/internal/usecases/roomheatingsysfn.go
@@ -74,6 +74,16 @@ func NewRoomHeatingSystemFunction(
 	return r
 }
 
+// newLegacyRoomHeatingSystemFunctionStrategy constructs only the Phase 2
+// capability inspector and writer. It deliberately has no UseCaseBase and no
+// event subscription: upstream CRHSF is the sole negotiation owner.
+func newLegacyRoomHeatingSystemFunctionStrategy(
+	localEntity spineapi.EntityLocalInterface,
+	debug bool,
+) *RoomHeatingSystemFunction {
+	return &RoomHeatingSystemFunction{localEntity: localEntity, debug: debug}
+}
+
 // UseCase returns this use case for Service.AddUseCase.
 func (r *RoomHeatingSystemFunction) UseCase() eebusapi.UseCaseInterface { return r }
 

--- a/eebus-bridge/internal/usecases/roomheatingsysfn_configuration.go
+++ b/eebus-bridge/internal/usecases/roomheatingsysfn_configuration.go
@@ -1,0 +1,137 @@
+package usecases
+
+import (
+	"context"
+
+	eebusapi "github.com/enbility/eebus-go/api"
+	cacrhsf "github.com/enbility/eebus-go/usecases/ca/crhsf"
+	spineapi "github.com/enbility/spine-go/api"
+	"github.com/volschin/eebus-bridge/internal/eebus"
+)
+
+type roomHeatingSystemFunctionEntityResolver interface {
+	CompatibleEntity(string) eebus.EntityResolution
+}
+
+type roomHeatingSystemFunctionCapabilityInspector interface {
+	State(spineapi.EntityRemoteInterface) (RoomHeatingSystemFunctionState, error)
+}
+
+type roomHeatingOperationModeWriter interface {
+	WriteOperationMode(context.Context, spineapi.EntityRemoteInterface, string) error
+}
+
+// CRHSFConfigurationFacade keeps upstream CRHSF negotiation and entity
+// resolution separate from the release-wide capability and writer strategies.
+// Phase 2 deliberately selects the bridge inspector and legacy writer; there
+// is no per-request fallback to a second writer.
+type CRHSFConfigurationFacade struct {
+	useCase             eebusapi.UseCaseInterface
+	resolver            roomHeatingSystemFunctionEntityResolver
+	capabilityInspector roomHeatingSystemFunctionCapabilityInspector
+	operationModeWriter roomHeatingOperationModeWriter
+}
+
+func newCRHSFConfigurationFacade(
+	useCase eebusapi.UseCaseInterface,
+	resolver roomHeatingSystemFunctionEntityResolver,
+	capabilityInspector roomHeatingSystemFunctionCapabilityInspector,
+	operationModeWriter roomHeatingOperationModeWriter,
+) *CRHSFConfigurationFacade {
+	return &CRHSFConfigurationFacade{
+		useCase:             useCase,
+		resolver:            resolver,
+		capabilityInspector: capabilityInspector,
+		operationModeWriter: operationModeWriter,
+	}
+}
+
+// NewUpstreamRoomHeatingSystemFunctionConfiguration selects eebus-go CRHSF
+// for use-case negotiation, feature setup and cache population. Until CRHSF
+// exposes a fail-closed public WriteCapabilities API, a read-only bridge
+// inspector remains the capability owner and the legacy writer remains the
+// only selected write strategy. A nil upstream callback keeps MRHSF as the
+// sole owner of user-visible room-heating state events.
+func NewUpstreamRoomHeatingSystemFunctionConfiguration(
+	localEntity spineapi.EntityLocalInterface,
+	debug bool,
+) *CRHSFConfigurationFacade {
+	if localEntity == nil {
+		return &CRHSFConfigurationFacade{}
+	}
+	client := cacrhsf.NewCRHSF(localEntity, nil)
+	legacy := newLegacyRoomHeatingSystemFunctionStrategy(localEntity, debug)
+	return newCRHSFConfigurationFacade(
+		client,
+		crhsfEntityResolver{useCase: client},
+		bridgeRoomHeatingSystemFunctionCapabilityInspector{state: legacy},
+		legacy,
+	)
+}
+
+// UseCase returns eebus-go's CRHSF use case for service registration.
+func (f *CRHSFConfigurationFacade) UseCase() eebusapi.UseCaseInterface {
+	if f == nil {
+		return nil
+	}
+	return f.useCase
+}
+
+func (f *CRHSFConfigurationFacade) CompatibleEntity(ski string) eebus.EntityResolution {
+	if f == nil || f.resolver == nil {
+		return eebus.EntityResolution{}
+	}
+	return f.resolver.CompatibleEntity(ski)
+}
+
+func (f *CRHSFConfigurationFacade) State(
+	entity spineapi.EntityRemoteInterface,
+) (RoomHeatingSystemFunctionState, error) {
+	if f == nil || f.capabilityInspector == nil {
+		return RoomHeatingSystemFunctionState{}, ErrRoomHeatingSysFnDataUnavailable
+	}
+	return f.capabilityInspector.State(entity)
+}
+
+func (f *CRHSFConfigurationFacade) WriteOperationMode(
+	ctx context.Context,
+	entity spineapi.EntityRemoteInterface,
+	mode string,
+) error {
+	if f == nil || f.operationModeWriter == nil {
+		return ErrRoomHeatingSysFnNotWritable
+	}
+	return f.operationModeWriter.WriteOperationMode(ctx, entity, mode)
+}
+
+type crhsfEntityResolver struct {
+	useCase eebusapi.UseCaseInterface
+}
+
+func (r crhsfEntityResolver) CompatibleEntity(ski string) eebus.EntityResolution {
+	if r.useCase == nil {
+		return eebus.EntityResolution{}
+	}
+	return compatibleEntity(r.useCase.RemoteEntitiesScenarios(), ski)
+}
+
+// bridgeRoomHeatingSystemFunctionCapabilityInspector is intentionally
+// read-only. It preserves the legacy distinction between incomplete caches
+// (data unavailable) and a negotiated read-only function (ModeWritable=false)
+// without taking negotiation or write ownership away from upstream CRHSF.
+type bridgeRoomHeatingSystemFunctionCapabilityInspector struct {
+	state roomHeatingSystemFunctionCapabilityInspector
+}
+
+func (i bridgeRoomHeatingSystemFunctionCapabilityInspector) State(
+	entity spineapi.EntityRemoteInterface,
+) (RoomHeatingSystemFunctionState, error) {
+	if i.state == nil || entity == nil {
+		return RoomHeatingSystemFunctionState{}, ErrRoomHeatingSysFnDataUnavailable
+	}
+	state, err := i.state.State(entity)
+	if err != nil {
+		return RoomHeatingSystemFunctionState{}, err
+	}
+	return RoomHeatingSystemFunctionState{ModeWritable: state.ModeWritable}, nil
+}

--- a/eebus-bridge/internal/usecases/roomheatingsysfn_configuration_test.go
+++ b/eebus-bridge/internal/usecases/roomheatingsysfn_configuration_test.go
@@ -1,0 +1,176 @@
+package usecases
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	eebusapi "github.com/enbility/eebus-go/api"
+	cacrhsf "github.com/enbility/eebus-go/usecases/ca/crhsf"
+	ucmocks "github.com/enbility/eebus-go/usecases/mocks"
+	spineapi "github.com/enbility/spine-go/api"
+	spinemocks "github.com/enbility/spine-go/mocks"
+	"github.com/volschin/eebus-bridge/internal/eebus"
+)
+
+func TestUpstreamRoomHeatingSystemFunctionConfigurationSelectsCRHSF(t *testing.T) {
+	facade := NewUpstreamRoomHeatingSystemFunctionConfiguration(clientUsecaseLocalEntity(t), false)
+	client, ok := facade.UseCase().(*cacrhsf.CRHSF)
+	if !ok {
+		t.Fatalf("UseCase() = %T, want *crhsf.CRHSF", facade.UseCase())
+	}
+	if client.EventCB != nil {
+		t.Fatal("upstream CRHSF has an event callback; MRHSF must remain the sole state-event owner")
+	}
+	legacy, ok := facade.operationModeWriter.(*RoomHeatingSystemFunction)
+	if !ok {
+		t.Fatalf("operationModeWriter = %T, want *RoomHeatingSystemFunction", facade.operationModeWriter)
+	}
+	if legacy.UseCaseBase != nil {
+		t.Fatalf("legacy strategy UseCaseBase = %p, want nil", legacy.UseCaseBase)
+	}
+}
+
+type phase2RoomHeatingCapabilityInspector struct {
+	state  RoomHeatingSystemFunctionState
+	entity spineapi.EntityRemoteInterface
+	err    error
+}
+
+func (i *phase2RoomHeatingCapabilityInspector) State(
+	entity spineapi.EntityRemoteInterface,
+) (RoomHeatingSystemFunctionState, error) {
+	i.entity = entity
+	return i.state, i.err
+}
+
+type phase2RoomHeatingWriter struct {
+	entity spineapi.EntityRemoteInterface
+	mode   string
+	err    error
+}
+
+func (w *phase2RoomHeatingWriter) WriteOperationMode(
+	_ context.Context,
+	entity spineapi.EntityRemoteInterface,
+	mode string,
+) error {
+	w.entity = entity
+	w.mode = mode
+	return w.err
+}
+
+func TestCRHSFConfigurationFacadeComposesUpstreamEntityAndSelectedStrategies(t *testing.T) {
+	device := spinemocks.NewDeviceRemoteInterface(t)
+	device.EXPECT().Ski().Return("ab:cd").Maybe()
+	entity := spinemocks.NewEntityRemoteInterface(t)
+	entity.EXPECT().Device().Return(device).Maybe()
+	client := ucmocks.NewCaCRHSFInterface(t)
+	client.EXPECT().RemoteEntitiesScenarios().Return([]eebusapi.RemoteEntityScenarios{{
+		Entity: entity, Scenarios: []uint{1},
+	}})
+	inspector := &phase2RoomHeatingCapabilityInspector{
+		state: RoomHeatingSystemFunctionState{ModeWritable: true},
+	}
+	writer := &phase2RoomHeatingWriter{}
+	facade := newCRHSFConfigurationFacade(
+		client,
+		crhsfEntityResolver{useCase: client},
+		inspector,
+		writer,
+	)
+
+	resolution := facade.CompatibleEntity("ABCD")
+	if resolution.Entity != entity || resolution.DeviceCount != 1 {
+		t.Fatalf("CompatibleEntity() = %+v, want upstream CRHSF entity", resolution)
+	}
+	state, err := facade.State(entity)
+	if err != nil || !state.ModeWritable || inspector.entity != entity {
+		t.Fatalf("State() = %+v, %v; inspector entity = %p", state, err, inspector.entity)
+	}
+	if err := facade.WriteOperationMode(context.Background(), entity, "on"); err != nil {
+		t.Fatalf("WriteOperationMode() error = %v", err)
+	}
+	if writer.entity != entity || writer.mode != "on" {
+		t.Fatalf("writer entity/mode = %p/%q, want upstream entity/on", writer.entity, writer.mode)
+	}
+	if facade.UseCase() != client {
+		t.Fatalf("UseCase() = %T, want injected upstream client", facade.UseCase())
+	}
+}
+
+func TestBridgeRoomHeatingCapabilityInspectorPreservesUnavailableAndReadOnly(t *testing.T) {
+	entity := spinemocks.NewEntityRemoteInterface(t)
+	for _, test := range []struct {
+		name         string
+		legacyState  RoomHeatingSystemFunctionState
+		legacyError  error
+		wantWritable bool
+		wantError    error
+	}{
+		{
+			name:         "writable",
+			legacyState:  RoomHeatingSystemFunctionState{OperationMode: "auto", AvailableModes: []string{"auto"}, ModeWritable: true},
+			wantWritable: true,
+		},
+		{
+			name:        "negotiated read only",
+			legacyState: RoomHeatingSystemFunctionState{OperationMode: "off", AvailableModes: []string{"off"}},
+		},
+		{
+			name:        "cache incomplete",
+			legacyError: ErrRoomHeatingSysFnDataUnavailable,
+			wantError:   ErrRoomHeatingSysFnDataUnavailable,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			legacy := &phase2RoomHeatingCapabilityInspector{state: test.legacyState, err: test.legacyError}
+			state, err := (bridgeRoomHeatingSystemFunctionCapabilityInspector{state: legacy}).State(entity)
+			if !errors.Is(err, test.wantError) {
+				t.Fatalf("State() error = %v, want %v", err, test.wantError)
+			}
+			if state.ModeWritable != test.wantWritable {
+				t.Fatalf("State() = %+v, want writable=%t", state, test.wantWritable)
+			}
+			if state.OperationMode != "" || len(state.AvailableModes) != 0 {
+				t.Fatalf("State() leaked legacy read ownership: %+v", state)
+			}
+		})
+	}
+}
+
+func TestCRHSFConfigurationFacadeFailsClosedWhenIncomplete(t *testing.T) {
+	var nilFacade *CRHSFConfigurationFacade
+	if nilFacade.UseCase() != nil {
+		t.Fatal("nil facade returned a use case")
+	}
+	if resolution := nilFacade.CompatibleEntity("ABCD"); resolution != (eebus.EntityResolution{}) {
+		t.Fatalf("CompatibleEntity() = %+v", resolution)
+	}
+	if _, err := nilFacade.State(nil); !errors.Is(err, ErrRoomHeatingSysFnDataUnavailable) {
+		t.Fatalf("State() error = %v, want data unavailable", err)
+	}
+	if err := nilFacade.WriteOperationMode(context.Background(), nil, "on"); !errors.Is(err, ErrRoomHeatingSysFnNotWritable) {
+		t.Fatalf("WriteOperationMode() error = %v, want not writable", err)
+	}
+
+	empty := NewUpstreamRoomHeatingSystemFunctionConfiguration(nil, false)
+	if empty.UseCase() != nil {
+		t.Fatal("nil local entity initialized CRHSF")
+	}
+	if resolution := empty.CompatibleEntity("ABCD"); resolution != (eebus.EntityResolution{}) {
+		t.Fatalf("empty CompatibleEntity() = %+v", resolution)
+	}
+	if _, err := empty.State(nil); !errors.Is(err, ErrRoomHeatingSysFnDataUnavailable) {
+		t.Fatalf("empty State() error = %v, want data unavailable", err)
+	}
+	if err := empty.WriteOperationMode(context.Background(), nil, "on"); !errors.Is(err, ErrRoomHeatingSysFnNotWritable) {
+		t.Fatalf("empty WriteOperationMode() error = %v, want not writable", err)
+	}
+	if resolution := (crhsfEntityResolver{}).CompatibleEntity("ABCD"); resolution != (eebus.EntityResolution{}) {
+		t.Fatalf("empty resolver = %+v", resolution)
+	}
+	if _, err := (bridgeRoomHeatingSystemFunctionCapabilityInspector{}).State(nil); !errors.Is(err, ErrRoomHeatingSysFnDataUnavailable) {
+		t.Fatalf("empty inspector error = %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- register upstream `crhsf.NewCRHSF` as the sole owner of room-heating system-function negotiation, HVAC client setup, and cache population
- add `CRHSFConfigurationFacade` with explicit SKI-based CRHSF entity resolution and a conservative read-only capability inspector
- retain the legacy mode writer as the single release-wide write strategy, without a per-request fallback or a second CRHSF use-case registration
- keep MRHSF as the sole owner of room-heating reads and user-visible state events
- update the migration status and generated Go coverage badge

## Verification

- `go test ./internal/usecases ./cmd/eebus-bridge`
- `go vet ./...`
- `go test -race ./...`
- `go test -tags=integration -v ./internal/grpc/ -run TestIntegration`
- productive Go coverage: 85.1%
- changed-statement coverage: 100% (41/41)

## Hardware exit criterion

Phase 2 still requires VR940 validation after merge candidate deployment: fresh-start and reconnect cache population, stable `mode_writable`, and `auto`/`on`/`off` writes/read-back through the legacy writer using the HVAC client installed by upstream CRHSF.
