### PR TITLE
fix(ohpcf): offer only OHPCF-permitted compressor transitions

### DIFF
--- a/custom_components/eebus/select.py
+++ b/custom_components/eebus/select.py
@@ -18,12 +18,17 @@ from .state import StateField, is_fresh
 PARALLEL_UPDATES = 0  # Coordinator-based, no per-entity polling
 
 # Compressor-flexibility process states that count as "on" (consuming or about to).
-_OHPCF_ON_STATES = {"COMPRESSOR_STATE_RUNNING", "COMPRESSOR_STATE_SCHEDULED"}
+_OHPCF_RUNNING_STATE = "COMPRESSOR_STATE_RUNNING"
+_OHPCF_ON_STATES = {_OHPCF_RUNNING_STATE, "COMPRESSOR_STATE_SCHEDULED"}
 _OHPCF_PAUSED_STATE = "COMPRESSOR_STATE_PAUSED"
 
 OPTION_ON = "on"
 OPTION_PAUSED = "paused"
 OPTION_OFF = "off"
+
+# Canonical display order; the offered subset is filtered out of this tuple so
+# the dropdown never reorders as the process state changes.
+_OPTION_ORDER = (OPTION_ON, OPTION_PAUSED, OPTION_OFF)
 
 
 async def async_setup_entry(
@@ -48,13 +53,13 @@ class EebusCompressorFlexibilitySelect(EebusEntity, SelectEntity):
     paused = pause the running process.
     off    = abort the process (or the implicit state when no offer is running).
 
+    ``options`` is narrowed to the transitions the current process state and its
+    pausable/stoppable constraints actually permit.
+
     This is a primary operational control, so it has no entity category.
     """
 
     _attr_translation_key = "compressor_flexibility"
-    # RUF012: HA declares _attr_options as an instance variable, so annotating it
-    # ClassVar here makes mypy reject the override.
-    _attr_options = [OPTION_ON, OPTION_PAUSED, OPTION_OFF]  # noqa: RUF012
 
     def __init__(self, coordinator: EebusCoordinator) -> None:
         """Initialize."""
@@ -90,6 +95,31 @@ class EebusCompressorFlexibilitySelect(EebusEntity, SelectEntity):
         if state == _OHPCF_PAUSED_STATE:
             return OPTION_PAUSED
         return OPTION_OFF
+
+    @property
+    def options(self) -> list[str]:
+        """Return only the transitions OHPCF permits in the current state.
+
+        OHPCF-022 writes the state of an *existing* power sequence, so a pause
+        needs a running (and pausable) process and an abort needs an active or
+        scheduled (and stoppable) one. Offering the full list regardless would
+        let the dropdown advertise transitions that can only end in an error.
+        The current option always stays in the list, as HA requires.
+        """
+        flex = self._flex()
+        if flex is None:
+            return list(_OPTION_ORDER)
+        allowed = {self.current_option}
+        if flex.state == _OHPCF_PAUSED_STATE or flex.available:
+            allowed.add(OPTION_ON)
+        if flex.state == _OHPCF_RUNNING_STATE and flex.is_pausable:
+            allowed.add(OPTION_PAUSED)
+        if (
+            flex.state in _OHPCF_ON_STATES | {_OHPCF_PAUSED_STATE}
+            and flex.is_stoppable
+        ):
+            allowed.add(OPTION_OFF)
+        return [option for option in _OPTION_ORDER if option in allowed]
 
     @property
     def extra_state_attributes(self) -> dict[str, Any] | None:

--- a/custom_components/eebus/tests/test_ohpcf.py
+++ b/custom_components/eebus/tests/test_ohpcf.py
@@ -107,6 +107,53 @@ def test_select_current_option(raw: str, option: str) -> None:
     assert _select_with(_flex(raw)).current_option == option
 
 
+@pytest.mark.parametrize(
+    ("flex", "expected"),
+    [
+        # An offered but not yet started process: schedule it, nothing to pause or abort.
+        (_flex(), ["on", "off"]),
+        # Running: pausable per the offer, but not stoppable, so no abort.
+        (_flex("COMPRESSOR_STATE_RUNNING"), ["on", "paused"]),
+        (
+            replace(_flex("COMPRESSOR_STATE_RUNNING"), is_stoppable=True),
+            ["on", "paused", "off"],
+        ),
+        # Scheduled: OHPCF-022/2 needs a *running* process, so no pause.
+        (_flex("COMPRESSOR_STATE_SCHEDULED"), ["on"]),
+        (
+            replace(_flex("COMPRESSOR_STATE_SCHEDULED"), is_stoppable=True),
+            ["on", "off"],
+        ),
+        # Paused: resume is always permitted, abort only when stoppable.
+        (_flex("COMPRESSOR_STATE_PAUSED"), ["on", "paused"]),
+        (
+            replace(_flex("COMPRESSOR_STATE_PAUSED"), is_stoppable=True),
+            ["on", "paused", "off"],
+        ),
+        # No offer at all: nothing to schedule, pause or abort.
+        (
+            replace(
+                _flex("COMPRESSOR_STATE_STOPPED"),
+                available=False,
+                is_pausable=False,
+                is_stoppable=False,
+            ),
+            ["off"],
+        ),
+    ],
+)
+def test_select_offers_only_permitted_transitions(
+    flex: CompressorFlexibilityState, expected: list[str]
+) -> None:
+    select = _select_with(flex)
+    assert select.options == expected
+    assert select.current_option in select.options
+
+
+def test_select_options_fall_back_to_all_transitions_without_an_offer() -> None:
+    assert _select_with(None).options == ["on", "paused", "off"]
+
+
 def test_select_is_unavailable_when_retained_offer_is_stale() -> None:
     coordinator = _coordinator(_flex())
     coordinator.data = DeviceState(


### PR DESCRIPTION
## Problem

`select.eebus_compressor_flexibility` advertised a static `[on, paused, off]` no matter what the compressor's optional-consumption process was doing. With the process state `available` (SPINE `inactive` — an offer exists, no power sequence runs), the dropdown still offered `paused`, a transition that can only end in a `ServiceValidationError`.

## Spec

OHPCF-022 writes the state of an **existing** power sequence:

- `022/1` abort → `state = invalid`
- `022/2` pause → `state = paused`
- `022/3` resume → `state = running`

`isPausable` (OHPCF-011/6) and `isStoppable` (OHPCF-011/5) are constraints of the offered process, not a licence to pause an inactive one. Upstream `eebus-go` validates none of this — the preconditions live in `internal/grpc/ohpcf_service.go:200` and were already mirrored in `async_select_option`. Only the option list was stale.

## Change

`options` is now derived from the process state plus the offer's constraints:

| allowed | condition |
|---|---|
| `on` | state `PAUSED` (resume) or `available` (schedule) |
| `paused` | state `RUNNING` **and** `is_pausable` |
| `off` | state ∈ {`RUNNING`, `SCHEDULED`, `PAUSED`} **and** `is_stoppable` |

The result is filtered out of a fixed `(on, paused, off)` tuple so the dropdown never reorders, and `current_option` always stays in the list as HA requires. Without an offer the entity is `unavailable` anyway, so that path falls back to all three.

The guards in `async_select_option` stay — HA validates against `options`, but they keep mirroring the bridge-side preconditions.

## Verification

- `PYTHONPATH=. pytest` — 285 passed
- `ruff check custom_components/` — clean
- `mypy custom_components/eebus` — clean, 48 files
- Deployed to the live HA against the VR940: with process state `available`, the select reports `options: ['on', 'off']` (`paused` gone), `is_stoppable: True`, `minimal_run_seconds: 180`; status sensor `available`, 21 eebus entities healthy.

## Not in scope

`current_option` still folds `available` / `completed` / `stopped` into `off` (a select option must be commandable, and "available" is not a CEM command; the raw state stays on `sensor.…_compressor_flexibility_status`). Consequently, picking `off` while `available` still raises instead of being a no-op. Left for a follow-up after production observation.

No proto, bridge, or entity-inventory change, so `quality_scale.yaml` is unaffected.