### PR TITLE
perf(docker): move the runtime image to distroless static

### DIFF
--- a/eebus-bridge/Dockerfile
+++ b/eebus-bridge/Dockerfile
@@ -24,26 +24,39 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} GOARM=${TARGETVARIANT#v}
   -ldflags "-X github.com/volschin/eebus-bridge/internal/grpc.BuildVersion=${BUILD_VERSION}" \
   -o /eebus-bridge ./cmd/eebus-bridge
 
-FROM alpine:3.24
+# Stage the runtime filesystem while a shell is still available. distroless has
+# no shell and no package manager, so /data and its ownership cannot be created
+# in the final stage.
+FROM alpine:3.24 AS rootfs
 
-# hadolint ignore=DL3018
-RUN apk add --no-cache ca-certificates \
- && addgroup -g 101 -S eebus \
+RUN addgroup -g 101 -S eebus \
  && adduser -u 100 -S -G eebus eebus \
- && mkdir -p /data /etc/eebus-bridge \
- && chown eebus:eebus /data
+ && mkdir -p /rootfs/data /rootfs/etc/eebus-bridge \
+ && chown -R 100:101 /rootfs/data
 
+# distroless/static carries ca-certificates, tzdata and /etc/passwd, and nothing
+# else: no shell, no package manager, no busybox. The bridge is a static
+# CGO_ENABLED=0 binary that makes no outbound HTTP calls and never shells out,
+# so none of alpine's userland was reachable at runtime anyway.
+# Pinned by digest: distroless publishes no semver tags, so a digest is the only
+# way to get a reproducible base and satisfy hadolint DL3006/DL3007.
+# renovate: datasource=docker depName=gcr.io/distroless/static-debian12
+FROM gcr.io/distroless/static-debian12@sha256:a9fcaedd4c9b59e12dd65d954f0b5044f19b0647a8a3712e77205df9e7b102cd
+
+COPY --from=rootfs /rootfs/ /
 COPY --from=builder /eebus-bridge /usr/local/bin/eebus-bridge
 
 VOLUME /data
 EXPOSE 50051 4712
 
+# Absolute paths: distroless has no shell, so nothing resolves these via PATH
+# on our behalf if the image's PATH ever changes.
 HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
-  CMD ["eebus-bridge", "-healthcheck", "--config", "/etc/eebus-bridge/config.yaml"]
+  CMD ["/usr/local/bin/eebus-bridge", "-healthcheck", "--config", "/etc/eebus-bridge/config.yaml"]
 
 # Numeric form satisfies hadolint DL3066 and is resolvable without /etc/passwd.
 # 100:101 is exactly what `adduser -S` assigned before, so ownership of the
 # existing /data volume is unchanged and no re-pairing is triggered.
 USER 100:101
-ENTRYPOINT ["eebus-bridge"]
+ENTRYPOINT ["/usr/local/bin/eebus-bridge"]
 CMD ["--config", "/etc/eebus-bridge/config.yaml"]


### PR DESCRIPTION
Answers "can we use one of those nearly-empty base images": yes, and the bridge is close to the ideal case for it.

### Why it fits

The binary is static `CGO_ENABLED=0`. Checked the source rather than assumed — there is no `net/http`, no `/tmp` use, no `os/user` lookup, and nothing shells out. Alpine's busybox, apk and shell were never reachable at runtime; they were only attack surface and CVE noise.

Final stage is now `gcr.io/distroless/static-debian12`, which still ships ca-certificates, tzdata and `/etc/passwd`. A throwaway alpine stage prepares `/data` and `/etc/eebus-bridge`, since distroless has no shell to create them in place.

### The uid is load-bearing

Kept at **100:101**. Not cosmetic: stack 93's `/data` volume holds the TLS certs that define the bridge SKI. Any other uid either fails to read them or regenerates them, changing the SKI and forcing re-pairing with the VR940. I did **not** take distroless's `:nonroot` (65532) for exactly this reason.

Verified by running the image against a fresh bind-mounted `/data`:

```
drwx------ 2 100 101 80 certs      # created by the container, correct owner
```

### Also changed

`ENTRYPOINT` and `HEALTHCHECK` now use absolute paths. Both are exec-form and were relying on the runtime resolving a bare name via `PATH` — a needless dependency on the base image's environment once there's no shell to fall back on.

Base pinned by digest with a renovate comment: distroless publishes no semver tags, so a digest is the only reproducible reference, and it also clears hadolint `DL3006`/`DL3007`.

### Verified locally

| Check | Result |
|---|---|
| Builds amd64 / arm64 / arm/v7 | pass — distroless publishes all three |
| Container health | `healthy`, health log `ExitCode: 0` — HEALTHCHECK works with no shell |
| Certs written to `/data` | uid 100 gid 101 |
| arm64 under emulation | runs |
| hadolint `--failure-threshold info` | clean |
| Image size | 63.1MB → **54.8MB** |

### Trade-off you should agree to

**No shell in the image any more**, so `docker exec ... sh` for live debugging is gone. Nothing in the README, `docs/` or the compose file directed anyone to do that, and the bridge is diagnosed from logs plus the gRPC health service — which is how I debugged it this session. If an incident ever needs an interactive shell, `gcr.io/distroless/static-debian12:debug` is a one-line temporary swap.

Stacks with #171 (SBOM + provenance); they touch different files and don't conflict.