### PR TITLE
feat(discovery): log per-feature function inventory

### DIFF
--- a/docs/open-items-consolidation-spec.md
+++ b/docs/open-items-consolidation-spec.md
@@ -209,6 +209,21 @@ Geräte-Notify.
 Exit: nach OPEN-B2 erneut mit enger Write-Folge messen; kein Sample zeigt den
 Vorzustand nach abgeschlossenem Write.
 
+**OPEN-D6 — Lesbare Gerätefunktionen ohne Bridge-Nutzung.**
+Quelle: Function-Inventar des VR940 (`docs/vr940-function-inventory.md`, Capture
+2026-07-13). Die Schreibfläche des Geräts ist vollständig ausgeschöpft, vier
+lesbare Functions werden aber nicht konsumiert: `deviceClassificationUserData`
+auf `5`/`5:1`/`5:1:1` (Heizkreis-, Zonen- und Raumnamen; der zugehörige
+`visualizationOfHeatingAreaName` wird annonciert),
+`electricalConnectionCharacteristicListData` auf `3:f7`,
+`measurementConstraintsListData` auf allen Measurement-Features sowie die
+beiden HVAC-Relations-Listen.
+Reine Bestandsaufnahme, kein Fehler: jede Umsetzung ist ein eigenes Feature mit
+eigenem Hardwaretest. Priorität liegt bei den Namen, weil sie generische
+Entity-Namen in HA ersetzen würden.
+Exit: entweder pro Punkt ein Feature-Ticket mit Hardwareabnahme, oder eine
+dokumentierte Entscheidung gegen die Umsetzung.
+
 ## 4. Reihenfolge und Abhängigkeiten
 
 ```text
@@ -223,6 +238,7 @@ OPEN-B3 (unabhängig einreichbar)
 
 OPEN-C1 wartet auf Produktionstelemetrie.
 OPEN-C3 ist jederzeit unabhängig umsetzbar; OPEN-D1 bis OPEN-D4 sind erledigt.
+OPEN-D6 ist unabhängig und reine Bestandsaufnahme.
 ```
 
 Empfohlene Bearbeitung:

