### PR TITLE
feat: migrate room heating mode writes to CRHSF

### DIFF
--- a/docs/badges/go-coverage.svg
+++ b/docs/badges/go-coverage.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="172" height="28" role="img" aria-label="Go coverage: 85.1%">
-  <title>Go coverage: 85.1%</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="172" height="28" role="img" aria-label="Go coverage: 85.3%">
+  <title>Go coverage: 85.3%</title>
   <linearGradient id="s" x2="0" y2="100%">
     <stop offset="0" stop-color="#fff" stop-opacity=".15"/>
     <stop offset="1" stop-opacity=".15"/>
@@ -12,6 +12,6 @@
   </g>
   <g fill="#fff" text-anchor="middle" font-family="Verdana,DejaVu Sans,sans-serif" font-size="10" font-weight="700">
     <text x="56" y="18">GO COVERAGE</text>
-    <text x="142" y="18">85.1%</text>
+    <text x="142" y="18">85.3%</text>
   </g>
 </svg>

--- a/docs/room-heating-eebus-go-migration-spec.md
+++ b/docs/room-heating-eebus-go-migration-spec.md
@@ -1,7 +1,7 @@
 # Room Heating auf eebus-go migrieren — Spec Proposal
 
 **Datum:** 2026-07-22
-**Status:** In Umsetzung — Phase 2 begonnen
+**Status:** In Umsetzung — Phase 3 begonnen
 **Scope:** Schrittweise Ablösung der bridge-lokalen Implementierungen für
 Configuration/Monitoring of Room Heating durch die bereits im gepinnten
 `eebus-go`-Fork enthaltenen Upstream-PRs, ohne Änderung des bestehenden gRPC-
@@ -668,6 +668,28 @@ Exit:
 
 Rollback: In einem Folgerelease wird die Legacy-Strategie wieder ausgewählt.
 Ein fehlgeschlagener Upstream-Write wird niemals im selben Request wiederholt.
+
+Umsetzungsstand 2026-07-22:
+
+- [x] Bridge-seitigen CRHSF-Writer eingeführt und als releaseweit einzige
+  Mode-Write-Strategie ausgewählt; der Legacy-Writer bleibt unverändert im
+  Baum und es existiert kein Request-Fallback.
+- [x] Angeforderte Modi werden vor dem Senden sowohl gegen die MRHSF- als auch
+  gegen die CRHSF-Modusliste geprüft. Abweichende oder fremde Modi senden
+  keinen Write.
+- [x] CRHSF-Result wird anhand des Message Counters context- und
+  timeoutgebunden abgewartet; Geräteablehnung, read-only, Data-Unavailable und
+  Context-Fehler bleiben auf die bestehenden Bridge-Sentinels abgebildet.
+- [x] Unit-, Composition- und vollständige Go-Suite für den Bridge-Teil grün.
+- [ ] CRHSF upstream auf eindeutige Mode-ID-Auflösung und Post-Result-Refresh
+  härten und den Fork-Pin aktualisieren. Der aktuelle Pin `b40877d34a63` wählt
+  bei mehreren IDs desselben Mode-Typs noch den ersten Treffer und refreshed
+  nach einem akzeptierten Write nicht explizit.
+- [ ] Den gemeinsamen `features/client.NewFeature`-Sentinel aus §4.6 upstream
+  einreichen und im Bridge-Mapping übernehmen; der aktuelle Pin liefert im
+  Disconnect-Rennen weiterhin nicht klassifizierbare Textfehler.
+- [ ] Hardwarematrix (alle Modi, mindestens zehn Übergänge sowie drei
+  Reconnect-/Restart-Zyklen) durchführen und Ausgangszustand wiederherstellen.
 
 ### Phase 4 — Upstream CRHT übernimmt Negotiation und Reads
 

--- a/docs/room-heating-eebus-go-migration-spec.md
+++ b/docs/room-heating-eebus-go-migration-spec.md
@@ -688,8 +688,21 @@ Umsetzungsstand 2026-07-22:
 - [ ] Den gemeinsamen `features/client.NewFeature`-Sentinel aus §4.6 upstream
   einreichen und im Bridge-Mapping übernehmen; der aktuelle Pin liefert im
   Disconnect-Rennen weiterhin nicht klassifizierbare Textfehler.
-- [ ] Hardwarematrix (alle Modi, mindestens zehn Übergänge sowie drei
-  Reconnect-/Restart-Zyklen) durchführen und Ausgangszustand wiederherstellen.
+- [x] Hardwarematrix am VR940 (SKI `682f708c…`, Stack 93, Image
+  `crhsf-phase3`) am 2026-07-22 durchgeführt:
+  - Frischstart füllt Caches ohne Legacy-Writer: `hvac_modes=[auto, heat, off]`,
+    Setpoint 21.0 °C.
+  - 18 Mode-Übergänge über alle drei angebotenen Modi, alle vom Gerät
+    übernommen; keine Ablehnung, kein Fehler im Bridge-Log.
+  - Setpoint-Write (Legacy-Pfad, unverändert) 21.0 → 21.5 → 21.0 erfolgreich.
+  - Drei Container-Restarts: Modi, Setpoint und Schreibfähigkeit identisch
+    reproduziert; Post-Restart-Write erfolgreich.
+  - Konvergenz nach akzeptiertem Write < 0,1 s (Geräte-Notify), obwohl der
+    Upstream-Writer keinen expliziten Post-Result-Refresh sendet. Einmalig
+    zeigte ein Sample bei sehr schneller Write-Folge (6 s Abstand) noch den
+    Vorzustand; der Zustand konvergierte anschließend korrekt.
+  - Stack nach dem Test auf `:latest` zurückgesetzt, Ausgangszustand
+    (`auto`, 21.0 °C) wiederhergestellt.
 
 ### Phase 4 — Upstream CRHT übernimmt Negotiation und Reads
 

