### PR TITLE
ci: skip unaffected jobs, pin govulncheck, cancel superseded runs

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,7 +1,12 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "local>olcond/renovate-config"
+    "local>olcond/renovate-config",
+    // Picks up `# renovate: datasource=… depName=…` comments above *_VERSION
+    // env vars in workflows (currently govulncheck). The shared preset does not
+    // include it, so without this the pinned tool versions would never be
+    // bumped and would silently rot.
+    "customManagers:githubActionsVersions"
   ],
   "packageRules": [
     {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,13 @@ on:
 permissions:
   contents: read
 
+# A second push to a PR supersedes the first: keeping the older run alive only
+# burns runner minutes on a diff nobody will merge. Runs on main are keyed by
+# their own ref and cancel only each other, never a PR run.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   # Detect which paths changed so Go jobs can be skipped when irrelevant
   changes:
@@ -120,8 +127,17 @@ jobs:
         # already-persisted credentials and fails with
         # `remote: Duplicate header: "Authorization"` (HTTP 400). The repo is
         # already checked out and Go is already set up above.
+        #
+        # Pinned rather than @latest: every action in this repo is SHA-pinned,
+        # and an unpinned `go install` in the security step is the one place an
+        # upstream compromise would land straight in CI. The env var carries the
+        # version because that is the shape customManagers:githubActionsVersions
+        # matches — a bare `@v1.6.0` in the run body would rot unnoticed.
+        env:
+          # renovate: datasource=go depName=golang.org/x/vuln
+          GOVULNCHECK_VERSION: v1.6.0
         run: |
-          go install golang.org/x/vuln/cmd/govulncheck@latest
+          go install "golang.org/x/vuln/cmd/govulncheck@${GOVULNCHECK_VERSION}"
           govulncheck ./...
       - run: go build ./cmd/eebus-bridge/
 
@@ -138,6 +154,13 @@ jobs:
       - run: docker build -t eebus-bridge ./eebus-bridge
 
   test:
+    # Gated like the go job: a Go- or Dockerfile-only PR cannot break ruff,
+    # mypy or pytest, and this matrix spends ~3.5 job-minutes installing
+    # homeassistant to prove it. The python filter covers custom_components,
+    # pyproject.toml and this workflow, so anything that can affect the result
+    # still triggers a run.
+    needs: changes
+    if: needs.changes.outputs.python == 'true'
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/hacs.yml
+++ b/.github/workflows/hacs.yml
@@ -1,17 +1,33 @@
 name: HACS
 
+# HACS validates the integration's repository structure: custom_components,
+# hacs.json, the manifest, and the README it renders as the store description.
+# The path list replaces the former '**/*.md' ignore — GitHub rejects paths and
+# paths-ignore on the same event, so README.md is listed explicitly as the one
+# markdown file that is validated input. Go- and Dockerfile-only PRs no longer
+# trigger this. (Duplicated per event: Actions does not expand YAML anchors.)
 on:
   push:
     branches: [main]
-    paths-ignore:
-      - '**/*.md'
+    paths:
+      - 'custom_components/**'
+      - 'hacs.json'
+      - 'README.md'
+      - '.github/workflows/hacs.yml'
   pull_request:
     branches: [main]
-    paths-ignore:
-      - '**/*.md'
+    paths:
+      - 'custom_components/**'
+      - 'hacs.json'
+      - 'README.md'
+      - '.github/workflows/hacs.yml'
 
 permissions:
   contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   hacs:

--- a/.github/workflows/hassfest.yml
+++ b/.github/workflows/hassfest.yml
@@ -1,17 +1,27 @@
 name: Hassfest
 
+# hassfest validates manifest.json and the integration's file layout, so only
+# custom_components (and this workflow) can change its verdict. Go- and
+# Dockerfile-only PRs no longer trigger it. (Duplicated per event: Actions does
+# not expand YAML anchors.)
 on:
   push:
     branches: [main]
-    paths-ignore:
-      - '**/*.md'
+    paths:
+      - 'custom_components/**'
+      - '.github/workflows/hassfest.yml'
   pull_request:
     branches: [main]
-    paths-ignore:
-      - '**/*.md'
+    paths:
+      - 'custom_components/**'
+      - '.github/workflows/hassfest.yml'
 
 permissions:
   contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   hassfest:


### PR DESCRIPTION
Three small, independent CI fixes. No production code touched.

## 1. Path gating for the Python jobs

`changes` already computes a `python` filter output, but the `test` matrix never consumed it — no `needs: changes`, no `if:`. Consequence, measured on #173 (a one-file Dockerfile change):

| job | time | could it fail? |
|---|---|---|
| `test (3.13)` | 1m50 | no |
| `test (3.14)` | 1m42 | no |
| `hacs` | 50s | no |
| `hassfest` | 21s | no |

~4.5 job-minutes per Go/Docker PR, guaranteed green.

- `test` now uses the existing `python` filter (`custom_components/**`, `pyproject.toml`, `ci.yml`).
- `hacs` / `hassfest` get `paths:` triggers scoped to what they validate.
- The `**/*.md` ignore had to become an explicit `paths:` list — GitHub rejects `paths` and `paths-ignore` on the same event. `README.md` stays listed for hacs because HACS renders it as the store description; all other markdown is now correctly ignored.
- Paths are duplicated per event on purpose: Actions does not expand YAML anchors.

Safe here because `main` has no branch protection (`Branch not protected`), so a skipped job cannot stall a merge.

## 2. Pin govulncheck

```diff
-go install golang.org/x/vuln/cmd/govulncheck@latest
+GOVULNCHECK_VERSION: v1.6.0   # in env:
```

Every action in this repo is SHA-pinned with a renovate comment. This `go install` was the sole exception — in the security step, where an upstream compromise lands directly in CI.

- v1.6.0 is exactly what `@latest` resolves to today (`proxy.golang.org/golang.org/x/vuln/@latest` → v1.6.0), so **CI behaviour is unchanged**.
- The version sits in an `env:` var, not inline in `run:`, because that is the shape `customManagers:githubActionsVersions` matches.
- That manager is **not** part of the shared `local>olcond/renovate-config` preset (verified against its `default.json`), so it is added to `.github/renovate.json5`. Without it the pin would silently rot — the exact failure mode the pin exists to avoid.

## 3. Concurrency

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: true
```

Added to ci/hacs/hassfest. Keyed by ref, so main runs and PR runs never cancel each other. Deliberately **not** added to `release.yml` — an interrupted publish is worse than a duplicate one.

## Verification

- All three workflows parse (`yaml.safe_load`); `renovate.json5` parses.
- `govulncheck@v1.6.0` installed and ran against `eebus-bridge/` locally. It reports stdlib findings on my local go1.26.0, which is expected: stable is go1.26.5 and CI uses `check-latest: true`. Not related to the pin.
- This PR is self-testing: it touches `ci.yml` (in the `python` filter) so the Python matrix still runs, and touches `hacs.yml`/`hassfest.yml` so both still trigger. A follow-up Go-only PR is what will show the jobs correctly skipping.