--- a/docs/vr940-function-inventory.md
+++ b/docs/vr940-function-inventory.md
@@ -1,0 +1,81 @@
+# VR940 SPINE function inventory
+
+Companion to `vr940-usecase-dump.txt`. That file lists what the gateway *advertises*
+(`nodeManagementUseCaseData`); this one lists what it actually *exposes* — every
+feature function reported by detailed discovery, with the operations the device
+permits on it.
+
+The distinction matters because a device can implement a function without
+advertising the corresponding use case. A function carrying `write` can be written
+through a direct SPINE request even when `device.UseCases()` never mentions it —
+that is how the DHW and room-heating setpoint paths were built before eebus-go had
+the matching use cases.
+
+Source: extended capture taken 2026-07-13 on the live stack (Vaillant VR940f
+gateway, SKI `682F708CEBA5DF9ADCB9E6787EA911D9FC3AC490`, aroTHERM plus
+VWL 75/8.1 A 230V). Entity/feature layout re-confirmed 2026-07-23.
+
+## Entities
+
+| Address | Type |
+|---|---|
+| `0` | DeviceInformation |
+| `3` | HeatPumpAppliance |
+| `3:1` | Compressor |
+| `4` | DHWCircuit |
+| `5` | HeatingCircuit |
+| `5:1` | HeatingZone |
+| `5:1:1` | HVACRoom |
+| `6` | TemperatureSensor |
+
+Entities `1` and `2` (CEM, `Generic/client`) appear in the use-case dump as the
+consumer side for MGCP / VAPD / VABD and carry no server functions.
+
+## Writable functions — the complete write surface
+
+Every function the VR940 reports as writable, and the bridge feature that uses it.
+There are no others: the gateway's write surface is fully exercised.
+
+| Entity | Feature | Function | Used by |
+|---|---|---|---|
+| `3` HeatPumpAppliance | `3:f24` DeviceConfiguration | `deviceConfigurationKeyValueListData` | LPC failsafe limit / duration |
+| `3` HeatPumpAppliance | `3:f10` LoadControl | `loadControlLimitListData` | LPC consumption limit (§14a) |
+| `3:1` Compressor | `3:1:f19` SmartEnergyManagementPs | `smartEnergyManagementPsData` | OHPCF compressor flexibility |
+| `4` DHWCircuit | `4:f9` HVAC | `hvacOverrunListData` | DHW boost switch |
+| `4` DHWCircuit | `4:f9` HVAC | `hvacSystemFunctionListData` | DHW operation-mode select |
+| `4` DHWCircuit | `4:f18` Setpoint | `setpointListData` | DHW target temperature |
+| `5:1:1` HVACRoom | `5:1:1:f9` HVAC | `hvacSystemFunctionListData` | Room-heating mode (`auto`/`on`/`off`) |
+| `5:1:1` HVACRoom | `5:1:1:f18` Setpoint | `setpointListData` | Room-heating setpoint |
+
+## Readable functions not consumed by the bridge
+
+Gaps, in rough order of usefulness. Tracked as OPEN-D6 in
+`open-items-consolidation-spec.md`.
+
+| Entity | Feature | Function | What it would give us |
+|---|---|---|---|
+| `5`, `5:1`, `5:1:1` | `f4` DeviceClassification | `deviceClassificationUserData` | User-assigned heating-circuit / zone / room names (the advertised `visualizationOfHeatingAreaName` use case), instead of generic entity names |
+| `3` | `3:f7` ElectricalConnection | `electricalConnectionCharacteristicListData` | Nominal power and connection limits of the heat pump |
+| `3`, `3:1`, `4`, `5:1:1`, `6` | `f11` Measurement | `measurementConstraintsListData` | Per-measurement min / max / resolution, usable as HA entity attributes |
+| `4`, `5:1:1` | `f9` HVAC | `hvacSystemFunctionSetpointRelationListData`, `hvacSystemFunctionOperationModeRelationListData` | Explicit mode↔setpoint relations; currently only resolved implicitly inside the fork's use cases |
+
+## Not present at all
+
+Confirmed absent from the inventory, so not implementable regardless of approach:
+
+- Cooling (no cooling system function or setpoint).
+- Schedules / time programs (no `timeSeries`, no `incentiveTable`).
+- `hvac_action` (no running-state function on the HVAC features).
+
+## Regenerating this inventory
+
+The `[DISCOVERY]` dump in `internal/eebus/discovery.go` prints entities, features,
+their functions and the permitted operations (`r`, `rp`, `w`, `wp`) once per SKI.
+It is gated behind debug events, so on the deployed bridge:
+
+1. Set `logging.debug_events: true` (or `EEBUS_DEBUG_EVENTS=true`) and restart.
+2. Wait for the device to reach `Trusted` and the use cases to report support.
+3. `grep '\[DISCOVERY\]'` in the container log.
+
+Diffing two dumps across firmware versions shows exactly which functions a gateway
+update added or removed.

--- a/eebus-bridge/internal/eebus/discovery.go
+++ b/eebus-bridge/internal/eebus/discovery.go
@@ -84,6 +84,9 @@ func FormatDeviceUseCases(ski string, device spineapi.DeviceRemoteInterface) str
 		}
 		fmt.Fprintf(&b, "[DISCOVERY]   entity addr=%s type=%s features=[%s]\n",
 			formatEntityAddress(e.Address()), e.EntityType(), formatFeatures(e.Features()))
+		for _, line := range formatFeatureFunctions(e.Features()) {
+			fmt.Fprintf(&b, "[DISCOVERY]     %s\n", line)
+		}
 	}
 
 	useCases := device.UseCases()
@@ -153,4 +156,77 @@ func formatFeatures(features []spineapi.FeatureRemoteInterface) string {
 	}
 	sort.Strings(out)
 	return strings.Join(out, ", ")
