### PR TITLE
perf(docker): cross-compile the bridge instead of emulating the toolchain

### DIFF
--- a/eebus-bridge/Dockerfile
+++ b/eebus-bridge/Dockerfile
@@ -1,4 +1,9 @@
-FROM golang:1.26-alpine AS builder
+# Pinning the builder to BUILDPLATFORM keeps the toolchain running natively on
+# the runner. Without it, buildx runs the whole builder stage — including the Go
+# compiler — under QEMU for every non-native target, which dominated release
+# build time. The binary is CGO_ENABLED=0, so cross-compiling is a plain
+# GOARCH/GOARM switch and produces the same static output.
+FROM --platform=$BUILDPLATFORM golang:1.26-alpine AS builder
 
 # hadolint ignore=DL3018
 RUN apk add --no-cache git
@@ -9,7 +14,13 @@ RUN go mod download
 
 COPY . .
 ARG BUILD_VERSION=dev
-RUN CGO_ENABLED=0 go build \
+# Provided by buildx: TARGETARCH is arm64/amd64/arm, TARGETVARIANT is v7 for
+# linux/arm/v7 and empty elsewhere. GOARM only applies to GOARCH=arm and is
+# ignored otherwise, so the stripped variant can be passed unconditionally.
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} GOARM=${TARGETVARIANT#v} go build \
   -ldflags "-X github.com/volschin/eebus-bridge/internal/grpc.BuildVersion=${BUILD_VERSION}" \
   -o /eebus-bridge ./cmd/eebus-bridge
 


### PR DESCRIPTION
Cuts release image builds from **~17 min to ~1 min**.

### The actual problem

The builder stage had no platform pin, so buildx ran the entire stage — **including the Go compiler** — under QEMU for every non-native target. The release job was spending nearly all its time emulating a compiler.

| Release | publish-image |
|---|---|
| v0.15.4 | 17m03s |
| v0.15.0–v0.15.3 | 10–17 min |

This was neither native-runner nor cross-compiled: it was emulated native compilation, the slowest of the three.

### The change

Pin the builder to `$BUILDPLATFORM` so the toolchain runs natively on the runner, and pick the target via `GOARCH`/`GOARM` from buildx's `TARGETARCH`/`TARGETVARIANT`. The binary is already `CGO_ENABLED=0`, so this is a plain cross-compile producing identical static output — no new toolchain, no sysroot, no `release.yml` change.

`GOARM` only applies to `GOARCH=arm` and is ignored otherwise, so the stripped variant is passed unconditionally instead of branching per platform.

### Why not native ARM runners

Considered, and rejected as the primary fix. GitHub's `ubuntu-24.04-arm` runners are free for this public repo, but there is **no armv7 runner** — the Ampere/Cobalt parts don't do AArch32 — so `linux/arm/v7` would stay emulated regardless. Native runners also need a matrix, digest pushes, and a manifest-merge job (~60 lines of workflow restructuring) to beat what this achieves in 5 lines of Dockerfile. For a pure-Go static binary, cross-compilation is the canonical fast path. The two are stackable later if the runtime stage ever becomes the bottleneck.

### Verified locally, not assumed

All three published platforms produce correctly-architected binaries:

```
linux/amd64    ELF 64-bit LSB executable, x86-64, statically linked
linux/arm64    ELF 64-bit LSB executable, ARM aarch64, statically linked
linux/arm/v7   ELF 32-bit LSB executable, ARM, EABI5, statically linked
```

Full three-platform build: **59s**. The arm64 image was additionally run under emulation to confirm it isn't just correctly labelled:

```
$ docker run --rm --platform linux/arm64 <image> ...
uid=100(eebus) gid=101(eebus) groups=101(eebus)
aarch64
Usage of eebus-bridge: ...
```

hadolint stays clean at `--failure-threshold info`. armv7 remains in the published platform list — it's referenced only in `release.yml` and `CLAUDE.md`, never in the README or compose file, so I couldn't confirm consumers either way and dropping a published arch is breaking.