### PR TITLE
security: protect CI and release tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,12 +3,8 @@ name: CI
 on:
   push:
     branches: [main]
-    paths-ignore:
-      - '**/*.md'
   pull_request:
     branches: [main]
-    paths-ignore:
-      - '**/*.md'
 
 permissions:
   contents: read
@@ -31,6 +27,8 @@ jobs:
       python: ${{ steps.filter.outputs.python }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
         id: filter
         with:
@@ -67,6 +65,17 @@ jobs:
               - 'custom_components/eebus/tests/test_proto_postprocess.py'
               - 'docs/proto-contract-matrix.md'
 
+  policy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Test release version policy
+        run: python3 -m unittest scripts.tests.test_check_addon_version -v
+      - name: Check add-on version matches the integration
+        run: python3 scripts/check_addon_version.py
+
   go:
     needs: changes
     if: needs.changes.outputs.go == 'true'
@@ -78,6 +87,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: "1.26"
@@ -155,6 +165,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Lint Dockerfile
         uses: hadolint/hadolint-action@2a66e89f53d0771bb131a7fa31f3136336094aa6 # v3.4.0 # renovate: datasource=github-releases depName=hadolint/hadolint-action
         with:
@@ -206,6 +218,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Lint add-on Dockerfile
         uses: hadolint/hadolint-action@2a66e89f53d0771bb131a7fa31f3136336094aa6 # v3.4.0 # renovate: datasource=github-releases depName=hadolint/hadolint-action
         with:
@@ -235,6 +249,8 @@ jobs:
         python-version: ["3.13", "3.14"]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ matrix.python-version }}
@@ -261,6 +277,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: "1.26"
@@ -282,6 +300,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: "1.26"
@@ -299,10 +318,14 @@ jobs:
         run: .cache/proto-tools/bin/buf lint
       - name: Buf breaking check
         if: github.event_name == 'pull_request'
-        run: .cache/proto-tools/bin/buf breaking --against ".git#branch=origin/${{ github.base_ref }},subdir=eebus-bridge/proto"
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: .cache/proto-tools/bin/buf breaking --against ".git#branch=origin/${BASE_REF},subdir=eebus-bridge/proto"
       - name: Check scoped cardinality waivers
         if: github.event_name == 'pull_request'
-        run: python scripts/check_proto_cardinality.py "origin/${{ github.base_ref }}"
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: python scripts/check_proto_cardinality.py "origin/${BASE_REF}"
       - name: Regenerate proto stubs
         run: PYTHON_BIN=python bash generate_proto.sh
       - name: Check for stub drift
@@ -312,4 +335,35 @@ jobs:
       - name: Check v1 governance rules
         run: python scripts/check_proto_governance.py
 
-  
+  required:
+    name: Required
+    needs: [changes, policy, go, docker, addon, test, cross-language, proto-governance]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require every applicable CI job
+        env:
+          CHANGES_RESULT: ${{ needs.changes.result }}
+          POLICY_RESULT: ${{ needs.policy.result }}
+          GO_RESULT: ${{ needs.go.result }}
+          DOCKER_RESULT: ${{ needs.docker.result }}
+          ADDON_RESULT: ${{ needs.addon.result }}
+          TEST_RESULT: ${{ needs.test.result }}
+          CROSS_LANGUAGE_RESULT: ${{ needs.cross-language.result }}
+          PROTO_GOVERNANCE_RESULT: ${{ needs.proto-governance.result }}
+        run: |
+          set -euo pipefail
+          failed=0
+          for name in CHANGES POLICY GO DOCKER ADDON TEST CROSS_LANGUAGE PROTO_GOVERNANCE; do
+            result_var="${name}_RESULT"
+            result="${!result_var}"
+            case "${result}" in
+              success|skipped)
+                ;;
+              *)
+                echo "::error::${name} concluded ${result}"
+                failed=1
+                ;;
+            esac
+          done
+          exit "${failed}"

--- a/.github/workflows/grpcio-sync.yml
+++ b/.github/workflows/grpcio-sync.yml
@@ -28,9 +28,10 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          # A PAT lets the resulting PR trigger CI; falls back to GITHUB_TOKEN
-          # (PRs opened with GITHUB_TOKEN do NOT trigger other workflows).
-          token: ${{ secrets.WORKFLOW_PAT || secrets.GITHUB_TOKEN }}
+          # Keep the write-capable PAT out of the checkout and all dependency
+          # installation/generation steps. It is exposed only after those
+          # steps have completed, immediately before publishing the branch.
+          persist-credentials: false
 
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
@@ -108,6 +109,7 @@ jobs:
             echo "Branch ${BRANCH} already exists — PR likely open. Skipping."
             exit 0
           fi
+          gh auth setup-git
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git switch -c "${BRANCH}"

--- a/.github/workflows/hacs.yml
+++ b/.github/workflows/hacs.yml
@@ -34,6 +34,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - uses: hacs/action@1ebf01c408f29afcb6406bd431bc98fd8cbb15aa # main
         with:
           category: integration

--- a/.github/workflows/hassfest.yml
+++ b/.github/workflows/hassfest.yml
@@ -28,4 +28,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - uses: home-assistant/actions/hassfest@a7c616ce81ccda50150bf1595786c71b1883fabb # master

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,6 @@ on:
 
 permissions:
   contents: read
-  packages: write
 
 jobs:
   create-release:
@@ -28,8 +27,25 @@ jobs:
 
   publish-image:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Validate release source and version
