### PR TITLE
ci: smoke-run the image, build all release platforms, drop QEMU

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,7 @@ jobs:
               - 'eebus-bridge/**'
               - 'scripts/check_go_patch_coverage.py'
               - 'scripts/tests/test_check_go_patch_coverage.py'
+              - 'scripts/smoke-image.sh'
               - 'docs/badges/go-coverage.svg'
               - '.github/workflows/ci.yml'
             python:
@@ -151,7 +152,43 @@ jobs:
         uses: hadolint/hadolint-action@2a66e89f53d0771bb131a7fa31f3136336094aa6 # v3.4.0 # renovate: datasource=github-releases depName=hadolint/hadolint-action
         with:
           dockerfile: eebus-bridge/Dockerfile
-      - run: docker build -t eebus-bridge ./eebus-bridge
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0 # renovate: datasource=github-releases depName=docker/setup-buildx-action
+      # Recorded so the log shows whether emulation was even available. No
+      # setup-qemu-action here on purpose: since the rootfs stage was folded
+      # into the BUILDPLATFORM-pinned builder, no RUN executes outside the
+      # native builder and the arm stages are COPY-only. If this job goes red
+      # for a missing binfmt handler, that assumption is wrong.
+      - name: Record binfmt handlers
+        run: ls /proc/sys/fs/binfmt_misc/ 2>/dev/null || echo "no binfmt handlers registered"
+      # Previously a plain amd64 `docker build`. A cross-compile break on
+      # arm64/armv7 — the platforms the release publishes — was invisible until
+      # the tag build, i.e. after the release was already cut.
+      - name: Build all release platforms
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0 # renovate: datasource=github-releases depName=docker/build-push-action
+        with:
+          context: ./eebus-bridge
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: |
+            BUILD_VERSION=ci-${{ github.sha }}
+      # Multi-platform results cannot be loaded into the docker daemon, so the
+      # smoke target is rebuilt for amd64 alone. Everything is cached from the
+      # step above, so this costs seconds.
+      - name: Build amd64 image for the smoke run
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0 # renovate: datasource=github-releases depName=docker/build-push-action
+        with:
+          context: ./eebus-bridge
+          platforms: linux/amd64
+          load: true
+          tags: eebus-bridge:ci
+          cache-from: type=gha
+          build-args: |
+            BUILD_VERSION=ci-${{ github.sha }}
+      - name: Smoke-run the image
+        run: bash scripts/smoke-image.sh eebus-bridge:ci
 
   test:
     # Gated like the go job: a Go- or Dockerfile-only PR cannot break ruff,

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,10 @@ permissions:
 
 jobs:
   create-release:
+    # Gated on the image so a failed or unhealthy build cannot produce a
+    # published release. HACS updates users from published releases, so a
+    # release without a working image strands everyone who upgrades on it.
+    needs: publish-image
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -27,9 +31,10 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0 # renovate: datasource=github-releases depName=docker/setup-qemu-action
-
+      # No setup-qemu-action: the builder stage is pinned to BUILDPLATFORM and
+      # the arm stages are COPY-only, so nothing executes under emulation. CI's
+      # docker job builds the same three platforms without it on every PR, which
+      # is where a wrong assumption here would surface first.
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0 # renovate: datasource=github-releases depName=docker/setup-buildx-action
 
@@ -49,6 +54,26 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
+
+      # Built and smoke-run before anything is pushed. v0.13.0 shipped a
+      # startup panic with every gate green because no gate ever started the
+      # binary; the image was published and deployed before anyone noticed.
+      # Multi-platform results cannot be loaded into the docker daemon, so the
+      # smoke target is amd64-only — a startup panic is not arch-specific, and
+      # the other two platforms are covered by the build succeeding.
+      - name: Build amd64 image for the smoke run
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0 # renovate: datasource=github-releases depName=docker/build-push-action
+        with:
+          context: ./eebus-bridge
+          platforms: linux/amd64
+          load: true
+          tags: eebus-bridge:smoke
+          build-args: |
+            BUILD_VERSION=${{ github.ref_name }}
+          cache-from: type=gha
+
+      - name: Smoke-run the image
+        run: bash scripts/smoke-image.sh eebus-bridge:smoke
 
       - name: Build and push multi-arch image
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0 # renovate: datasource=github-releases depName=docker/build-push-action

