### PR TITLE
feat(binary_sensor): derive heat pump active state from power draw

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ Die Integration nutzt **gRPC Streaming** (Server-Sent Events) fuer Echtzeit-Upda
 |--------|-----|-------------|
 | `sensor.eebus_power_consumption` | sensor | Aktuelle elektr. Leistung (W) |
 | `sensor.eebus_consumption_limit` | sensor | Aktuell gesetztes LPC-Limit (W), readonly |
+| `binary_sensor.eebus_heat_pump_active` | binary_sensor | Verdichter laeuft, abgeleitet aus Leistungsaufnahme > 100 W |
 
 ### Steuerung
 

--- a/custom_components/eebus/binary_sensor.py
+++ b/custom_components/eebus/binary_sensor.py
@@ -17,6 +17,11 @@ from .state import StateField, is_fresh
 
 PARALLEL_UPDATES = 0  # Coordinator-based, no per-entity polling
 
+# Standby draw sits at roughly 5-25 W (measured on a Bosch Compress 5800i), while
+# a running compressor pulls far more, so anything above this separates the two
+# without needing an extra EEBUS data point.
+HEAT_PUMP_ACTIVE_THRESHOLD_W = 100.0
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -29,6 +34,7 @@ async def async_setup_entry(
         [
             EebusConnectedSensor(coordinator),
             EebusHeartbeatOkSensor(coordinator),
+            EebusHeatPumpActiveSensor(coordinator),
         ]
     )
 
@@ -103,3 +109,38 @@ class EebusHeartbeatOkSensor(EebusEntity, BinarySensorEntity):
             return None
         # PROBLEM class: is_on=True means there's a problem
         return not hb.within_duration