+}
+
+// formatFeatureFunctions renders one line per remote feature listing every function
+// the device reports in its detailed discovery, annotated with the operations it
+// permits (r = read, rp = read partial, w = write, wp = write partial).
+//
+// This is the inventory that matters when a device implements functionality without
+// advertising the corresponding use case: a function carrying "w" can be written via
+// a direct SPINE request even though device.UseCases() never mentions it. Lines are
+// sorted so two dumps can be diffed across firmware versions.
+func formatFeatureFunctions(features []spineapi.FeatureRemoteInterface) []string {
+	out := make([]string, 0, len(features))
+	for _, f := range features {
+		if f == nil {
+			continue
+		}
+		ops := f.Operations()
+		names := make([]string, 0, len(ops))
+		for function, op := range ops {
+			names = append(names, fmt.Sprintf("%s(%s)", function, formatOperations(op)))
+		}
+		sort.Strings(names)
+		out = append(out, fmt.Sprintf("feature addr=%s type=%s role=%s functions=[%s]",
+			formatFeatureAddress(f.Address()), f.Type(), f.Role(), strings.Join(names, ", ")))
+	}
+	sort.Strings(out)
+	return out
+}
+
+// formatOperations renders the permitted operations of a single function as a
+// compact flag list, e.g. "r,w" for a readable and writable function. Returns "-"
+// when the device permits none.
+func formatOperations(op spineapi.OperationsInterface) string {
+	if op == nil {
+		return "-"
+	}
+	flags := make([]string, 0, 4)
+	for _, f := range []struct {
+		name    string
+		allowed bool
+	}{
+		{"r", op.Read()},
+		{"rp", op.ReadPartial()},
+		{"w", op.Write()},
+		{"wp", op.WritePartial()},
+	} {
+		if f.allowed {
+			flags = append(flags, f.name)
+		}
+	}
+	if len(flags) == 0 {
+		return "-"
+	}
+	return strings.Join(flags, ",")
+}
+
+// formatFeatureAddress renders the feature address path (e.g. "1:2:5") for the dump.
+// Returns "?" when the address is absent.
+func formatFeatureAddress(addr *model.FeatureAddressType) string {
+	if addr == nil {
+		return "?"
+	}
+	parts := make([]string, 0, len(addr.Entity)+1)
+	for _, a := range addr.Entity {
+		parts = append(parts, fmt.Sprintf("%d", uint(a)))
+	}
+	if addr.Feature != nil {
+		parts = append(parts, fmt.Sprintf("%d", uint(*addr.Feature)))
+	}
+	if len(parts) == 0 {
+		return "?"
+	}
+	return strings.Join(parts, ":")
 }

