### PR TITLE
feat(eebus): complete the local device announcement

### DIFF
--- a/docs/badges/go-coverage.svg
+++ b/docs/badges/go-coverage.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="172" height="28" role="img" aria-label="Go coverage: 86.2%">
-  <title>Go coverage: 86.2%</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="172" height="28" role="img" aria-label="Go coverage: 87.0%">
+  <title>Go coverage: 87.0%</title>
   <linearGradient id="s" x2="0" y2="100%">
     <stop offset="0" stop-color="#fff" stop-opacity=".15"/>
     <stop offset="1" stop-opacity=".15"/>
@@ -12,6 +12,6 @@
   </g>
   <g fill="#fff" text-anchor="middle" font-family="Verdana,DejaVu Sans,sans-serif" font-size="10" font-weight="700">
     <text x="56" y="18">GO COVERAGE</text>
-    <text x="142" y="18">86.2%</text>
+    <text x="142" y="18">87.0%</text>
   </g>
 </svg>

--- a/docs/open-items-consolidation-spec.md
+++ b/docs/open-items-consolidation-spec.md
@@ -224,6 +224,20 @@ Entity-Namen in HA ersetzen würden.
 Exit: entweder pro Punkt ein Feature-Ticket mit Hardwareabnahme, oder eine
 dokumentierte Entscheidung gegen die Umsetzung.
 
+**OPEN-D7 — Vendorname wird upstream aus der Brand abgeleitet.**
+Quelle: Announcement-Audit, PR #161. `spine.NewDeviceLocal` kennt keinen
+Vendor-Parameter und befüllt `VendorName` wie `BrandName` aus der Brand
+(`spine/device_local.go`), `eebus-go`s `api.Configuration` führt nur den
+`vendorCode` (IANA PEN), keinen Vendornamen. Die Bridge korrigiert
+`deviceClassificationManufacturerData` deshalb nach `Setup` selbst
+(`internal/eebus/announcement.go`).
+Ein Fork von `spine-go` ist bewusst ausgeschlossen: ein zweiter
+`replace`-Eintrag mit eigenem Patch-Inventar arbeitet direkt gegen OPEN-A3.
+Der saubere Weg sind zwei Upstream-PRs — `vendorName` als Parameter in
+`spine.NewDeviceLocal` plus optionales Feld in `api.Configuration`.
+Exit: beide Upstream-PRs eingereicht; nach Merge entfällt die Bridge-Korrektur
+ersatzlos, oder es steht eine dokumentierte Ablehnung dagegen.
+
 ## 4. Reihenfolge und Abhängigkeiten
 
 ```text
@@ -239,6 +253,7 @@ OPEN-B3 (unabhängig einreichbar)
 OPEN-C1 wartet auf Produktionstelemetrie.
 OPEN-C3 ist jederzeit unabhängig umsetzbar; OPEN-D1 bis OPEN-D4 sind erledigt.
 OPEN-D6 ist unabhängig und reine Bestandsaufnahme.
+OPEN-D7 hängt wie OPEN-A1/A2 an fremdem Merge-Tempo, blockiert aber nichts.
 ```
 
 Empfohlene Bearbeitung:

