### PR TITLE
fix(docker): pin the runtime user to a numeric uid

### DIFF
--- a/eebus-bridge/Dockerfile
+++ b/eebus-bridge/Dockerfile
@@ -17,8 +17,8 @@ FROM alpine:3.24
 
 # hadolint ignore=DL3018
 RUN apk add --no-cache ca-certificates \
- && addgroup -S eebus \
- && adduser -S -G eebus eebus \
+ && addgroup -g 101 -S eebus \
+ && adduser -u 100 -S -G eebus eebus \
  && mkdir -p /data /etc/eebus-bridge \
  && chown eebus:eebus /data
 
@@ -30,6 +30,9 @@ EXPOSE 50051 4712
 HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
   CMD ["eebus-bridge", "-healthcheck", "--config", "/etc/eebus-bridge/config.yaml"]
 
-USER eebus
+# Numeric form satisfies hadolint DL3066 and is resolvable without /etc/passwd.
+# 100:101 is exactly what `adduser -S` assigned before, so ownership of the
+# existing /data volume is unchanged and no re-pairing is triggered.
+USER 100:101
 ENTRYPOINT ["eebus-bridge"]
 CMD ["--config", "/etc/eebus-bridge/config.yaml"]


### PR DESCRIPTION
Unblocks CI. **Not** caused by #168 — that PR was just the first Go-touching change to surface it.

### What broke

hadolint `DL3066` ("Non-numeric user-id may not be resolvable by host system") fires on `USER eebus`, and the docker job runs with `failure-threshold: info`. The rule came in with the hadolint-action bump `v3.3.0 → v3.4.0` (`8c175bc`, 2026-07-30).

main has been red for every PR touching Go or proto since then:

| Commit | docker job |
|---|---|
| `8c175bc` (the bump itself) | failure |
| `8783d01` (grpc 1.83.0) | failure |
| `c1e2a8f` (docs salvage) | success — path filters skipped the job |

### The fix, and why this exact uid

`adduser -S` assigns **uid 100 / gid 101** on `alpine:3.24`. Those are now pinned explicitly, with `USER 100:101`.

Picking a fresh "nicer" uid (10001, the usual convention) would have been actively dangerous here: stack 93's `/data` volume holds the TLS certs that define the bridge SKI. `chown` in the Dockerfile only affects the image layer, not an existing named volume — so a uid change means the bridge either can't write `/data` or regenerates the certs, changing the SKI and forcing re-pairing with the VR940. Keeping 100:101 makes this a pure lint fix with zero runtime change.

### Verified locally

```
$ docker run --rm --entrypoint sh <image> -c 'id; ls -ld /data'
uid=100(eebus) gid=101(eebus) groups=101(eebus)
drwxr-xr-x 2 eebus eebus 4096 /data

$ docker run --rm --entrypoint eebus-bridge <image> --help
Usage of eebus-bridge: ...        # exit 0

$ hadolint --failure-threshold info eebus-bridge/Dockerfile
                                  # exit 0
```