+        run: |
+          set -euo pipefail
+          python3 scripts/check_addon_version.py "${GITHUB_REF_NAME}"
+          git fetch --no-tags origin main
+          release_commit="$(git rev-parse "${GITHUB_REF_NAME}^{commit}")"
+          if ! git merge-base --is-ancestor "${release_commit}" origin/main; then
+            echo "::error::release tag ${GITHUB_REF_NAME} does not point to a commit on main"
+            exit 1
+          fi
 
       # No setup-qemu-action: the builder stage is pinned to BUILDPLATFORM and
       # the arm stages are COPY-only, so nothing executes under emulation. CI's

--- a/scripts/check_addon_version.py
+++ b/scripts/check_addon_version.py
@@ -22,6 +22,7 @@ ADDON_CONFIG = ROOT / "eebus-bridge-addon" / "config.yaml"
 MANIFEST = ROOT / "custom_components" / "eebus" / "manifest.json"
 
 ADDON_VERSION_RE = re.compile(r"""^version:\s*["']?([^"'\s#]+)["']?\s*(?:#.*)?$""", re.MULTILINE)
+RELEASE_TAG_RE = re.compile(r"v[0-9]+(?:\.[0-9]+){2}")
 
 
 def addon_version() -> str:
@@ -41,7 +42,15 @@ def integration_version() -> str:
     return version
 
 
-def main() -> int:
+def validate_release_tag(release_tag: str, version: str) -> None:
+    """Require a canonical release tag for the version being published."""
+    if RELEASE_TAG_RE.fullmatch(release_tag) is None:
+        raise ValueError(f"release tag {release_tag!r} must have the form vMAJOR.MINOR.PATCH")
+    if release_tag != f"v{version}":
+        raise ValueError(f"release tag {release_tag!r} does not match manifest version {version!r}")
+
+
+def main(release_tag: str | None = None) -> int:
     """Compare both versions and report the mismatch."""
     addon = addon_version()
     integration = integration_version()
@@ -54,9 +63,19 @@ def main() -> int:
             file=sys.stderr,
         )
         return 1
+    if release_tag is not None:
+        try:
+            validate_release_tag(release_tag, integration)
+        except ValueError as err:
+            print(err, file=sys.stderr)
+            return 1
     print(f"add-on and integration agree on version {addon}")
+    if release_tag is not None:
+        print(f"release tag {release_tag} matches version {integration}")
     return 0
 
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    if len(sys.argv) > 2:
+        raise SystemExit(f"usage: {Path(sys.argv[0]).name} [RELEASE_TAG]")
+    raise SystemExit(main(sys.argv[1] if len(sys.argv) == 2 else None))

--- a/scripts/tests/test_check_addon_version.py
+++ b/scripts/tests/test_check_addon_version.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import sys
+import unittest
+
+
+SCRIPT = Path(__file__).parents[1] / "check_addon_version.py"
+SPEC = importlib.util.spec_from_file_location("check_addon_version", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+versions = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = versions
+SPEC.loader.exec_module(versions)
+
+
+class ReleaseTagTest(unittest.TestCase):
+    def test_accepts_tag_matching_manifest_version(self) -> None:
+        versions.validate_release_tag("v0.16.2", "0.16.2")
+
+    def test_rejects_tag_without_v_prefix(self) -> None:
+        with self.assertRaisesRegex(ValueError, "must have the form"):
+            versions.validate_release_tag("0.16.2", "0.16.2")
+
+    def test_rejects_tag_not_matching_manifest_version(self) -> None:
+        with self.assertRaisesRegex(ValueError, "does not match"):
+            versions.validate_release_tag("v0.16.3", "0.16.2")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add an always-running aggregate `Required` CI gate and remove the docs-only blind spot
- keep checkout credentials out of all subsequent workflow steps and expose `WORKFLOW_PAT` only for the final grpcio-sync publish step
- validate that release tags match the manifest/add-on version and point to a commit on `main`
- scope `packages: write` to the image publishing job
- remove two attacker-controlled expression expansions from shell commands

## Live rulesets

- `main`: pull request required, deletion and non-fast-forward updates blocked, no bypass actors
- `v*` tags: deletion and non-fast-forward updates blocked, no bypass actors

The `Required` context will be added to the active main ruleset after this PR has produced that check successfully.

## Verification

- `python3 -m unittest discover -s scripts/tests -p 'test_*.py' -v`
- `ruff check scripts/check_addon_version.py scripts/tests/test_check_addon_version.py`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7`
- `uvx zizmor --offline .` (no findings)
- `git diff --check`

## Summary by Sourcery

Harden CI and release workflows by enforcing version and source policy for releases, aggregating job results into a single required status, and tightening credential and permission handling across GitHub Actions.

Enhancements:
- Add a policy job and a Required aggregate CI gate that depends on all relevant jobs so documentation-only changes and other paths still run through required checks.
- Restrict GitHub Actions checkout steps to avoid persisting credentials and adjust buf and proto cardinality invocations to avoid attacker-controlled expression expansion.
- Constrain release image publishing permissions by scoping packages: write to the publish-image job and validating that release tags match the manifest version and originate from commits on main.
- Limit exposure of the WORKFLOW_PAT in the grpcio-sync workflow by keeping it out of checkout and setup steps and configuring git authentication only immediately before publishing.

Tests:
- Add unit tests for release tag validation to ensure only canonical, version-matching tags are accepted and integrate these tests into the CI policy job.