--- a/eebus-bridge/internal/eebus/discovery_test.go
+++ b/eebus-bridge/internal/eebus/discovery_test.go
@@ -22,6 +22,25 @@ func buildDeviceMock(t *testing.T, ski string) *mocks.DeviceRemoteInterface {
 	feature := mocks.NewFeatureRemoteInterface(t)
 	feature.On("Type").Return(model.FeatureTypeTypeMeasurement).Maybe()
 	feature.On("Role").Return(model.RoleTypeServer).Maybe()
+	featureNumber := model.AddressFeatureType(5)
+	feature.On("Address").Return(&model.FeatureAddressType{
+		Entity:  []model.AddressEntityType{1, 2},
+		Feature: &featureNumber,
+	}).Maybe()
+	readOnly := mocks.NewOperationsInterface(t)
+	readOnly.On("Read").Return(true).Maybe()
+	readOnly.On("ReadPartial").Return(false).Maybe()
+	readOnly.On("Write").Return(false).Maybe()
+	readOnly.On("WritePartial").Return(false).Maybe()
+	writable := mocks.NewOperationsInterface(t)
+	writable.On("Read").Return(true).Maybe()
+	writable.On("ReadPartial").Return(false).Maybe()
+	writable.On("Write").Return(true).Maybe()
+	writable.On("WritePartial").Return(true).Maybe()
+	feature.On("Operations").Return(map[model.FunctionType]spineapi.OperationsInterface{
+		model.FunctionTypeMeasurementListData:            readOnly,
+		model.FunctionTypeMeasurementDescriptionListData: writable,
+	}).Maybe()
 
 	entity := mocks.NewEntityRemoteInterface(t)
 	entity.On("Address").Return(entityAddr).Maybe()
@@ -64,10 +83,41 @@ func TestFormatDeviceUseCases(t *testing.T) {
 		string(model.UseCaseNameTypeMonitoringOfPowerConsumption),
 		"available=true",
 		"scenarios=[1,2,3]",
+		"feature addr=1:2:5 type=Measurement role=server",
+		"measurementListData(r)",
+		"measurementDescriptionListData(r,w,wp)",
 	} {
 		if !strings.Contains(out, want) {
 			t.Errorf("FormatDeviceUseCases output missing %q:\n%s", want, out)
 		}
+	}
+}
+
+// TestFormatOperationsEdgeCases pins the compact flag rendering, including a device
+// that reports a function without permitting any operation on it.
+func TestFormatOperationsEdgeCases(t *testing.T) {
+	if got := formatOperations(nil); got != "-" {
+		t.Errorf("formatOperations(nil) = %q, want %q", got, "-")
+	}
+
+	none := mocks.NewOperationsInterface(t)
+	none.On("Read").Return(false).Maybe()
+	none.On("ReadPartial").Return(false).Maybe()
+	none.On("Write").Return(false).Maybe()
+	none.On("WritePartial").Return(false).Maybe()
+	if got := formatOperations(none); got != "-" {
+		t.Errorf("formatOperations(no ops) = %q, want %q", got, "-")
+	}
+}
+
+// TestFormatFeatureAddressMissing covers features the stack reports without an
+// address, which must not abort the dump.
+func TestFormatFeatureAddressMissing(t *testing.T) {
+	if got := formatFeatureAddress(nil); got != "?" {
+		t.Errorf("formatFeatureAddress(nil) = %q, want %q", got, "?")
+	}
+	if got := formatFeatureAddress(&model.FeatureAddressType{}); got != "?" {
+		t.Errorf("formatFeatureAddress(empty) = %q, want %q", got, "?")
 	}
 }
 
@@ -85,7 +135,7 @@ func TestUseCaseDiscoveryLogOnceDedup(t *testing.T) {
 	device := buildDeviceMock(t, "ABCD1234")
 
 	d.LogOnce("ABCD1234", device)
-	d.LogOnce("abcd1234", device)   // same SKI, different case -> deduped
+	d.LogOnce("abcd1234", device)     // same SKI, different case -> deduped
 	d.LogOnce("  abcd 1234 ", device) // same SKI, spacing -> deduped
 
 	if calls != 1 {


### PR DESCRIPTION
## What

The `[DISCOVERY]` dump listed entities, features and advertised use cases, but never the functions behind each feature. That list is the one that decides whether a capability is reachable: a device can expose a **writable** function without advertising the matching use case — exactly how the DHW and room-heating setpoint paths were built.

Each feature now prints its functions annotated with the permitted operations (`r`, `rp`, `w`, `wp`), sorted so two dumps can be diffed across firmware versions.

```
[DISCOVERY]   entity addr=4 type=DHWCircuit features=[HVAC/server, Measurement/server, Setpoint/server]
[DISCOVERY]     feature addr=4:18 type=Setpoint role=server functions=[setpointConstraintsListData(r), setpointDescriptionListData(r), setpointListData(r,w)]
```

## Findings

`docs/vr940-function-inventory.md` records the resulting VR940 inventory (from the 2026-07-13 extended capture, layout re-confirmed 2026-07-23):

- **The gateway's write surface is fully exercised** — all 8 writable functions are already consumed by LPC, OHPCF, DHW and room heating. No hidden write path left.
- Four readable functions are unused: heating-circuit/zone/room names (`deviceClassificationUserData`), `electricalConnectionCharacteristicListData`, `measurementConstraintsListData`, and the two HVAC relation lists. Tracked as **OPEN-D6**.
- Confirmed absent: cooling, schedules (no `timeSeries`/`incentiveTable`), `hvac_action`.

## Test

- `go vet ./...`, `go test -race ./internal/eebus/` — green.
- New cases cover the operation-flag rendering (including a function with no permitted operation) and features reported without an address.