--- a/eebus-bridge/UPSTREAM_PATCHES.md
+++ b/eebus-bridge/UPSTREAM_PATCHES.md
@@ -34,6 +34,13 @@ the eebus-go revision used by the bridge.
 
 ## Known limitations (not yet filed upstream)
 
+- `crhsf.CRHSF.WriteOperationMode` currently selects the first related mode ID
+  whose description has the requested type. It does not deduplicate identical
+  IDs or fail closed when several distinct IDs share that type. Unlike the
+  hardened CDSF writer, it also does not request
+  `HvacSystemFunctionListData` again after an accepted result. Room-heating
+  Phase 3 therefore still needs an upstream hardening patch for unambiguous
+  mode resolution and post-result refresh before hardware acceptance.
 - `cdsf.CDSF.WriteCapabilities` deliberately returns zero capabilities with a
   nil error whenever required CDSF metadata is missing, ambiguous, or the
   device genuinely doesn't support the write (`usecases/ca/cdsf/public.go`).

--- a/eebus-bridge/cmd/eebus-bridge/app.go
+++ b/eebus-bridge/cmd/eebus-bridge/app.go
@@ -323,9 +323,9 @@ func NewApplication(cfg *config.Config) (*Application, error) {
 		)
 		roomHeatingTemperature := usecases.NewRoomHeatingTemperature(localEntity, bus, registry, cfg.Logging.DebugEvents)
 		roomHeatingSystemFunctionMonitoring := usecases.NewRoomHeatingSystemFunctionMonitoring(bus, registry, cfg.Logging.DebugEvents)