--- a/eebus-bridge/cmd/eebus-bridge/app.go
+++ b/eebus-bridge/cmd/eebus-bridge/app.go
@@ -43,6 +43,7 @@ type bridgeLifecycle interface {
 	Shutdown()
 	RegisterRemoteSKI(string)
 	UnregisterRemoteSKI(string)
+	AnnounceLocalIdentity(string) error
 }
 
 type grpcLifecycle interface {
@@ -699,6 +700,12 @@ func (a *Application) startComponents(runtimeCtx context.Context, tx *lifecycleT
 	}
 	if err := a.bridgeSvc.Setup(); err != nil {
 		return fmt.Errorf("setting up EEBUS service: %w", err)
+	}
+	// Setup created the local SPINE device; complete its announcement (operating
+	// state, vendor name) before Start exposes it to remotes.
+	if err := a.bridgeSvc.AnnounceLocalIdentity(a.cfg.EEBUS.Vendor); err != nil {
+		a.bridgeSvc.Shutdown()
+		return fmt.Errorf("announcing local identity: %w", err)
 	}
 	if err := tx.add("EEBUS", func() error {
 		a.bridgeSvc.Shutdown()

--- a/eebus-bridge/cmd/eebus-bridge/app_test.go
+++ b/eebus-bridge/cmd/eebus-bridge/app_test.go
@@ -596,6 +596,7 @@ func TestApplicationStartRollsBackOnlySuccessfulStagesInReverseOrder(t *testing.
 	tests := []struct {
 		name         string
 		setupErr     error
+		announceErr  error
 		bridgeErr    error
 		module1Err   error
 		module2Err   error
@@ -603,6 +604,9 @@ func TestApplicationStartRollsBackOnlySuccessfulStagesInReverseOrder(t *testing.
 		wantRollback []string
 	}{
 		{name: "setup", setupErr: errors.New("setup"), wantRollback: nil},
+		// Announcing runs before the rollback ledger owns the service, so the
+		// failure path shuts the bridge down itself.
+		{name: "announce", announceErr: errors.New("announce"), wantRollback: []string{"bridge"}},
 		{name: "bridge", bridgeErr: errors.New("bridge"), wantRollback: []string{"bridge"}},
 		{name: "first module", module1Err: errors.New("module"), wantRollback: []string{"bridge"}},
 		{name: "second module", module2Err: errors.New("module"), wantRollback: []string{"module-one", "bridge"}},
@@ -612,7 +616,10 @@ func TestApplicationStartRollsBackOnlySuccessfulStagesInReverseOrder(t *testing.
 		t.Run(test.name, func(t *testing.T) {
 			recorder := &shutdownRecorder{}
 			bridge := &fakeBridgeLifecycle{
-				setupErr: test.setupErr, startErr: test.bridgeErr, recorder: recorder,
+				setupErr:    test.setupErr,
+				announceErr: test.announceErr,
+				startErr:    test.bridgeErr,
+				recorder:    recorder,
 			}
 			grpcServer := &fakeGRPCLifecycle{startErr: test.grpcErr, recorder: recorder}
 			app := newTestApplication(bridge, grpcServer, &fakeHeartbeatLifecycle{}, nil)

--- a/eebus-bridge/cmd/eebus-bridge/app_test.go
+++ b/eebus-bridge/cmd/eebus-bridge/app_test.go
@@ -25,6 +25,8 @@ import (
 type fakeBridgeLifecycle struct {
 	mu           sync.Mutex
 	setupErr     error
+	announceErr  error
+	announced    []string
 	startErr     error
 	started      chan struct{}
 	startOnce    sync.Once
@@ -38,6 +40,13 @@ type fakeBridgeLifecycle struct {
 	setupStarted chan struct{}
 	setupRelease chan struct{}
 	setupOnce    sync.Once
+}
+
+func (f *fakeBridgeLifecycle) AnnounceLocalIdentity(vendor string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.announced = append(f.announced, vendor)
+	return f.announceErr
 }
 
 func (f *fakeBridgeLifecycle) Setup() error {

--- a/eebus-bridge/internal/eebus/announcement.go
+++ b/eebus-bridge/internal/eebus/announcement.go
@@ -5,10 +5,14 @@ import (
 	"fmt"
 
 	"github.com/enbility/eebus-go/features/server"
+	spineapi "github.com/enbility/spine-go/api"
 	"github.com/enbility/spine-go/model"
 )
 
-var errNoLocalEntity = errors.New("local entity not available")
+var (
+	errNoLocalEntity      = errors.New("local entity not available")
+	errNoManufacturerData = errors.New("local manufacturer data not available")
+)
 
 // AnnounceLocalIdentity fills the two gaps spine-go leaves in the local device's
 // SPINE announcement. Call it after BridgeService.Setup (which creates the local
@@ -17,11 +21,14 @@ var errNoLocalEntity = errors.New("local entity not available")
 //
 // vendor is the display name for deviceClassificationManufacturerData. Passing an
 // empty string keeps whatever spine-go derived from the brand.
+//
+// Both halves are attempted even when the first fails, so a partial announcement
+// still gets as far as it can and the caller sees every reason it did not.
 func (b *BridgeService) AnnounceLocalIdentity(vendor string) error {
-	if err := b.SetOperatingState(model.DeviceDiagnosisOperatingStateTypeNormalOperation); err != nil {
-		return err
-	}
-	return b.setVendorName(vendor)
+	return errors.Join(
+		b.SetOperatingState(model.DeviceDiagnosisOperatingStateTypeNormalOperation),
+		b.setVendorName(vendor),
+	)
 }
 
 // SetOperatingState publishes the local entity's DeviceDiagnosis operating state.
@@ -32,22 +39,7 @@ func (b *BridgeService) AnnounceLocalIdentity(vendor string) error {
 // same place a Vaillant gateway puts it on its HeatPumpAppliance entity — not on
 // the DeviceInformation entity.
 func (b *BridgeService) SetOperatingState(state model.DeviceDiagnosisOperatingStateType) error {
-	entity := b.LocalEntity()
-	if entity == nil {
-		return errNoLocalEntity
-	}
-
-	// GetOrAddFeature and AddFunctionType are both idempotent, so this stays
-	// correct when the heartbeat manager has already created the feature.
-	feature := entity.GetOrAddFeature(model.FeatureTypeTypeDeviceDiagnosis, model.RoleTypeServer)
-	feature.AddFunctionType(model.FunctionTypeDeviceDiagnosisStateData, true, false)
-
-	diagnosis, err := server.NewDeviceDiagnosis(entity)
-	if err != nil {
-		return fmt.Errorf("creating local device diagnosis: %w", err)
-	}
-	diagnosis.SetLocalOperatingState(state)
-	return nil
+	return setLocalOperatingState(b.LocalEntity(), state)
 }
 
 // setVendorName corrects the vendor name in deviceClassificationManufacturerData.
@@ -60,23 +52,53 @@ func (b *BridgeService) setVendorName(vendor string) error {
 	if vendor == "" {
 		return nil
 	}
+	var entity spineapi.EntityLocalInterface
+	if device := b.service.LocalDevice(); device != nil {
+		entity = device.EntityForType(model.EntityTypeTypeDeviceInformation)
+	}
+	return setLocalVendorName(entity, vendor)
+}
 
-	device := b.service.LocalDevice()
-	if device == nil {
+// setLocalOperatingState is the entity-scoped half of SetOperatingState, split out
+// so the failure paths are reachable without a running EEBUS service.
+func setLocalOperatingState(
+	entity spineapi.EntityLocalInterface,
+	state model.DeviceDiagnosisOperatingStateType,
+) error {
+	if entity == nil {
 		return errNoLocalEntity
 	}
-	entity := device.EntityForType(model.EntityTypeTypeDeviceInformation)
+
+	// GetOrAddFeature and AddFunctionType are both idempotent, so this stays
+	// correct when the heartbeat manager has already created the feature.
+	feature := entity.GetOrAddFeature(model.FeatureTypeTypeDeviceDiagnosis, model.RoleTypeServer)
+	if feature == nil {
+		return errNoLocalEntity
+	}
+	feature.AddFunctionType(model.FunctionTypeDeviceDiagnosisStateData, true, false)
+
+	diagnosis, err := server.NewDeviceDiagnosis(entity)
+	if err != nil {
+		return fmt.Errorf("creating local device diagnosis: %w", err)
+	}
+	diagnosis.SetLocalOperatingState(state)
+	return nil
+}
+
+// setLocalVendorName is the entity-scoped half of setVendorName, split out for the
+// same reason.
+func setLocalVendorName(entity spineapi.EntityLocalInterface, vendor string) error {
 	if entity == nil {
 		return errNoLocalEntity
 	}
 	feature := entity.FeatureOfTypeAndRole(model.FeatureTypeTypeDeviceClassification, model.RoleTypeServer)
 	if feature == nil {
-		return errNoLocalEntity
+		return errNoManufacturerData
 	}
 
 	data, ok := feature.DataCopy(model.FunctionTypeDeviceClassificationManufacturerData).(*model.DeviceClassificationManufacturerDataType)
 	if !ok || data == nil {
-		return fmt.Errorf("local manufacturer data unavailable")
+		return errNoManufacturerData
 	}
 	name := model.DeviceClassificationStringType(vendor)
 	data.VendorName = &name

--- a/eebus-bridge/internal/eebus/announcement.go
+++ b/eebus-bridge/internal/eebus/announcement.go
@@ -1,0 +1,85 @@
+package eebus
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/enbility/eebus-go/features/server"
+	"github.com/enbility/spine-go/model"
+)
+
+var errNoLocalEntity = errors.New("local entity not available")
+
+// AnnounceLocalIdentity fills the two gaps spine-go leaves in the local device's
+// SPINE announcement. Call it after BridgeService.Setup (which creates the local
+// device) and before Start, so the data is in place before the first remote reads
+// it.
+//
+// vendor is the display name for deviceClassificationManufacturerData. Passing an
+// empty string keeps whatever spine-go derived from the brand.
+func (b *BridgeService) AnnounceLocalIdentity(vendor string) error {
+	if err := b.SetOperatingState(model.DeviceDiagnosisOperatingStateTypeNormalOperation); err != nil {
+		return err
+	}
+	return b.setVendorName(vendor)
+}
+
+// SetOperatingState publishes the local entity's DeviceDiagnosis operating state.
+//
+// spine-go creates the DeviceDiagnosis server feature for the heartbeat but never
+// publishes deviceDiagnosisStateData, so a remote reading our operating state got
+// an empty response. The state lives on the CEM entity — the functional one, the
+// same place a Vaillant gateway puts it on its HeatPumpAppliance entity — not on
+// the DeviceInformation entity.
+func (b *BridgeService) SetOperatingState(state model.DeviceDiagnosisOperatingStateType) error {
+	entity := b.LocalEntity()
+	if entity == nil {
+		return errNoLocalEntity
+	}
+
+	// GetOrAddFeature and AddFunctionType are both idempotent, so this stays
+	// correct when the heartbeat manager has already created the feature.
+	feature := entity.GetOrAddFeature(model.FeatureTypeTypeDeviceDiagnosis, model.RoleTypeServer)
+	feature.AddFunctionType(model.FunctionTypeDeviceDiagnosisStateData, true, false)
+
+	diagnosis, err := server.NewDeviceDiagnosis(entity)
+	if err != nil {
+		return fmt.Errorf("creating local device diagnosis: %w", err)
+	}
+	diagnosis.SetLocalOperatingState(state)
+	return nil
+}
+
+// setVendorName corrects the vendor name in deviceClassificationManufacturerData.
+//
+// spine-go fills both BrandName and VendorName from the brand it was constructed
+// with (spine/device_local.go), so the configured eebus.vendor never reached the
+// wire and the bridge announced its brand twice. Everything else in the payload
+// stays as spine-go built it.
+func (b *BridgeService) setVendorName(vendor string) error {
+	if vendor == "" {
+		return nil
+	}
+
+	device := b.service.LocalDevice()
+	if device == nil {
+		return errNoLocalEntity
+	}
+	entity := device.EntityForType(model.EntityTypeTypeDeviceInformation)
+	if entity == nil {
+		return errNoLocalEntity
+	}
+	feature := entity.FeatureOfTypeAndRole(model.FeatureTypeTypeDeviceClassification, model.RoleTypeServer)
+	if feature == nil {
+		return errNoLocalEntity
+	}
+
+	data, ok := feature.DataCopy(model.FunctionTypeDeviceClassificationManufacturerData).(*model.DeviceClassificationManufacturerDataType)
+	if !ok || data == nil {
+		return fmt.Errorf("local manufacturer data unavailable")
+	}
+	name := model.DeviceClassificationStringType(vendor)
+	data.VendorName = &name
+	feature.SetData(model.FunctionTypeDeviceClassificationManufacturerData, data)
+	return nil
+}

--- a/eebus-bridge/internal/eebus/announcement_test.go
+++ b/eebus-bridge/internal/eebus/announcement_test.go
@@ -1,9 +1,12 @@
 package eebus
 
 import (
+	"errors"
+	"strings"
 	"testing"
 
 	shipcert "github.com/enbility/ship-go/cert"
+	"github.com/enbility/spine-go/mocks"
 	"github.com/enbility/spine-go/model"
 	"github.com/volschin/eebus-bridge/internal/config"
 )
@@ -142,4 +145,59 @@ func manufacturerData(t *testing.T, bridge *BridgeService) *model.DeviceClassifi
 		t.Fatal("manufacturer data unavailable")
 	}
 	return data
+}
+
+// TestSetLocalOperatingStateFailurePaths covers the guards that a running service
+// never hits: a missing entity, an entity that yields no feature, and the
+// eebus-go constructor failing because the feature is not resolvable.
+func TestSetLocalOperatingStateFailurePaths(t *testing.T) {
+	state := model.DeviceDiagnosisOperatingStateTypeNormalOperation
+
+	if err := setLocalOperatingState(nil, state); !errors.Is(err, errNoLocalEntity) {
+		t.Fatalf("nil entity: err = %v, want %v", err, errNoLocalEntity)
+	}
+
+	noFeature := mocks.NewEntityLocalInterface(t)
+	noFeature.On("GetOrAddFeature", model.FeatureTypeTypeDeviceDiagnosis, model.RoleTypeServer).
+		Return(nil).Once()
+	if err := setLocalOperatingState(noFeature, state); !errors.Is(err, errNoLocalEntity) {
+		t.Fatalf("nil feature: err = %v, want %v", err, errNoLocalEntity)
+	}
+
+	feature := mocks.NewFeatureLocalInterface(t)
+	feature.On("AddFunctionType", model.FunctionTypeDeviceDiagnosisStateData, true, false).Once()
+	unresolvable := mocks.NewEntityLocalInterface(t)
+	unresolvable.On("GetOrAddFeature", model.FeatureTypeTypeDeviceDiagnosis, model.RoleTypeServer).
+		Return(feature).Once()
+	unresolvable.On("Device").Return(nil).Once()
+	unresolvable.On("FeatureOfTypeAndRole", model.FeatureTypeTypeDeviceDiagnosis, model.RoleTypeServer).
+		Return(nil).Once()
+	err := setLocalOperatingState(unresolvable, state)
+	if err == nil || !strings.Contains(err.Error(), "creating local device diagnosis") {
+		t.Fatalf("unresolvable feature: err = %v", err)
+	}
+}
+
+// TestSetLocalVendorNameFailurePaths covers the same class of guards for the
+// manufacturer-data rewrite.
+func TestSetLocalVendorNameFailurePaths(t *testing.T) {
+	if err := setLocalVendorName(nil, "vendor"); !errors.Is(err, errNoLocalEntity) {
+		t.Fatalf("nil entity: err = %v, want %v", err, errNoLocalEntity)
+	}
+
+	noFeature := mocks.NewEntityLocalInterface(t)
+	noFeature.On("FeatureOfTypeAndRole", model.FeatureTypeTypeDeviceClassification, model.RoleTypeServer).
+		Return(nil).Once()
+	if err := setLocalVendorName(noFeature, "vendor"); !errors.Is(err, errNoManufacturerData) {
+		t.Fatalf("nil feature: err = %v, want %v", err, errNoManufacturerData)
+	}
+
+	feature := mocks.NewFeatureLocalInterface(t)
+	feature.On("DataCopy", model.FunctionTypeDeviceClassificationManufacturerData).Return(nil).Once()
+	noData := mocks.NewEntityLocalInterface(t)
+	noData.On("FeatureOfTypeAndRole", model.FeatureTypeTypeDeviceClassification, model.RoleTypeServer).
+		Return(feature).Once()
+	if err := setLocalVendorName(noData, "vendor"); !errors.Is(err, errNoManufacturerData) {
+		t.Fatalf("missing manufacturer data: err = %v, want %v", err, errNoManufacturerData)
+	}
 }

--- a/eebus-bridge/internal/eebus/announcement_test.go
+++ b/eebus-bridge/internal/eebus/announcement_test.go
@@ -1,0 +1,145 @@
+package eebus
+
+import (
+	"testing"
+
+	shipcert "github.com/enbility/ship-go/cert"
+	"github.com/enbility/spine-go/model"
+	"github.com/volschin/eebus-bridge/internal/config"
+)
+
+// newAnnouncementBridge builds a real, set-up bridge service so the assertions run
+// against the data spine-go actually holds for the local device.
+func newAnnouncementBridge(t *testing.T, vendor string, port int) *BridgeService {
+	t.Helper()
+
+	certificate, err := shipcert.CreateCertificate("test", "test", "DE", "announcement")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.Config{
+		EEBUS: config.EEBUSConfig{
+			Port:   port,
+			Vendor: vendor,
+			Brand:  "test-brand",
+			Model:  "test-model",
+			Serial: "announcement",
+		},
+	}
+	bridge, err := NewBridgeService(cfg, certificate, NewEventBus())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := bridge.Setup(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(bridge.Shutdown)
+	return bridge
+}
+
+func TestAnnounceLocalIdentityPublishesOperatingState(t *testing.T) {
+	bridge := newAnnouncementBridge(t, "test-vendor", 49881)
+
+	if err := bridge.AnnounceLocalIdentity("test-vendor"); err != nil {
+		t.Fatalf("AnnounceLocalIdentity: %v", err)
+	}
+
+	feature := bridge.LocalEntity().FeatureOfTypeAndRole(
+		model.FeatureTypeTypeDeviceDiagnosis, model.RoleTypeServer)
+	if feature == nil {
+		t.Fatal("local entity has no DeviceDiagnosis server feature")
+	}
+	if operations := feature.Operations()[model.FunctionTypeDeviceDiagnosisStateData]; operations == nil ||
+		!operations.Read() {
+		t.Fatal("deviceDiagnosisStateData is not announced as readable")
+	}
+	data, ok := feature.DataCopy(model.FunctionTypeDeviceDiagnosisStateData).(*model.DeviceDiagnosisStateDataType)
+	if !ok || data == nil || data.OperatingState == nil {
+		t.Fatalf("operating state not published: %#v", data)
+	}
+	if *data.OperatingState != model.DeviceDiagnosisOperatingStateTypeNormalOperation {
+		t.Fatalf("operating state = %s, want %s",
+			*data.OperatingState, model.DeviceDiagnosisOperatingStateTypeNormalOperation)
+	}
+}
+
+func TestAnnounceLocalIdentitySetsVendorName(t *testing.T) {
+	bridge := newAnnouncementBridge(t, "test-vendor", 49882)
+
+	if err := bridge.AnnounceLocalIdentity("test-vendor"); err != nil {
+		t.Fatalf("AnnounceLocalIdentity: %v", err)
+	}
+
+	data := manufacturerData(t, bridge)
+	if data.VendorName == nil || string(*data.VendorName) != "test-vendor" {
+		t.Fatalf("vendor name = %v, want test-vendor", data.VendorName)
+	}
+	// The rest of the payload must survive the rewrite.
+	if data.BrandName == nil || string(*data.BrandName) != "test-brand" {
+		t.Fatalf("brand name = %v, want test-brand", data.BrandName)
+	}
+	if data.SerialNumber == nil || string(*data.SerialNumber) != "announcement" {
+		t.Fatalf("serial number = %v, want announcement", data.SerialNumber)
+	}
+}
+
+// TestAnnounceLocalIdentityKeepsBrandVendorWithoutConfig covers the empty-vendor
+// argument: spine-go's brand-derived vendor name stays untouched. (eebus-go
+// rejects an empty vendorCode at construction, so this is the defensive path, not
+// a reachable configuration.)
+func TestAnnounceLocalIdentityKeepsBrandVendorWithoutConfig(t *testing.T) {
+	bridge := newAnnouncementBridge(t, "test-vendor", 49883)
+
+	if err := bridge.AnnounceLocalIdentity(""); err != nil {
+		t.Fatalf("AnnounceLocalIdentity: %v", err)
+	}
+
+	data := manufacturerData(t, bridge)
+	if data.VendorName == nil || string(*data.VendorName) != "test-brand" {
+		t.Fatalf("vendor name = %v, want the brand-derived test-brand", data.VendorName)
+	}
+}
+
+// TestSetOperatingStateIsIdempotent covers the second call: the feature and its
+// function type already exist, and the state is simply overwritten. This is the
+// path a later failure/standby transition would take.
+func TestSetOperatingStateIsIdempotent(t *testing.T) {
+	bridge := newAnnouncementBridge(t, "test-vendor", 49884)
+
+	if err := bridge.SetOperatingState(model.DeviceDiagnosisOperatingStateTypeNormalOperation); err != nil {
+		t.Fatalf("first SetOperatingState: %v", err)
+	}
+	if err := bridge.SetOperatingState(model.DeviceDiagnosisOperatingStateTypeFailure); err != nil {
+		t.Fatalf("second SetOperatingState: %v", err)
+	}
+
+	feature := bridge.LocalEntity().FeatureOfTypeAndRole(
+		model.FeatureTypeTypeDeviceDiagnosis, model.RoleTypeServer)
+	data, ok := feature.DataCopy(model.FunctionTypeDeviceDiagnosisStateData).(*model.DeviceDiagnosisStateDataType)
+	if !ok || data == nil || data.OperatingState == nil {
+		t.Fatalf("operating state not published: %#v", data)
+	}
+	if *data.OperatingState != model.DeviceDiagnosisOperatingStateTypeFailure {
+		t.Fatalf("operating state = %s, want %s",
+			*data.OperatingState, model.DeviceDiagnosisOperatingStateTypeFailure)
+	}
+}
+
+func manufacturerData(t *testing.T, bridge *BridgeService) *model.DeviceClassificationManufacturerDataType {
+	t.Helper()
+
+	entity := bridge.Service().LocalDevice().EntityForType(model.EntityTypeTypeDeviceInformation)
+	if entity == nil {
+		t.Fatal("local device has no DeviceInformation entity")
+	}
+	feature := entity.FeatureOfTypeAndRole(model.FeatureTypeTypeDeviceClassification, model.RoleTypeServer)
+	if feature == nil {
+		t.Fatal("DeviceInformation entity has no DeviceClassification server feature")
+	}
+	data, ok := feature.DataCopy(
+		model.FunctionTypeDeviceClassificationManufacturerData).(*model.DeviceClassificationManufacturerDataType)
+	if !ok || data == nil {
+		t.Fatal("manufacturer data unavailable")
+	}
+	return data
+}

--- a/eebus-bridge/internal/usecases/mgcp.go
+++ b/eebus-bridge/internal/usecases/mgcp.go
@@ -234,13 +234,12 @@ func (p *MGCPProvider) PublishGridSnapshot(snapshot GridSnapshot) error {
 		return err
 	}
 	next := snapshot.clone()
-	if err := p.snapshots.commit(next, snapshot.Validity.ValidUntil, func(version uint64) {
-		p.expireGridSnapshot(version, time.Now())
-	}); err != nil {
-		return err
-	}
+	// Announced before the commit: the measurements are already on the wire, and
+	// Close holds the same publish mutex, so this cannot outlive the provider.
 	p.available.set(true)
-	return nil
+	return p.snapshots.commit(next, snapshot.Validity.ValidUntil, func(version uint64) {
+		p.expireGridSnapshot(version, time.Now())
+	})
 }
 
 func (p *MGCPProvider) CurrentGridSnapshot(now time.Time) (GridSnapshot, bool) {

--- a/eebus-bridge/internal/usecases/mgcp.go
+++ b/eebus-bridge/internal/usecases/mgcp.go
@@ -59,6 +59,7 @@ type MGCPProvider struct {
 
 	publishMu sync.Mutex
 	snapshots providerSnapshotStore[GridSnapshot]
+	available providerAvailability
 }
 
 // NewMGCPProvider builds the provider on the given local grid-connection-point
@@ -96,7 +97,16 @@ func NewMGCPProvider(gridEntity spineapi.EntityLocalInterface, bus *eebus.EventB
 		validEntityTypes,
 		false,
 	)
+	p.available.bind(p.UpdateUseCaseAvailability)
 	return p
+}
+
+// AddUseCase announces the use case and immediately marks it unavailable:
+// eebus-go's AddUseCase hardcodes available=true, but the bridge has nothing to
+// serve until Home Assistant delivers a first sample.
+func (p *MGCPProvider) AddUseCase() {
+	p.UseCaseBase.AddUseCase()
+	p.available.set(false)
 }
 
 // UseCase returns the provider for registration via Service.AddUseCase, which calls
@@ -217,15 +227,20 @@ func (p *MGCPProvider) PublishGridSnapshot(snapshot GridSnapshot) error {
 		if err := p.invalidateGridMeasurements(); err != nil {
 			return err
 		}
+		p.available.set(false)
 		return p.snapshots.invalidate()
 	}
 	if err := p.publishGridMeasurements(snapshot); err != nil {
 		return err
 	}
 	next := snapshot.clone()
-	return p.snapshots.commit(next, snapshot.Validity.ValidUntil, func(version uint64) {
+	if err := p.snapshots.commit(next, snapshot.Validity.ValidUntil, func(version uint64) {
 		p.expireGridSnapshot(version, time.Now())
-	})
+	}); err != nil {
+		return err
+	}
+	p.available.set(true)
+	return nil
 }
 
 func (p *MGCPProvider) CurrentGridSnapshot(now time.Time) (GridSnapshot, bool) {
@@ -251,6 +266,7 @@ func (p *MGCPProvider) expireGridSnapshot(version uint64, now time.Time) {
 		return
 	}
 	p.snapshots.clearExpired(version)
+	p.available.set(false)
 }
 
 // Close stops sample expiry and prevents every later EEBUS write. It is safe
@@ -259,6 +275,7 @@ func (p *MGCPProvider) Close() error {
 	p.publishMu.Lock()
 	defer p.publishMu.Unlock()
 	p.snapshots.close()
+	p.available.set(false)
 	return nil
 }
 

--- a/eebus-bridge/internal/usecases/provider_availability.go
+++ b/eebus-bridge/internal/usecases/provider_availability.go
@@ -1,0 +1,53 @@
+package usecases
+
+import "sync"
+
+// providerAvailability mirrors a provider's data state into the advertised
+// `useCaseAvailable` flag of nodeManagementUseCaseData.
+//
+// The bridge's provider use cases (MGCP, VAPD, VABD) serve data that originates in
+// Home Assistant. Announcing them permanently as available is wrong whenever that
+// source has not delivered yet, has expired, or the provider was closed: a consumer
+// would bind and read empty measurements instead of skipping the use case.
+//
+// eebus-go documents UpdateUseCaseAvailability as client-side only and points
+// server-side implementations at RemoveUseCase/AddUseCase instead. The bridge
+// deliberately uses the availability flag anyway: removing and re-adding a use case
+// re-announces the whole use-case map and drops the consumer's bindings and
+// subscriptions, which would churn on every sample gap. Flipping availability is
+// exactly what the flag is specified for and leaves the features in place.
+//
+// Transitions are deduplicated, so a provider publishing every few seconds emits a
+// single notification when its state actually changes.
+type providerAvailability struct {
+	mu        sync.Mutex
+	update    func(bool)
+	known     bool
+	available bool
+}
+
+// bind installs the use case's availability setter. Providers call this once their
+// embedded UseCaseBase exists.
+func (a *providerAvailability) bind(update func(bool)) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.update = update
+}
+
+// set announces available when it differs from the last announced value. Safe
+// before bind: the state is remembered but nothing is announced.
+func (a *providerAvailability) set(available bool) {
+	a.mu.Lock()
+	if a.known && a.available == available {
+		a.mu.Unlock()
+		return
+	}
+	a.known = true
+	a.available = available
+	update := a.update
+	a.mu.Unlock()
+
+	if update != nil {
+		update(available)
+	}
+}

--- a/eebus-bridge/internal/usecases/provider_availability_test.go
+++ b/eebus-bridge/internal/usecases/provider_availability_test.go
@@ -102,10 +102,138 @@ func TestProviderAvailabilityFollowsSampleLifecycle(t *testing.T) {
 	}
 }
 
+// TestVisualizationProviderAvailabilityFollowsSampleLifecycle is the VAPD/VABD
+// half of the lifecycle assertion: both providers announce, publish and expire
+// through the same helper, so the flag has to follow for each of them.
+func TestVisualizationProviderAvailabilityFollowsSampleLifecycle(t *testing.T) {
+	certificate, err := shipcert.CreateCertificate("test", "test", "DE", "provider-availability-vis")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.Config{
+		EEBUS: config.EEBUSConfig{
+			Port: 49878, Vendor: "Test", Brand: "Test", Model: "Test", Serial: "provider-availability-vis",
+		},
+		Experimental: config.ExperimentalConfig{VAPDProvider: true, VABDProvider: true},
+	}
+	bridge, err := eebus.NewBridgeService(cfg, certificate, eebus.NewEventBus())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := bridge.Setup(); err != nil {
+		t.Fatal(err)
+	}
+	defer bridge.Shutdown()
+
+	now := time.Now()
+	validity := ProviderValidity{ObservedAt: now, ValidUntil: now.Add(time.Minute)}
+
+	vapd := NewVAPDProvider(bridge.PVEntity(), nil, false)
+	if err := vapd.AddFeatures(); err != nil {
+		t.Fatalf("VAPD AddFeatures: %v", err)
+	}
+	vapd.AddUseCase()
+	if announcedAvailability(t, bridge, model.UseCaseNameTypeVisualizationOfAggregatedPhotovoltaicData) {
+		t.Fatal("VAPD announced as available before the first sample")
+	}
+	if err := vapd.PublishPVSnapshot(PVSnapshot{PowerW: 500, Validity: validity}); err != nil {
+		t.Fatalf("PublishPVSnapshot: %v", err)
+	}
+	if !announcedAvailability(t, bridge, model.UseCaseNameTypeVisualizationOfAggregatedPhotovoltaicData) {
+		t.Fatal("VAPD still unavailable after a current sample")
+	}
+	vapd.expirePVSnapshot(vapd.snapshots.snapshotVersion(), now.Add(2*time.Minute))
+	if announcedAvailability(t, bridge, model.UseCaseNameTypeVisualizationOfAggregatedPhotovoltaicData) {
+		t.Fatal("VAPD still available after the sample expired")
+	}
+
+	vabd := NewVABDProvider(bridge.BatteryEntity(), nil, false)
+	if err := vabd.AddFeatures(); err != nil {
+		t.Fatalf("VABD AddFeatures: %v", err)
+	}
+	vabd.AddUseCase()
+	if announcedAvailability(t, bridge, model.UseCaseNameTypeVisualizationOfAggregatedBatteryData) {
+		t.Fatal("VABD announced as available before the first sample")
+	}
+	if err := vabd.PublishBatterySnapshot(BatterySnapshot{PowerW: -300, Validity: validity}); err != nil {
+		t.Fatalf("PublishBatterySnapshot: %v", err)
+	}
+	if !announcedAvailability(t, bridge, model.UseCaseNameTypeVisualizationOfAggregatedBatteryData) {
+		t.Fatal("VABD still unavailable after a current sample")
+	}
+	if err := vabd.Close(); err != nil {
+		t.Fatalf("VABD Close: %v", err)
+	}
+	if announcedAvailability(t, bridge, model.UseCaseNameTypeVisualizationOfAggregatedBatteryData) {
+		t.Fatal("VABD still available after the provider was closed")
+	}
+}
+
+// TestProviderAvailabilityFollowsInvalidatedSample covers the third path into
+// unavailable: Home Assistant reporting the source as invalid rather than the
+// sample ageing out.
+func TestProviderAvailabilityFollowsInvalidatedSample(t *testing.T) {
+	certificate, err := shipcert.CreateCertificate("test", "test", "DE", "provider-availability-invalid")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.Config{
+		EEBUS: config.EEBUSConfig{
+			Port: 49879, Vendor: "Test", Brand: "Test", Model: "Test", Serial: "provider-availability-invalid",
+		},
+		Experimental: config.ExperimentalConfig{MGCPProvider: true},
+	}
+	bridge, err := eebus.NewBridgeService(cfg, certificate, eebus.NewEventBus())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := bridge.Setup(); err != nil {
+		t.Fatal(err)
+	}
+	defer bridge.Shutdown()
+
+	provider := NewMGCPProvider(bridge.GridEntity(), nil, false)
+	if err := provider.AddFeatures(); err != nil {
+		t.Fatalf("AddFeatures: %v", err)
+	}
+	provider.AddUseCase()
+
+	now := time.Now()
+	err = provider.PublishGridSnapshot(GridSnapshot{
+		PowerW:   42,
+		Validity: ProviderValidity{ObservedAt: now, ValidUntil: now.Add(time.Minute)},
+	})
+	if err != nil {
+		t.Fatalf("PublishGridSnapshot: %v", err)
+	}
+	if !announcedMGCPAvailability(t, bridge) {
+		t.Fatal("still unavailable after a current sample")
+	}
+
+	err = provider.PublishGridSnapshot(GridSnapshot{Validity: ProviderValidity{Invalid: true}})
+	if err != nil {
+		t.Fatalf("PublishGridSnapshot (invalid): %v", err)
+	}
+	if announcedMGCPAvailability(t, bridge) {
+		t.Fatal("still available after the source was reported invalid")
+	}
+}
+
 // announcedMGCPAvailability reads the useCaseAvailable flag the bridge actually
 // puts on the wire, i.e. from nodeManagementUseCaseData rather than from provider
 // state.
 func announcedMGCPAvailability(t *testing.T, bridge *eebus.BridgeService) bool {
+	t.Helper()
+	return announcedAvailability(t, bridge, model.UseCaseNameTypeMonitoringOfGridConnectionPoint)
+}
+
+// announcedAvailability reads the useCaseAvailable flag for one use case out of
+// nodeManagementUseCaseData, i.e. the value a consumer actually sees.
+func announcedAvailability(
+	t *testing.T,
+	bridge *eebus.BridgeService,
+	useCase model.UseCaseNameType,
+) bool {
 	t.Helper()
 
 	nodeManagement := bridge.Service().LocalDevice().NodeManagement()
@@ -118,13 +246,12 @@ func announcedMGCPAvailability(t *testing.T, bridge *eebus.BridgeService) bool {
 	}
 	for _, information := range data.UseCaseInformation {
 		for _, support := range information.UseCaseSupport {
-			if support.UseCaseName == nil ||
-				*support.UseCaseName != model.UseCaseNameTypeMonitoringOfGridConnectionPoint {
+			if support.UseCaseName == nil || *support.UseCaseName != useCase {
 				continue
 			}
 			return support.UseCaseAvailable != nil && *support.UseCaseAvailable
 		}
 	}
-	t.Fatal("MGCP use case is not announced at all")
+	t.Fatalf("use case %s is not announced at all", useCase)
 	return false
 }

--- a/eebus-bridge/internal/usecases/provider_availability_test.go
+++ b/eebus-bridge/internal/usecases/provider_availability_test.go
@@ -161,6 +161,36 @@ func TestVisualizationProviderAvailabilityFollowsSampleLifecycle(t *testing.T) {
 	if !announcedAvailability(t, bridge, model.UseCaseNameTypeVisualizationOfAggregatedBatteryData) {
 		t.Fatal("VABD still unavailable after a current sample")
 	}
+	vabd.expireBatterySnapshot(vabd.snapshots.snapshotVersion(), now.Add(2*time.Minute))
+	if announcedAvailability(t, bridge, model.UseCaseNameTypeVisualizationOfAggregatedBatteryData) {
+		t.Fatal("VABD still available after the sample expired")
+	}
+
+	// Both providers must also follow an explicitly invalidated source, and VABD
+	// must end up unavailable once closed.
+	if err := vapd.PublishPVSnapshot(PVSnapshot{PowerW: 500, Validity: validity}); err != nil {
+		t.Fatalf("PublishPVSnapshot: %v", err)
+	}
+	if err := vapd.PublishPVSnapshot(PVSnapshot{Validity: ProviderValidity{Invalid: true}}); err != nil {
+		t.Fatalf("PublishPVSnapshot (invalid): %v", err)
+	}
+	if announcedAvailability(t, bridge, model.UseCaseNameTypeVisualizationOfAggregatedPhotovoltaicData) {
+		t.Fatal("VAPD still available after the source was reported invalid")
+	}
+
+	if err := vabd.PublishBatterySnapshot(BatterySnapshot{PowerW: -300, Validity: validity}); err != nil {
+		t.Fatalf("PublishBatterySnapshot: %v", err)
+	}
+	if err := vabd.PublishBatterySnapshot(BatterySnapshot{Validity: ProviderValidity{Invalid: true}}); err != nil {
+		t.Fatalf("PublishBatterySnapshot (invalid): %v", err)
+	}
+	if announcedAvailability(t, bridge, model.UseCaseNameTypeVisualizationOfAggregatedBatteryData) {
+		t.Fatal("VABD still available after the source was reported invalid")
+	}
+
+	if err := vabd.PublishBatterySnapshot(BatterySnapshot{PowerW: -300, Validity: validity}); err != nil {
+		t.Fatalf("PublishBatterySnapshot: %v", err)
+	}
 	if err := vabd.Close(); err != nil {
 		t.Fatalf("VABD Close: %v", err)
 	}

--- a/eebus-bridge/internal/usecases/provider_availability_test.go
+++ b/eebus-bridge/internal/usecases/provider_availability_test.go
@@ -1,0 +1,130 @@
+package usecases
+
+import (
+	"testing"
+	"time"
+
+	shipcert "github.com/enbility/ship-go/cert"
+	"github.com/enbility/spine-go/model"
+	"github.com/volschin/eebus-bridge/internal/config"
+	"github.com/volschin/eebus-bridge/internal/eebus"
+)
+
+// TestProviderAvailabilityAnnouncesOnlyChanges pins the deduplication: a provider
+// publishing every few seconds must not emit a notification per sample.
+func TestProviderAvailabilityAnnouncesOnlyChanges(t *testing.T) {
+	var announced []bool
+	var availability providerAvailability
+	availability.bind(func(available bool) { announced = append(announced, available) })
+
+	availability.set(false)
+	availability.set(false)
+	availability.set(true)
+	availability.set(true)
+	availability.set(false)
+
+	want := []bool{false, true, false}
+	if len(announced) != len(want) {
+		t.Fatalf("announced %v, want %v", announced, want)
+	}
+	for i, value := range want {
+		if announced[i] != value {
+			t.Fatalf("announced %v, want %v", announced, want)
+		}
+	}
+}
+
+// TestProviderAvailabilityBeforeBind covers the constructor window: state set
+// before a setter exists is remembered, not announced, and does not swallow the
+// first real announcement of the opposite value.
+func TestProviderAvailabilityBeforeBind(t *testing.T) {
+	var availability providerAvailability
+	availability.set(true)
+
+	var announced []bool
+	availability.bind(func(available bool) { announced = append(announced, available) })
+	availability.set(true)
+	if len(announced) != 0 {
+		t.Fatalf("announced %v for an unchanged value, want none", announced)
+	}
+	availability.set(false)
+	if len(announced) != 1 || announced[0] {
+		t.Fatalf("announced %v, want [false]", announced)
+	}
+}
+
+// TestProviderAvailabilityFollowsSampleLifecycle drives a real MGCP provider on a
+// real local entity through announce -> sample -> expiry and asserts the announced
+// useCaseAvailable flag follows, since that is what a consumer reads.
+func TestProviderAvailabilityFollowsSampleLifecycle(t *testing.T) {
+	certificate, err := shipcert.CreateCertificate("test", "test", "DE", "provider-availability")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.Config{
+		EEBUS:        config.EEBUSConfig{Port: 49877, Vendor: "Test", Brand: "Test", Model: "Test", Serial: "provider-availability"},
+		Experimental: config.ExperimentalConfig{MGCPProvider: true},
+	}
+	bridge, err := eebus.NewBridgeService(cfg, certificate, eebus.NewEventBus())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := bridge.Setup(); err != nil {
+		t.Fatal(err)
+	}
+	defer bridge.Shutdown()
+
+	provider := NewMGCPProvider(bridge.GridEntity(), nil, false)
+	if err := provider.AddFeatures(); err != nil {
+		t.Fatalf("AddFeatures: %v", err)
+	}
+	provider.AddUseCase()
+
+	if available := announcedMGCPAvailability(t, bridge); available {
+		t.Fatal("use case announced as available before the first sample")
+	}
+
+	now := time.Now()
+	err = provider.PublishGridSnapshot(GridSnapshot{
+		PowerW:   1234,
+		Validity: ProviderValidity{ObservedAt: now, ValidUntil: now.Add(time.Minute)},
+	})
+	if err != nil {
+		t.Fatalf("PublishGridSnapshot: %v", err)
+	}
+	if available := announcedMGCPAvailability(t, bridge); !available {
+		t.Fatal("use case still announced as unavailable after a current sample")
+	}
+
+	provider.expireGridSnapshot(provider.snapshots.snapshotVersion(), now.Add(2*time.Minute))
+	if available := announcedMGCPAvailability(t, bridge); available {
+		t.Fatal("use case still announced as available after the sample expired")
+	}
+}
+
+// announcedMGCPAvailability reads the useCaseAvailable flag the bridge actually
+// puts on the wire, i.e. from nodeManagementUseCaseData rather than from provider
+// state.
+func announcedMGCPAvailability(t *testing.T, bridge *eebus.BridgeService) bool {
+	t.Helper()
+
+	nodeManagement := bridge.Service().LocalDevice().NodeManagement()
+	if nodeManagement == nil {
+		t.Fatal("local device has no node management feature")
+	}
+	data, ok := nodeManagement.DataCopy(model.FunctionTypeNodeManagementUseCaseData).(*model.NodeManagementUseCaseDataType)
+	if !ok || data == nil {
+		t.Fatal("node management use case data unavailable")
+	}
+	for _, information := range data.UseCaseInformation {
+		for _, support := range information.UseCaseSupport {
+			if support.UseCaseName == nil ||
+				*support.UseCaseName != model.UseCaseNameTypeMonitoringOfGridConnectionPoint {
+				continue
+			}
+			return support.UseCaseAvailable != nil && *support.UseCaseAvailable
+		}
+	}
+	t.Fatal("MGCP use case is not announced at all")
+	return false
+}

--- a/eebus-bridge/internal/usecases/vabd.go
+++ b/eebus-bridge/internal/usecases/vabd.go
@@ -244,13 +244,12 @@ func (p *VABDProvider) PublishBatterySnapshot(snapshot BatterySnapshot) error {
 		return err
 	}
 	next := snapshot.clone()
-	if err := p.snapshots.commit(next, snapshot.Validity.ValidUntil, func(version uint64) {
-		p.expireBatterySnapshot(version, time.Now())
-	}); err != nil {
-		return err
-	}
+	// Announced before the commit: the measurements are already on the wire, and
+	// Close holds the same publish mutex, so this cannot outlive the provider.
 	p.available.set(true)
-	return nil
+	return p.snapshots.commit(next, snapshot.Validity.ValidUntil, func(version uint64) {
+		p.expireBatterySnapshot(version, time.Now())
+	})
 }
 
 func (p *VABDProvider) CurrentBatterySnapshot(now time.Time) (BatterySnapshot, bool) {

--- a/eebus-bridge/internal/usecases/vabd.go
+++ b/eebus-bridge/internal/usecases/vabd.go
@@ -61,6 +61,7 @@ type VABDProvider struct {
 
 	publishMu sync.Mutex
 	snapshots providerSnapshotStore[BatterySnapshot]
+	available providerAvailability
 }
 
 // NewVABDProvider builds the provider on the given local battery-system entity
@@ -98,7 +99,16 @@ func NewVABDProvider(batteryEntity spineapi.EntityLocalInterface, bus *eebus.Eve
 		validEntityTypes,
 		false,
 	)
+	p.available.bind(p.UpdateUseCaseAvailability)
 	return p
+}
+
+// AddUseCase announces the use case and immediately marks it unavailable:
+// eebus-go's AddUseCase hardcodes available=true, but the bridge has nothing to
+// serve until Home Assistant delivers a first sample.
+func (p *VABDProvider) AddUseCase() {
+	p.UseCaseBase.AddUseCase()
+	p.available.set(false)
 }
 
 // UseCase returns the provider for registration via Service.AddUseCase, which calls
@@ -227,15 +237,20 @@ func (p *VABDProvider) PublishBatterySnapshot(snapshot BatterySnapshot) error {
 		if err := p.invalidateBatteryMeasurements(); err != nil {
 			return err
 		}
+		p.available.set(false)
 		return p.snapshots.invalidate()
 	}
 	if err := p.publishBatteryMeasurements(snapshot); err != nil {
 		return err
 	}
 	next := snapshot.clone()
-	return p.snapshots.commit(next, snapshot.Validity.ValidUntil, func(version uint64) {
+	if err := p.snapshots.commit(next, snapshot.Validity.ValidUntil, func(version uint64) {
 		p.expireBatterySnapshot(version, time.Now())
-	})
+	}); err != nil {
+		return err
+	}
+	p.available.set(true)
+	return nil
 }
 
 func (p *VABDProvider) CurrentBatterySnapshot(now time.Time) (BatterySnapshot, bool) {
@@ -261,6 +276,7 @@ func (p *VABDProvider) expireBatterySnapshot(version uint64, now time.Time) {
 		return
 	}
 	p.snapshots.clearExpired(version)
+	p.available.set(false)
 }
 
 // Close stops sample expiry and prevents every later EEBUS write.
@@ -268,6 +284,7 @@ func (p *VABDProvider) Close() error {
 	p.publishMu.Lock()
 	defer p.publishMu.Unlock()
 	p.snapshots.close()
+	p.available.set(false)
 	return nil
 }
 

--- a/eebus-bridge/internal/usecases/vapd.go
+++ b/eebus-bridge/internal/usecases/vapd.go
@@ -236,13 +236,12 @@ func (p *VAPDProvider) PublishPVSnapshot(snapshot PVSnapshot) error {
 		return err
 	}
 	next := snapshot.clone()
-	if err := p.snapshots.commit(next, snapshot.Validity.ValidUntil, func(version uint64) {
-		p.expirePVSnapshot(version, time.Now())
-	}); err != nil {
-		return err
-	}
+	// Announced before the commit: the measurements are already on the wire, and
+	// Close holds the same publish mutex, so this cannot outlive the provider.
 	p.available.set(true)
-	return nil
+	return p.snapshots.commit(next, snapshot.Validity.ValidUntil, func(version uint64) {
+		p.expirePVSnapshot(version, time.Now())
+	})
 }
 
 func (p *VAPDProvider) CurrentPVSnapshot(now time.Time) (PVSnapshot, bool) {

--- a/eebus-bridge/internal/usecases/vapd.go
+++ b/eebus-bridge/internal/usecases/vapd.go
@@ -59,6 +59,7 @@ type VAPDProvider struct {
 
 	publishMu sync.Mutex
 	snapshots providerSnapshotStore[PVSnapshot]
+	available providerAvailability
 }
 
 // NewVAPDProvider builds the provider on the given local PV-system entity
@@ -95,7 +96,16 @@ func NewVAPDProvider(pvEntity spineapi.EntityLocalInterface, bus *eebus.EventBus
 		validEntityTypes,
 		false,
 	)
+	p.available.bind(p.UpdateUseCaseAvailability)
 	return p
+}
+
+// AddUseCase announces the use case and immediately marks it unavailable:
+// eebus-go's AddUseCase hardcodes available=true, but the bridge has nothing to
+// serve until Home Assistant delivers a first sample.
+func (p *VAPDProvider) AddUseCase() {
+	p.UseCaseBase.AddUseCase()
+	p.available.set(false)
 }
 
 // UseCase returns the provider for registration via Service.AddUseCase, which calls
@@ -219,15 +229,20 @@ func (p *VAPDProvider) PublishPVSnapshot(snapshot PVSnapshot) error {
 		if err := p.invalidatePVMeasurements(); err != nil {
 			return err
 		}
+		p.available.set(false)
 		return p.snapshots.invalidate()
 	}
 	if err := p.publishPVMeasurements(snapshot); err != nil {
 		return err
 	}
 	next := snapshot.clone()
-	return p.snapshots.commit(next, snapshot.Validity.ValidUntil, func(version uint64) {
+	if err := p.snapshots.commit(next, snapshot.Validity.ValidUntil, func(version uint64) {
 		p.expirePVSnapshot(version, time.Now())
-	})
+	}); err != nil {
+		return err
+	}
+	p.available.set(true)
+	return nil
 }
 
 func (p *VAPDProvider) CurrentPVSnapshot(now time.Time) (PVSnapshot, bool) {
@@ -253,6 +268,7 @@ func (p *VAPDProvider) expirePVSnapshot(version uint64, now time.Time) {
 		return
 	}
 	p.snapshots.clearExpired(version)
+	p.available.set(false)
 }
 
 // Close stops sample expiry and prevents every later EEBUS write.
@@ -260,6 +276,7 @@ func (p *VAPDProvider) Close() error {
 	p.publishMu.Lock()
 	defer p.publishMu.Unlock()
 	p.snapshots.close()
+	p.available.set(false)
 	return nil
 }
 


### PR DESCRIPTION
Closes the two spec gaps found while auditing the VR940 function inventory (#159).

## 1. Operating state was never published

`DeviceDiagnosis` carried only the heartbeat. spine-go creates the feature for the heartbeat manager but never publishes `deviceDiagnosisStateData`, so a remote reading our operating state got an empty response.

The bridge now publishes `normalOperation` on the CEM entity right after `Setup`, before `Start` exposes the device — the same place a Vaillant gateway puts it on its `HeatPumpAppliance` entity. `SetOperatingState` is idempotent and takes any state, so a later failure/standby transition is a one-line call.

## 2. Providers announced permanent availability

MGCP, VAPD and VABD serve Home-Assistant-sourced data but advertised `useCaseAvailable=true` unconditionally — a consumer would bind and read empty measurements before the first sample ever arrived.

Availability now follows the sample lifecycle:

| Event | Announced |
|---|---|
| `AddUseCase` (no sample yet) | `false` |
| committed sample | `true` |
| invalidated sample | `false` |
| sample expired | `false` |
| provider closed | `false` |

Transitions are deduplicated, so a provider publishing every few seconds emits one notification per actual change.

**Deviation, deliberate:** eebus-go documents `UpdateUseCaseAvailability` as client-side only and points server implementations at `RemoveUseCase`/`AddUseCase`. Removing and re-adding re-announces the whole use-case map and drops the consumer's bindings and subscriptions — that would churn on every sample gap. Flipping the availability flag is what it is specified for and leaves the features in place.

## 3. Vendor name

spine-go fills both `BrandName` and `VendorName` from the brand (`spine/device_local.go`), so the configured `eebus.vendor` never reached the wire and the bridge announced its brand twice. Corrected after `Setup`; the rest of the manufacturer payload is untouched.

The upstream-correct fix is a spine-go change (a `vendorName` parameter on `NewDeviceLocal`, plus an optional field in eebus-go's `Configuration`). That is **not** done here: it would mean forking spine-go as well, i.e. a second `replace` directive, which works against OPEN-A3. Worth submitting upstream separately.

## Test

- `go vet ./...`, `go test -race ./...` — green
- New tests assert against real local entities and read the announced values back from `nodeManagementUseCaseData` and the feature data, not from provider state: availability lifecycle (announce → sample → expiry), dedup, pre-bind window, operating state incl. readable operation, vendor name incl. payload preservation.

## Hardware check still open

Whether the VR940 re-reads a use case after an availability flip to `true` is not verifiable off-device. Providers are experimental and off by default, so this cannot regress a default install.