+
+
+class EebusHeatPumpActiveSensor(EebusEntity, BinarySensorEntity):
+    """Binary sensor deriving compressor activity from total power draw.
+
+    The device reports no explicit "compressor running" flag, so this thresholds
+    the power consumption measurement instead: standby is a few watts, an active
+    compressor is orders of magnitude above it. Purely derived — it needs no
+    EEBUS data point beyond the power reading the power sensor already uses.
+    """
+
+    _attr_device_class = BinarySensorDeviceClass.RUNNING
+    _attr_translation_key = "heat_pump_active"
+
+    def __init__(self, coordinator: EebusCoordinator) -> None:
+        """Initialize."""
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{coordinator.ski}_heat_pump_active"
+
+    @property
+    def available(self) -> bool:
+        """Expose activity only while the power measurement is fresh."""
+        data = self.coordinator.data
+        return bool(super().available and data and is_fresh(data, StateField.POWER_WATTS))
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return True while power draw exceeds the standby threshold."""
+        data = self.coordinator.data
+        if data is None:
+            return None
+        power = data.measurements.power_watts
+        if power is None:
+            return None
+        return power > HEAT_PUMP_ACTIVE_THRESHOLD_W

--- a/custom_components/eebus/icons.json
+++ b/custom_components/eebus/icons.json
@@ -30,7 +30,8 @@
     "select": {},
     "binary_sensor": {
       "connected": { "default": "mdi:lan-connect" },
-      "heartbeat_ok": { "default": "mdi:heart-pulse" }
+      "heartbeat_ok": { "default": "mdi:heart-pulse" },
+      "heat_pump_active": { "default": "mdi:heat-pump" }
     },
     "climate": {
       "room_heating": { "default": "mdi:radiator" }

--- a/custom_components/eebus/strings.json
+++ b/custom_components/eebus/strings.json
@@ -167,7 +167,8 @@
     },
     "binary_sensor": {
       "connected": { "name": "Connected" },
-      "heartbeat_ok": { "name": "Heartbeat OK" }
+      "heartbeat_ok": { "name": "Heartbeat OK" },
+      "heat_pump_active": { "name": "Heat pump active" }
     },
     "climate": {
       "room_heating": { "name": "Room Heating" }

--- a/custom_components/eebus/tests/test_binary_sensor.py
+++ b/custom_components/eebus/tests/test_binary_sensor.py
@@ -2,15 +2,20 @@
 
 from unittest.mock import MagicMock
 
+import pytest
+
 from custom_components.eebus.binary_sensor import (
+    HEAT_PUMP_ACTIVE_THRESHOLD_W,
     EebusConnectedSensor,
     EebusHeartbeatOkSensor,
+    EebusHeatPumpActiveSensor,
 )
 from custom_components.eebus.models import HeartbeatState
 from custom_components.eebus.state import (
     ConnectionState,
     DeviceState,
     LPCState,
+    MeasurementsState,
     StateField,
 )
 
@@ -67,3 +72,62 @@ def test_heartbeat_available_with_fresh_connected_state() -> None:
 def test_heartbeat_unavailable_when_poll_failed() -> None:
     sensor = _heartbeat_sensor(within_duration=True, poll_ok=False)
     assert sensor.available is False
+
+
+def _heat_pump_sensor(
+    *,
+    power: float | None,
+    poll_ok: bool = True,
+    connected: bool = True,
+    has_data: bool = True,
+) -> EebusHeatPumpActiveSensor:
+    coordinator = MagicMock()
+    coordinator.data = (
+        DeviceState(
+            connection=ConnectionState(connected=connected),
+            measurements=MeasurementsState(power_watts=power),
+            fresh_fields=(frozenset({StateField.POWER_WATTS}) if power is not None else frozenset()),
+        )
+        if has_data
+        else None
+    )
+    coordinator.ski = "test-ski"
+    coordinator.last_update_success = poll_ok
+    return EebusHeatPumpActiveSensor(coordinator)
+
+
+@pytest.mark.parametrize(
+    ("power", "expected"),
+    [
+        (0.0, False),
+        (5.0, False),  # Bosch Compress 5800i standby floor
+        (25.0, False),  # standby ceiling
+        (HEAT_PUMP_ACTIVE_THRESHOLD_W, False),  # threshold itself is not active
+        (100.1, True),
+        (1500.0, True),
+    ],
+)
+def test_heat_pump_active_thresholds_power(power: float, expected: bool) -> None:
+    sensor = _heat_pump_sensor(power=power)
+    assert sensor.available is True
+    assert sensor.is_on is expected
+
+
+def test_heat_pump_active_unknown_without_power_reading() -> None:
+    sensor = _heat_pump_sensor(power=None)
+    assert sensor.available is False
+    assert sensor.is_on is None
+
+
+def test_heat_pump_active_unknown_before_first_update() -> None:
+    sensor = _heat_pump_sensor(power=None, has_data=False)
+    assert sensor.available is False
+    assert sensor.is_on is None
+
+
+def test_heat_pump_active_unavailable_when_disconnected() -> None:
+    assert _heat_pump_sensor(power=1500.0, connected=False).available is False
+
+
+def test_heat_pump_active_unavailable_when_poll_failed() -> None:
+    assert _heat_pump_sensor(power=1500.0, poll_ok=False).available is False

--- a/custom_components/eebus/translations/de.json
+++ b/custom_components/eebus/translations/de.json
@@ -168,7 +168,8 @@
     },
     "binary_sensor": {
       "connected": { "name": "Verbunden" },
-      "heartbeat_ok": { "name": "Heartbeat OK" }
+      "heartbeat_ok": { "name": "Heartbeat OK" },
+      "heat_pump_active": { "name": "Wärmepumpe aktiv" }
     },
     "climate": {
       "room_heating": { "name": "Raumheizung" }

--- a/custom_components/eebus/translations/en.json
+++ b/custom_components/eebus/translations/en.json
@@ -168,7 +168,8 @@
     },
     "binary_sensor": {
       "connected": { "name": "Connected" },
-      "heartbeat_ok": { "name": "Heartbeat OK" }
+      "heartbeat_ok": { "name": "Heartbeat OK" },
+      "heat_pump_active": { "name": "Heat pump active" }
     },
     "climate": {
       "room_heating": { "name": "Room Heating" }


### PR DESCRIPTION
## What

Adds `binary_sensor.eebus_heat_pump_active` (`BinarySensorDeviceClass.RUNNING`), reporting the compressor as running while the device's power consumption exceeds **100 W**.

Idea taken from one of our forks. Heat pumps such as the Bosch Compress 5800i idle at roughly 5-25 W and draw far more once the compressor engages, so a single threshold separates the two states without ambiguity.

## Why

There is no explicit "compressor running" data point on the EEBUS side. The sensor is purely derived from `StateField.POWER_WATTS` — the same reading `sensor.eebus_power_consumption` already consumes — so it costs no additional EEBUS traffic and works on any device that reports power. It gives automations a clean on/off trigger instead of forcing every user to hand-roll a numeric-state template.

## Details

- `HEAT_PUMP_ACTIVE_THRESHOLD_W = 100.0` as a module constant, documented with the standby-draw rationale. Strictly greater-than, so the threshold itself counts as inactive.
- Enabled by default — this is a primary entity, not diagnostics.
- `available` additionally requires `is_fresh(POWER_WATTS)`: with a missing or stale measurement the entity goes unavailable rather than reporting a misleading "off".
- `is_on` returns `None` before the first update and whenever the device reports no power value.
- Translations: `strings.json` / `en.json` "Heat pump active", `de.json` "Wärmepumpe aktiv". Icon `mdi:heat-pump` in `icons.json`. Sentence case follows the HA style guide and the rest of this integration.
- README entity table updated.

No `quality_scale.yaml` change needed: `entity-device-class`, `entity-translations`, `icon-translations` and `entity-disabled-by-default` are already `done` and the new entity satisfies all four.

## Testing

- 10 new tests in `test_binary_sensor.py`: parametrized threshold behaviour (0 / 5 / 25 / 100 / 100.1 / 1500 W), missing measurement, pre-first-update, disconnected device, failed poll.
- `PYTHONPATH=. pytest` → 295 passed (was 285)
- `mypy custom_components/eebus` → clean, 48 source files
- `ruff check custom_components/` + `ruff format --check` → clean

## Note

No hysteresis. The gap between standby and compressor load is wide enough that a plain threshold is sufficient, and YAGNI applies until a device is observed hovering around 100 W.