### PR TITLE
fix: enable failsafe limit number by default

### DIFF
--- a/custom_components/eebus/number.py
+++ b/custom_components/eebus/number.py
@@ -81,7 +81,7 @@ class EebusLPCLimitNumber(EebusEntity, NumberEntity):
 class EebusFailsafeLimitNumber(EebusEntity, NumberEntity):
     """Number entity for setting failsafe limit.
 
-    Gold: entity_category CONFIG, entity_disabled_by_default.
+    Gold: entity_category CONFIG. Enabled by default (primary §14a control).
     """
 
     _attr_device_class = NumberDeviceClass.POWER
@@ -92,7 +92,8 @@ class EebusFailsafeLimitNumber(EebusEntity, NumberEntity):
     _attr_native_step = 100
     _attr_translation_key = "failsafe_limit"
     _attr_entity_category = EntityCategory.CONFIG
-    _attr_entity_registry_enabled_default = False  # Gold: less popular entities disabled
+    # Enabled by default like the LPC limit number: the §14a failsafe fallback is a
+    # primary control, not a "less popular" entity — keep it reachable without manual enable.
 
     def __init__(self, coordinator: EebusCoordinator) -> None:
         """Initialize."""

--- a/custom_components/eebus/tests/test_number.py
+++ b/custom_components/eebus/tests/test_number.py
@@ -4,8 +4,8 @@ from unittest.mock import MagicMock
 
 from homeassistant.const import EntityCategory
 
-from custom_components.eebus.number import EebusLPCLimitNumber
-from custom_components.eebus.models import CapabilityState, ConsumptionLimitState
+from custom_components.eebus.number import EebusFailsafeLimitNumber, EebusLPCLimitNumber
+from custom_components.eebus.models import CapabilityState, ConsumptionLimitState, FailsafeState
 from custom_components.eebus.state import (
     CapabilitiesState,
     ConnectionState,
@@ -29,3 +29,20 @@ def test_lpc_limit_value():
     number = EebusLPCLimitNumber(coordinator)
     assert number.entity_category == EntityCategory.CONFIG
     assert number.native_value == 4200.0
+
+
+def test_failsafe_limit_enabled_by_default():
+    """Failsafe number is a primary §14a control: enabled by default, not hidden."""
+    coordinator = MagicMock()
+    coordinator.data = DeviceState(
+        connection=ConnectionState(connected=True),
+        lpc=LPCState(failsafe_limit=FailsafeState(3500.0, 7200)),
+        capabilities=CapabilitiesState(failsafe=CapabilityState.AVAILABLE),
+        fresh_fields=frozenset({StateField.FAILSAFE_LIMIT}),
+    )
+    coordinator.ski = "test-ski"
+
+    number = EebusFailsafeLimitNumber(coordinator)
+    assert number.entity_registry_enabled_default is True
+    assert number.entity_category == EntityCategory.CONFIG
+    assert number.native_value == 3500.0


### PR DESCRIPTION
## Problem

`EebusFailsafeLimitNumber` set `_attr_entity_registry_enabled_default = False` ("less popular entity"), so the writable failsafe-limit `number` was hidden until manually enabled. On integration re-add / SKI re-registration the registry entry is recreated at its disabled default, orphaning any previously-enabled entry (unique_id is SKI-based). Users silently lose the ability to change the LPC failsafe limit — no obvious cause.

Observed live on the VR940 deploy: `sensor.*_failsafe_limit` (read-only) present and healthy at 3500 W, but the writable `number.*_failsafe_limit` absent from the state machine — registry entry existed as `..._failsafe_limit_2`, `disabled_by=integration`.

## Fix

Remove the disabled-by-default flag so the failsafe number matches the LPC limit number (enabled). The §14a failsafe fallback is a primary control, not a less-popular entity.

- `entity-disabled-by-default` quality-scale rule stays satisfied: the binary_sensor + 11 diagnostic sensors remain disabled by default.
- Applies to future re-adds / fresh installs. Existing registry entries keep their own `disabled_by` state.

## Test

Adds `test_failsafe_limit_enabled_by_default` asserting `entity_registry_enabled_default is True`.

Local: `ruff` clean, `mypy` clean (48 files), 276 passed.