--- a/scripts/smoke-image.sh
+++ b/scripts/smoke-image.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Boot the built container image and wait for its own HEALTHCHECK to report
+# healthy.
+#
+# Every static gate can be green while the binary panics on the first line of
+# main(): v0.13.0 shipped a typed-nil panic in the use-case wiring with vet,
+# lint, race tests and coverage all passing, because nothing ever started the
+# thing. This runs the image exactly as docker-compose does — shipped config
+# mounted read-only, /data from the image's own VOLUME so cert generation gets
+# a writable directory owned by uid 100 — and fails if it does not come up.
+#
+# Usage: scripts/smoke-image.sh <image-ref> [config-path]
+set -euo pipefail
+
+IMAGE="${1:?usage: smoke-image.sh <image-ref> [config-path]}"
+CONFIG="${2:-eebus-bridge/config.yaml}"
+TIMEOUT_SECONDS="${SMOKE_TIMEOUT_SECONDS:-120}"
+
+if [[ ! -f "$CONFIG" ]]; then
+  echo "smoke: config not found: $CONFIG" >&2
+  exit 1
+fi
+CONFIG_ABS="$(cd "$(dirname "$CONFIG")" && pwd)/$(basename "$CONFIG")"
+
+NAME="eebus-smoke-$$"
+
+cleanup() {
+  echo "--- container logs ---"
+  docker logs "$NAME" 2>&1 | tail -40 || true
+  docker rm -f "$NAME" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+echo "smoke: starting $IMAGE"
+docker run -d --name "$NAME" \
+  -v "$CONFIG_ABS":/etc/eebus-bridge/config.yaml:ro \
+  "$IMAGE" >/dev/null
+
+deadline=$((SECONDS + TIMEOUT_SECONDS))
+while ((SECONDS < deadline)); do
+  running="$(docker inspect -f '{{.State.Running}}' "$NAME")"
+  if [[ "$running" != "true" ]]; then
+    code="$(docker inspect -f '{{.State.ExitCode}}' "$NAME")"
+    echo "smoke: container exited early with code $code" >&2
+    exit 1
+  fi
+
+  # No HEALTHCHECK would leave this at <nil> forever, so treat it as a failure
+  # rather than looping until the timeout.
+  status="$(docker inspect -f '{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}' "$NAME")"
+  case "$status" in
+    healthy)
+      echo "smoke: healthy after $((SECONDS))s"
+      exit 0
+      ;;
+    unhealthy)
+      echo "smoke: healthcheck reported unhealthy" >&2
+      exit 1
+      ;;
+    none)
+      echo "smoke: image defines no HEALTHCHECK" >&2
+      exit 1
+      ;;
+  esac
+  sleep 3
+done
+
+echo "smoke: still not healthy after ${TIMEOUT_SECONDS}s" >&2
+exit 1


### PR DESCRIPTION
Items 3, 4 and 9 from the CI review. Release hardening, plus the CI coverage that makes it verifiable.

## 3. Smoke gate — nothing ships unstarted

v0.13.0 shipped a typed-nil panic in the use-case wiring. `go vet`, golangci-lint, `-race` tests, coverage and govulncheck were all green, because **no gate ever started the binary**. It was published, deployed, and found in production.

New `scripts/smoke-image.sh` boots the image the way docker-compose does — shipped `config.yaml` mounted read-only, `/data` from the image's own `VOLUME` so cert generation gets a directory owned by uid 100 — and waits for the image's own `HEALTHCHECK`.

It runs in two places:
- **CI**, on every PR touching the bridge.
- **Release**, *before* anything is pushed to GHCR.

`create-release` now `needs: publish-image`. HACS updates users from published releases, so cutting release notes for an image that failed to build or failed to boot strands whoever upgrades onto it.

Verified locally against the current image:
```
$ ./scripts/smoke-image.sh eebus-bridge:amd64
smoke: healthy after 20s
  Registered EEBUS use cases: LPC, Monitoring, DHWMonitoring, MRT, MOT, ... OHPCF
  gRPC server listening on 127.0.0.1:50051
$ echo $?
0
```
And the negative case — a config the bridge rejects:
```
smoke: container exited early with code 1
  loading config: validating gRPC security: security mode "loopback" requires a loopback bind address
$ echo $?
1
```

## 4. CI builds all three release platforms

The `docker` job ran a plain amd64 `docker build`. A cross-compile break on arm64 or armv7 — the platforms the release actually publishes — was invisible until the tag build, i.e. after the release was cut. Now buildx across `linux/amd64,linux/arm64,linux/arm/v7` with gha cache.

The amd64 smoke image is a second, cache-hot build because multi-platform results cannot be `load`ed into the docker daemon.

## 9. QEMU removed from the release

Since #173 folded the rootfs stage into the BUILDPLATFORM-pinned builder, no `RUN` executes outside the native builder and the arm stages are `COPY`-only. `setup-qemu-action` has nothing left to emulate.

I could not falsify this locally — my host has qemu binfmt handlers registered system-wide, so a local build proves nothing either way. **CI is the experiment**: the new docker job builds all three platforms without `setup-qemu-action` and records the runner's binfmt handlers first, so the log states plainly whether emulation was available. If the assumption is wrong, this PR goes red instead of a future release.

## Verification

- Both workflows parse; `create-release` correctly gated on `publish-image`; no `uses: docker/setup-qemu-action` remains (one comment mentions it by name).
- `scripts/smoke-image.sh` passes `bash -n`, and both the success and failure paths were exercised locally as shown above.
- `scripts/smoke-image.sh` added to the `go` path filter so changes to it retrigger the docker job.