-		// MRHSF owns reads and state events. Upstream CRHSF owns negotiation and
-		// cache population; Phase 2 retains the read-only bridge capability
-		// inspector and legacy writer as release-wide strategies.
+		// MRHSF owns reads and state events. Upstream CRHSF owns negotiation,
+		// cache population and mode writes; the bridge temporarily retains only
+		// its read-only capability inspector.
 		roomHeatingSystemFunctionConfiguration := usecases.NewUpstreamRoomHeatingSystemFunctionConfiguration(
 			localEntity,
 			cfg.Logging.DebugEvents,

--- a/eebus-bridge/internal/usecases/roomheatingsysfn.go
+++ b/eebus-bridge/internal/usecases/roomheatingsysfn.go
@@ -74,9 +74,10 @@ func NewRoomHeatingSystemFunction(
 	return r
 }
 
-// newLegacyRoomHeatingSystemFunctionStrategy constructs only the Phase 2
-// capability inspector and writer. It deliberately has no UseCaseBase and no
-// event subscription: upstream CRHSF is the sole negotiation owner.
+// newLegacyRoomHeatingSystemFunctionStrategy constructs the retained
+// capability inspector and rollback writer. It deliberately has no
+// UseCaseBase and no event subscription: upstream CRHSF is the sole
+// negotiation owner.
 func newLegacyRoomHeatingSystemFunctionStrategy(
 	localEntity spineapi.EntityLocalInterface,
 	debug bool,

--- a/eebus-bridge/internal/usecases/roomheatingsysfn_adapter.go
+++ b/eebus-bridge/internal/usecases/roomheatingsysfn_adapter.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"slices"
 
 	eebusapi "github.com/enbility/eebus-go/api"
 	ucapi "github.com/enbility/eebus-go/usecases/api"
@@ -122,9 +123,9 @@ type roomHeatingSystemFunctionWriter interface {
 	WriteOperationMode(context.Context, spineapi.EntityRemoteInterface, string) error
 }
 
-// RoomHeatingSystemFunctionAdapter combines MRHSF reads with the legacy CRHSF
-// configuration path. The two independently negotiated entities are composed
-// by normalized device SKI so a stale monitoring entity is never used for a
+// RoomHeatingSystemFunctionAdapter combines MRHSF reads with CRHSF
+// configuration. The two independently negotiated entities are composed by
+// normalized device SKI so a stale monitoring entity is never used for a
 // configuration write after reconnect.
 type RoomHeatingSystemFunctionAdapter struct {
 	monitoring    roomHeatingSystemFunctionReader
@@ -174,6 +175,16 @@ func (a *RoomHeatingSystemFunctionAdapter) WriteOperationMode(
 	configurationEntity := a.configurationEntity(entity)
 	if configurationEntity == nil {
 		return ErrRoomHeatingSysFnNotWritable
+	}
+	if a == nil || a.monitoring == nil {
+		return ErrRoomHeatingSysFnDataUnavailable
+	}
+	monitoringState, err := a.monitoring.State(entity)
+	if err != nil {
+		return err
+	}
+	if !slices.Contains(monitoringState.AvailableModes, mode) {
+		return fmt.Errorf("%w: %s", ErrRoomHeatingSysFnInvalidMode, mode)
 	}
 	return a.configuration.WriteOperationMode(ctx, configurationEntity, mode)
 }

--- a/eebus-bridge/internal/usecases/roomheatingsysfn_adapter.go
+++ b/eebus-bridge/internal/usecases/roomheatingsysfn_adapter.go
@@ -172,12 +172,12 @@ func (a *RoomHeatingSystemFunctionAdapter) WriteOperationMode(
 	entity spineapi.EntityRemoteInterface,
 	mode string,
 ) error {
+	if a == nil || a.monitoring == nil {
+		return ErrRoomHeatingSysFnDataUnavailable
+	}
 	configurationEntity := a.configurationEntity(entity)
 	if configurationEntity == nil {
 		return ErrRoomHeatingSysFnNotWritable
-	}
-	if a == nil || a.monitoring == nil {
-		return ErrRoomHeatingSysFnDataUnavailable
 	}
 	monitoringState, err := a.monitoring.State(entity)
 	if err != nil {

--- a/eebus-bridge/internal/usecases/roomheatingsysfn_adapter_test.go
+++ b/eebus-bridge/internal/usecases/roomheatingsysfn_adapter_test.go
@@ -184,6 +184,48 @@ func TestRoomHeatingSystemFunctionAdapterFailsClosedWithoutCRHSF(t *testing.T) {
 	}
 }
 
+func TestRoomHeatingSystemFunctionAdapterPrevalidatesMRHSFModes(t *testing.T) {
+	device := spinemocks.NewDeviceRemoteInterface(t)
+	device.EXPECT().Ski().Return("ab:cd")
+	monitoringEntity := spinemocks.NewEntityRemoteInterface(t)
+	monitoringEntity.EXPECT().Device().Return(device)
+	configurationEntity := spinemocks.NewEntityRemoteInterface(t)
+	reader := &fakeRoomHeatingSystemFunctionReader{state: RoomHeatingSystemFunctionState{
+		AvailableModes: []string{"auto", "on"},
+	}}
+	writer := &fakeRoomHeatingSystemFunctionWriter{entity: configurationEntity}
+
+	err := NewRoomHeatingSystemFunctionAdapter(reader, writer).WriteOperationMode(
+		context.Background(), monitoringEntity, "off",
+	)
+	if !errors.Is(err, ErrRoomHeatingSysFnInvalidMode) {
+		t.Fatalf("WriteOperationMode() error = %v, want ErrRoomHeatingSysFnInvalidMode", err)
+	}
+	if writer.writeEntity != nil {
+		t.Fatal("configuration writer was called for a mode absent from MRHSF")
+	}
+}
+
+func TestRoomHeatingSystemFunctionAdapterFailsClosedWhenMRHSFStateIsUnavailable(t *testing.T) {
+	device := spinemocks.NewDeviceRemoteInterface(t)
+	device.EXPECT().Ski().Return("ab:cd")
+	monitoringEntity := spinemocks.NewEntityRemoteInterface(t)
+	monitoringEntity.EXPECT().Device().Return(device)
+	configurationEntity := spinemocks.NewEntityRemoteInterface(t)
+	reader := &fakeRoomHeatingSystemFunctionReader{stateErr: ErrRoomHeatingSysFnDataUnavailable}
+	writer := &fakeRoomHeatingSystemFunctionWriter{entity: configurationEntity}
+
+	err := NewRoomHeatingSystemFunctionAdapter(reader, writer).WriteOperationMode(
+		context.Background(), monitoringEntity, "on",
+	)
+	if !errors.Is(err, ErrRoomHeatingSysFnDataUnavailable) {
+		t.Fatalf("WriteOperationMode() error = %v, want ErrRoomHeatingSysFnDataUnavailable", err)
+	}
+	if writer.writeEntity != nil {
+		t.Fatal("configuration writer was called with unavailable MRHSF state")
+	}
+}
+
 func TestRoomHeatingSystemFunctionAdapterKeepsMRHSFReadsWhenCRHSFStateIsUnavailable(t *testing.T) {
 	device := spinemocks.NewDeviceRemoteInterface(t)
 	device.EXPECT().Ski().Return("ab:cd")

--- a/eebus-bridge/internal/usecases/roomheatingsysfn_adapter_test.go
+++ b/eebus-bridge/internal/usecases/roomheatingsysfn_adapter_test.go
@@ -283,8 +283,11 @@ func TestRoomHeatingSystemFunctionAdapterFailsClosedWithoutMonitoring(t *testing
 	if _, err := empty.State(nil); !errors.Is(err, ErrRoomHeatingSysFnDataUnavailable) {
 		t.Fatalf("State() error = %v, want ErrRoomHeatingSysFnDataUnavailable", err)
 	}
-	if err := empty.WriteOperationMode(context.Background(), nil, "on"); !errors.Is(err, ErrRoomHeatingSysFnNotWritable) {
-		t.Fatalf("WriteOperationMode() error = %v, want ErrRoomHeatingSysFnNotWritable", err)
+	if err := adapter.WriteOperationMode(context.Background(), nil, "on"); !errors.Is(err, ErrRoomHeatingSysFnDataUnavailable) {
+		t.Fatalf("WriteOperationMode() error = %v, want ErrRoomHeatingSysFnDataUnavailable", err)
+	}
+	if err := empty.WriteOperationMode(context.Background(), nil, "on"); !errors.Is(err, ErrRoomHeatingSysFnDataUnavailable) {
+		t.Fatalf("WriteOperationMode() error = %v, want ErrRoomHeatingSysFnDataUnavailable", err)
 	}
 }
 

--- a/eebus-bridge/internal/usecases/roomheatingsysfn_configuration.go
+++ b/eebus-bridge/internal/usecases/roomheatingsysfn_configuration.go
@@ -4,10 +4,23 @@ import (
 	"context"
 
 	eebusapi "github.com/enbility/eebus-go/api"
+	ucapi "github.com/enbility/eebus-go/usecases/api"
 	cacrhsf "github.com/enbility/eebus-go/usecases/ca/crhsf"
 	spineapi "github.com/enbility/spine-go/api"
+	"github.com/enbility/spine-go/model"
 	"github.com/volschin/eebus-bridge/internal/eebus"
 )
+
+type caCRHSFClient interface {
+	eebusapi.UseCaseInterface
+	RemoteEntitiesScenarios() []eebusapi.RemoteEntityScenarios
+	OperationModes(spineapi.EntityRemoteInterface) ([]ucapi.HvacOperationModeType, error)
+	WriteOperationMode(
+		spineapi.EntityRemoteInterface,
+		ucapi.HvacOperationModeType,
+		func(model.ResultDataType, model.MsgCounterType),
+	) (*model.MsgCounterType, error)
+}
 
 type roomHeatingSystemFunctionEntityResolver interface {
 	CompatibleEntity(string) eebus.EntityResolution
@@ -23,8 +36,9 @@ type roomHeatingOperationModeWriter interface {
 
 // CRHSFConfigurationFacade keeps upstream CRHSF negotiation and entity
 // resolution separate from the release-wide capability and writer strategies.
-// Phase 2 deliberately selects the bridge inspector and legacy writer; there
-// is no per-request fallback to a second writer.
+// Phase 3 retains the read-only bridge capability inspector while selecting
+// CRHSF as the sole writer. There is no per-request fallback to the legacy
+// writer.
 type CRHSFConfigurationFacade struct {
 	useCase             eebusapi.UseCaseInterface
 	resolver            roomHeatingSystemFunctionEntityResolver
@@ -49,9 +63,9 @@ func newCRHSFConfigurationFacade(
 // NewUpstreamRoomHeatingSystemFunctionConfiguration selects eebus-go CRHSF
 // for use-case negotiation, feature setup and cache population. Until CRHSF
 // exposes a fail-closed public WriteCapabilities API, a read-only bridge
-// inspector remains the capability owner and the legacy writer remains the
-// only selected write strategy. A nil upstream callback keeps MRHSF as the
-// sole owner of user-visible room-heating state events.
+// inspector remains the capability owner. CRHSF is the only selected write
+// strategy. A nil upstream callback keeps MRHSF as the sole owner of
+// user-visible room-heating state events.
 func NewUpstreamRoomHeatingSystemFunctionConfiguration(
 	localEntity spineapi.EntityLocalInterface,
 	debug bool,
@@ -61,11 +75,12 @@ func NewUpstreamRoomHeatingSystemFunctionConfiguration(
 	}
 	client := cacrhsf.NewCRHSF(localEntity, nil)
 	legacy := newLegacyRoomHeatingSystemFunctionStrategy(localEntity, debug)
+	inspector := bridgeRoomHeatingSystemFunctionCapabilityInspector{state: legacy}
 	return newCRHSFConfigurationFacade(
 		client,
 		crhsfEntityResolver{useCase: client},
-		bridgeRoomHeatingSystemFunctionCapabilityInspector{state: legacy},
-		legacy,
+		inspector,
+		&upstreamRoomHeatingOperationModeWriter{client: client, inspector: inspector},
 	)
 }
 

--- a/eebus-bridge/internal/usecases/roomheatingsysfn_configuration_test.go
+++ b/eebus-bridge/internal/usecases/roomheatingsysfn_configuration_test.go
@@ -22,12 +22,15 @@ func TestUpstreamRoomHeatingSystemFunctionConfigurationSelectsCRHSF(t *testing.T
 	if client.EventCB != nil {
 		t.Fatal("upstream CRHSF has an event callback; MRHSF must remain the sole state-event owner")
 	}
-	legacy, ok := facade.operationModeWriter.(*RoomHeatingSystemFunction)
+	writer, ok := facade.operationModeWriter.(*upstreamRoomHeatingOperationModeWriter)
 	if !ok {
-		t.Fatalf("operationModeWriter = %T, want *RoomHeatingSystemFunction", facade.operationModeWriter)
+		t.Fatalf("operationModeWriter = %T, want *upstreamRoomHeatingOperationModeWriter", facade.operationModeWriter)
 	}
-	if legacy.UseCaseBase != nil {
-		t.Fatalf("legacy strategy UseCaseBase = %p, want nil", legacy.UseCaseBase)
+	if writer.client != client {
+		t.Fatalf("writer client = %T, want facade CRHSF client", writer.client)
+	}
+	if _, ok := writer.inspector.(bridgeRoomHeatingSystemFunctionCapabilityInspector); !ok {
+		t.Fatalf("writer inspector = %T, want bridge capability inspector", writer.inspector)
 	}
 }
 

--- a/eebus-bridge/internal/usecases/roomheatingsysfn_upstream_mode.go
+++ b/eebus-bridge/internal/usecases/roomheatingsysfn_upstream_mode.go
@@ -1,0 +1,124 @@
+package usecases
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"time"
+
+	eebusapi "github.com/enbility/eebus-go/api"
+	ucapi "github.com/enbility/eebus-go/usecases/api"
+	spineapi "github.com/enbility/spine-go/api"
+	"github.com/enbility/spine-go/model"
+)
+
+// upstreamRoomHeatingOperationModeWriter delegates operation-mode writes to
+// eebus-go CRHSF while retaining the bridge's public validation, synchronous
+// result and error contracts. Post-write convergence belongs to CRHSF; this
+// adapter deliberately does not issue a second request or write.
+type upstreamRoomHeatingOperationModeWriter struct {
+	client    caCRHSFClient
+	inspector roomHeatingSystemFunctionCapabilityInspector
+}
+
+func (w *upstreamRoomHeatingOperationModeWriter) WriteOperationMode(
+	ctx context.Context,
+	entity spineapi.EntityRemoteInterface,
+	mode string,
+) error {
+	if w == nil || w.client == nil || w.inspector == nil || entity == nil {
+		return ErrRoomHeatingSysFnDataUnavailable
+	}
+	state, err := w.inspector.State(entity)
+	if err != nil {
+		return err
+	}
+	if !state.ModeWritable {
+		return ErrRoomHeatingSysFnNotWritable
+	}
+
+	// Validate against CRHSF's relation-derived modes before writing. The
+	// adapter separately validates against MRHSF, so disagreement between the
+	// independently negotiated use cases fails closed without sending.
+	modes, err := w.client.OperationModes(entity)
+	if err != nil {
+		return mapUpstreamRoomHeatingWriteError(err)
+	}
+	requested := ucapi.HvacOperationModeType(mode)
+	if !slices.Contains(modes, requested) {
+		return fmt.Errorf("%w: %s", ErrRoomHeatingSysFnInvalidMode, mode)
+	}
+
+	return awaitRoomHeatingSystemFunctionWrite(ctx, func(callback roomHeatingResultCallback) (*model.MsgCounterType, error) {
+		counter, writeErr := w.client.WriteOperationMode(entity, requested, callback)
+		return counter, mapUpstreamRoomHeatingWriteError(writeErr)
+	})
+}
+
+type roomHeatingResultCallback func(model.ResultDataType, model.MsgCounterType)
+type roomHeatingWriteCall func(roomHeatingResultCallback) (*model.MsgCounterType, error)
+
+var roomHeatingSystemFunctionWriteTimeout = hvacWriteTimeout
+
+func awaitRoomHeatingSystemFunctionWrite(ctx context.Context, write roomHeatingWriteCall) error {
+	type writeResult struct {
+		data    model.ResultDataType
+		counter model.MsgCounterType
+	}
+	result := make(chan writeResult, 1)
+	counter, err := write(func(data model.ResultDataType, counter model.MsgCounterType) {
+		result <- writeResult{data: data, counter: counter}
+	})
+	if err != nil {
+		return err
+	}
+	if counter == nil {
+		return errors.New("sending room heating operation mode returned no message counter")
+	}
+
+	timer := time.NewTimer(roomHeatingSystemFunctionWriteTimeout)
+	defer timer.Stop()
+	select {
+	case response := <-result:
+		if response.counter != *counter {
+			return errors.New("waiting for room heating operation mode result returned unexpected message counter")
+		}
+		if response.data.ErrorNumber != nil && *response.data.ErrorNumber != 0 {
+			err := fmt.Errorf("%w: room heating operation mode error=%d", ErrRoomHeatingSysFnRejected, *response.data.ErrorNumber)
+			if response.data.Description != nil && *response.data.Description != "" {
+				err = fmt.Errorf("%w (%s)", err, *response.data.Description)
+			}
+			return err
+		}
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return errors.New("timed out waiting for room heating operation mode result")
+	}
+}
+
+func mapUpstreamRoomHeatingWriteError(err error) error {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, eebusapi.ErrNotSupported) {
+		return fmt.Errorf("%w: %v", ErrRoomHeatingSysFnNotWritable, err)
+	}
+	for _, unavailable := range []error{
+		eebusapi.ErrMetadataNotAvailable,
+		eebusapi.ErrDataNotAvailable,
+		eebusapi.ErrDataInvalid,
+		eebusapi.ErrDataForMetadataKeyNotFound,
+		eebusapi.ErrEntityNotFound,
+		eebusapi.ErrMissingData,
+		eebusapi.ErrDeviceDisconnected,
+		eebusapi.ErrNoCompatibleEntity,
+	} {
+		if errors.Is(err, unavailable) {
+			return fmt.Errorf("%w: %v", ErrRoomHeatingSysFnDataUnavailable, err)
+		}
+	}
+	return err
+}

--- a/eebus-bridge/internal/usecases/roomheatingsysfn_upstream_mode_test.go
+++ b/eebus-bridge/internal/usecases/roomheatingsysfn_upstream_mode_test.go
@@ -1,0 +1,199 @@
+package usecases
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	eebusapi "github.com/enbility/eebus-go/api"
+	ucapi "github.com/enbility/eebus-go/usecases/api"
+	ucmocks "github.com/enbility/eebus-go/usecases/mocks"
+	spineapi "github.com/enbility/spine-go/api"
+	spinemocks "github.com/enbility/spine-go/mocks"
+	"github.com/enbility/spine-go/model"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestUpstreamRoomHeatingOperationModeWriterWritesAndAwaitsResult(t *testing.T) {
+	entity := spinemocks.NewEntityRemoteInterface(t)
+	client := ucmocks.NewCaCRHSFInterface(t)
+	client.EXPECT().OperationModes(entity).Return([]ucapi.HvacOperationModeType{
+		ucapi.HvacOperationModeTypeAuto,
+		ucapi.HvacOperationModeTypeOn,
+		ucapi.HvacOperationModeTypeOff,
+	}, nil)
+	counter := model.MsgCounterType(41)
+	client.EXPECT().WriteOperationMode(entity, ucapi.HvacOperationModeTypeOn, mock.Anything).RunAndReturn(
+		func(_ spineapi.EntityRemoteInterface, _ ucapi.HvacOperationModeType, callback func(model.ResultDataType, model.MsgCounterType)) (*model.MsgCounterType, error) {
+			callback(model.ResultDataType{}, counter)
+			return &counter, nil
+		},
+	)
+	writer := &upstreamRoomHeatingOperationModeWriter{
+		client: client,
+		inspector: &phase2RoomHeatingCapabilityInspector{state: RoomHeatingSystemFunctionState{
+			ModeWritable: true,
+		}},
+	}
+
+	if err := writer.WriteOperationMode(context.Background(), entity, "on"); err != nil {
+		t.Fatalf("WriteOperationMode() error = %v", err)
+	}
+}
+
+func TestUpstreamRoomHeatingOperationModeWriterPrevalidatesCRHSFRelation(t *testing.T) {
+	entity := spinemocks.NewEntityRemoteInterface(t)
+	client := ucmocks.NewCaCRHSFInterface(t)
+	client.EXPECT().OperationModes(entity).Return([]ucapi.HvacOperationModeType{
+		ucapi.HvacOperationModeTypeAuto,
+		ucapi.HvacOperationModeTypeOn,
+	}, nil)
+	writer := &upstreamRoomHeatingOperationModeWriter{
+		client: client,
+		inspector: &phase2RoomHeatingCapabilityInspector{state: RoomHeatingSystemFunctionState{
+			ModeWritable: true,
+		}},
+	}
+
+	if err := writer.WriteOperationMode(context.Background(), entity, "off"); !errors.Is(err, ErrRoomHeatingSysFnInvalidMode) {
+		t.Fatalf("WriteOperationMode() error = %v, want ErrRoomHeatingSysFnInvalidMode", err)
+	}
+}
+
+func TestUpstreamRoomHeatingOperationModeWriterReturnsDeviceRejection(t *testing.T) {
+	entity := spinemocks.NewEntityRemoteInterface(t)
+	client := ucmocks.NewCaCRHSFInterface(t)
+	client.EXPECT().OperationModes(entity).Return([]ucapi.HvacOperationModeType{ucapi.HvacOperationModeTypeOff}, nil)
+	counter := model.MsgCounterType(42)
+	description := model.DescriptionType("mode blocked")
+	client.EXPECT().WriteOperationMode(entity, ucapi.HvacOperationModeTypeOff, mock.Anything).RunAndReturn(
+		func(_ spineapi.EntityRemoteInterface, _ ucapi.HvacOperationModeType, callback func(model.ResultDataType, model.MsgCounterType)) (*model.MsgCounterType, error) {
+			callback(model.ResultDataType{
+				ErrorNumber: ptr(model.ErrorNumberTypeCommandRejected),
+				Description: &description,
+			}, counter)
+			return &counter, nil
+		},
+	)
+	writer := &upstreamRoomHeatingOperationModeWriter{
+		client: client,
+		inspector: &phase2RoomHeatingCapabilityInspector{state: RoomHeatingSystemFunctionState{
+			ModeWritable: true,
+		}},
+	}
+
+	err := writer.WriteOperationMode(context.Background(), entity, "off")
+	if !errors.Is(err, ErrRoomHeatingSysFnRejected) || !strings.Contains(err.Error(), string(description)) {
+		t.Fatalf("WriteOperationMode() error = %v, want device rejection", err)
+	}
+}
+
+func TestUpstreamRoomHeatingOperationModeWriterHonoursCancellation(t *testing.T) {
+	entity := spinemocks.NewEntityRemoteInterface(t)
+	client := ucmocks.NewCaCRHSFInterface(t)
+	client.EXPECT().OperationModes(entity).Return([]ucapi.HvacOperationModeType{ucapi.HvacOperationModeTypeAuto}, nil)
+	counter := model.MsgCounterType(43)
+	client.EXPECT().WriteOperationMode(entity, ucapi.HvacOperationModeTypeAuto, mock.Anything).Return(&counter, nil)
+	writer := &upstreamRoomHeatingOperationModeWriter{
+		client: client,
+		inspector: &phase2RoomHeatingCapabilityInspector{state: RoomHeatingSystemFunctionState{
+			ModeWritable: true,
+		}},
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if err := writer.WriteOperationMode(ctx, entity, "auto"); !errors.Is(err, context.Canceled) {
+		t.Fatalf("WriteOperationMode() error = %v, want context.Canceled", err)
+	}
+}
+
+func TestUpstreamRoomHeatingOperationModeWriterMapsSendFailuresWithoutFallback(t *testing.T) {
+	sendErr := errors.New("send failed")
+	for _, test := range []struct {
+		name string
+		err  error
+		want error
+	}{
+		{name: "not writable", err: eebusapi.ErrNotSupported, want: ErrRoomHeatingSysFnNotWritable},
+		{name: "cache unavailable", err: eebusapi.ErrDataNotAvailable, want: ErrRoomHeatingSysFnDataUnavailable},
+		{name: "disconnected", err: eebusapi.ErrDeviceDisconnected, want: ErrRoomHeatingSysFnDataUnavailable},
+		{name: "transport error", err: sendErr, want: sendErr},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			entity := spinemocks.NewEntityRemoteInterface(t)
+			client := ucmocks.NewCaCRHSFInterface(t)
+			client.EXPECT().OperationModes(entity).Return([]ucapi.HvacOperationModeType{ucapi.HvacOperationModeTypeOn}, nil)
+			client.EXPECT().WriteOperationMode(entity, ucapi.HvacOperationModeTypeOn, mock.Anything).Return(nil, test.err).Once()
+			writer := &upstreamRoomHeatingOperationModeWriter{
+				client: client,
+				inspector: &phase2RoomHeatingCapabilityInspector{state: RoomHeatingSystemFunctionState{
+					ModeWritable: true,
+				}},
+			}
+
+			if err := writer.WriteOperationMode(context.Background(), entity, "on"); !errors.Is(err, test.want) {
+				t.Fatalf("WriteOperationMode() error = %v, want %v", err, test.want)
+			}
+		})
+	}
+}
+
+func TestUpstreamRoomHeatingOperationModeWriterFailsClosedBeforeSending(t *testing.T) {
+	entity := spinemocks.NewEntityRemoteInterface(t)
+	client := ucmocks.NewCaCRHSFInterface(t)
+	writer := &upstreamRoomHeatingOperationModeWriter{
+		client:    client,
+		inspector: &phase2RoomHeatingCapabilityInspector{},
+	}
+	if err := writer.WriteOperationMode(context.Background(), entity, "auto"); !errors.Is(err, ErrRoomHeatingSysFnNotWritable) {
+		t.Fatalf("WriteOperationMode() error = %v, want ErrRoomHeatingSysFnNotWritable", err)
+	}
+
+	inspectionErr := errors.New("inspection failed")
+	writer.inspector = &phase2RoomHeatingCapabilityInspector{err: inspectionErr}
+	if err := writer.WriteOperationMode(context.Background(), entity, "auto"); !errors.Is(err, inspectionErr) {
+		t.Fatalf("WriteOperationMode() inspection error = %v, want %v", err, inspectionErr)
+	}
+
+	for name, incomplete := range map[string]*upstreamRoomHeatingOperationModeWriter{
+		"nil writer":    nil,
+		"nil client":    {inspector: &phase2RoomHeatingCapabilityInspector{}},
+		"nil inspector": {client: client},
+		"nil entity":    {client: client, inspector: &phase2RoomHeatingCapabilityInspector{}},
+	} {
+		t.Run(name, func(t *testing.T) {
+			var gotEntity spineapi.EntityRemoteInterface = entity
+			if name == "nil entity" {
+				gotEntity = nil
+			}
+			if err := incomplete.WriteOperationMode(context.Background(), gotEntity, "auto"); !errors.Is(err, ErrRoomHeatingSysFnDataUnavailable) {
+				t.Fatalf("WriteOperationMode() error = %v, want ErrRoomHeatingSysFnDataUnavailable", err)
+			}
+		})
+	}
+}
+
+func TestUpstreamRoomHeatingOperationModeWriterTimesOut(t *testing.T) {
+	entity := spinemocks.NewEntityRemoteInterface(t)
+	client := ucmocks.NewCaCRHSFInterface(t)
+	client.EXPECT().OperationModes(entity).Return([]ucapi.HvacOperationModeType{ucapi.HvacOperationModeTypeOn}, nil)
+	counter := model.MsgCounterType(44)
+	client.EXPECT().WriteOperationMode(entity, ucapi.HvacOperationModeTypeOn, mock.Anything).Return(&counter, nil)
+	writer := &upstreamRoomHeatingOperationModeWriter{
+		client: client,
+		inspector: &phase2RoomHeatingCapabilityInspector{state: RoomHeatingSystemFunctionState{
+			ModeWritable: true,
+		}},
+	}
+	previousTimeout := roomHeatingSystemFunctionWriteTimeout
+	roomHeatingSystemFunctionWriteTimeout = time.Millisecond
+	t.Cleanup(func() { roomHeatingSystemFunctionWriteTimeout = previousTimeout })
+
+	err := writer.WriteOperationMode(context.Background(), entity, "on")
+	if err == nil || !strings.Contains(err.Error(), "timed out") {
+		t.Fatalf("WriteOperationMode() error = %v, want timeout", err)
+	}
+}

--- a/eebus-bridge/internal/usecases/roomheatingsysfn_upstream_mode_test.go
+++ b/eebus-bridge/internal/usecases/roomheatingsysfn_upstream_mode_test.go
@@ -197,3 +197,61 @@ func TestUpstreamRoomHeatingOperationModeWriterTimesOut(t *testing.T) {
 		t.Fatalf("WriteOperationMode() error = %v, want timeout", err)
 	}
 }
+
+func TestUpstreamRoomHeatingOperationModeWriterMapsRelationLookupError(t *testing.T) {
+	entity := spinemocks.NewEntityRemoteInterface(t)
+	client := ucmocks.NewCaCRHSFInterface(t)
+	client.EXPECT().OperationModes(entity).Return(nil, eebusapi.ErrDataNotAvailable)
+	writer := &upstreamRoomHeatingOperationModeWriter{
+		client: client,
+		inspector: &phase2RoomHeatingCapabilityInspector{state: RoomHeatingSystemFunctionState{
+			ModeWritable: true,
+		}},
+	}
+
+	if err := writer.WriteOperationMode(context.Background(), entity, "on"); !errors.Is(err, ErrRoomHeatingSysFnDataUnavailable) {
+		t.Fatalf("WriteOperationMode() error = %v, want ErrRoomHeatingSysFnDataUnavailable", err)
+	}
+}
+
+func TestUpstreamRoomHeatingOperationModeWriterRejectsMissingMessageCounter(t *testing.T) {
+	entity := spinemocks.NewEntityRemoteInterface(t)
+	client := ucmocks.NewCaCRHSFInterface(t)
+	client.EXPECT().OperationModes(entity).Return([]ucapi.HvacOperationModeType{ucapi.HvacOperationModeTypeOn}, nil)
+	client.EXPECT().WriteOperationMode(entity, ucapi.HvacOperationModeTypeOn, mock.Anything).Return(nil, nil)
+	writer := &upstreamRoomHeatingOperationModeWriter{
+		client: client,
+		inspector: &phase2RoomHeatingCapabilityInspector{state: RoomHeatingSystemFunctionState{
+			ModeWritable: true,
+		}},
+	}
+
+	err := writer.WriteOperationMode(context.Background(), entity, "on")
+	if err == nil || !strings.Contains(err.Error(), "no message counter") {
+		t.Fatalf("WriteOperationMode() error = %v, want missing message counter", err)
+	}
+}
+
+func TestUpstreamRoomHeatingOperationModeWriterRejectsForeignMessageCounter(t *testing.T) {
+	entity := spinemocks.NewEntityRemoteInterface(t)
+	client := ucmocks.NewCaCRHSFInterface(t)
+	client.EXPECT().OperationModes(entity).Return([]ucapi.HvacOperationModeType{ucapi.HvacOperationModeTypeOn}, nil)
+	counter := model.MsgCounterType(45)
+	client.EXPECT().WriteOperationMode(entity, ucapi.HvacOperationModeTypeOn, mock.Anything).RunAndReturn(
+		func(_ spineapi.EntityRemoteInterface, _ ucapi.HvacOperationModeType, callback func(model.ResultDataType, model.MsgCounterType)) (*model.MsgCounterType, error) {
+			callback(model.ResultDataType{}, model.MsgCounterType(99))
+			return &counter, nil
+		},
+	)
+	writer := &upstreamRoomHeatingOperationModeWriter{
+		client: client,
+		inspector: &phase2RoomHeatingCapabilityInspector{state: RoomHeatingSystemFunctionState{
+			ModeWritable: true,
+		}},
+	}
+
+	err := writer.WriteOperationMode(context.Background(), entity, "on")
+	if err == nil || !strings.Contains(err.Error(), "unexpected message counter") {
+		t.Fatalf("WriteOperationMode() error = %v, want unexpected message counter", err)
+	}
+}


### PR DESCRIPTION
## Summary

- select upstream CRHSF as the sole room-heating mode writer without request fallback
- prevalidate requested modes against both MRHSF and CRHSF state
- await matching write results with context, timeout, rejection, and existing bridge error mapping
- retain the legacy implementation for release rollback and document the Phase 3 status

## Validation

- go test ./...
- go vet ./...
- go test -race ./...
- git diff --check

## Remaining Phase 3 acceptance work

- harden upstream CRHSF for duplicate mode IDs and post-result refresh, then update the fork pin
- add the upstream feature-disappearance sentinel and bridge mapping
- run the required hardware mode-transition and reconnect/restart matrix

This remains a draft until those upstream and hardware acceptance items are complete.