### PR TITLE
ci(release): attach an SBOM and pin provenance to mode=max

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,13 @@ jobs:
           context: ./eebus-bridge
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           push: true
+          # Provenance was already attached by the action's default, but the
+          # default mode differs between event types and the published
+          # attestation reported completeness.resolvedDependencies=false. Pin
+          # max so every release records the full build materials regardless of
+          # how it was triggered. SBOM was not attached at all before this.
+          provenance: mode=max
+          sbom: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |


### PR DESCRIPTION
Adds the missing SBOM and makes provenance deterministic.

### Current state, measured on the published v0.16.0

- **Provenance:** already attached — but from the action's default, not an explicit setting, and `completeness` reported `{"request": true, "resolvedDependencies": false}`.
- **SBOM:** absent. `docker buildx imagetools inspect --format '{{ json .SBOM }}'` returned `{}`.

### Change

```yaml
provenance: mode=max
sbom: true
```

Pinning `mode=max` matters because the action's default differs by event type; without it the attestation quality depends on how the build was triggered.

### Verified locally

Built all three platforms to an OCI tarball and read the attestation manifests back:

```
linux/amd64
linux/arm64
linux/arm/v7
  attestation: ['https://spdx.dev/Document', 'https://slsa.dev/provenance/v1']
  attestation: ['https://spdx.dev/Document', 'https://slsa.dev/provenance/v1']
  attestation: ['https://spdx.dev/Document', 'https://slsa.dev/provenance/v1']
```

### Cost and trade-off

Warm-cache local build was 50.7s with attestations vs 59.5s without, so no material penalty locally — but the SBOM scanner runs per platform and the honest number is whatever the next release reports against v0.16.0's **2m50s**. I'll check it after the next tag rather than assume.

`mode=max` embeds build args, env and the source map into a public attestation. The only build arg is `BUILD_VERSION` and the repo is public, so nothing new is exposed — but that is the reason max isn't the default, so it's a deliberate call rather than an oversight.

### Not included

GitHub's own `actions/attest-build-provenance` (what `gh attestation verify` reads) is a separate mechanism from buildkit's in-manifest attestations and would need `id-token: write`. Happy to add it if you want both.