### PR TITLE
security: redact sensitive log details

### DIFF
--- a/custom_components/eebus/__init__.py
+++ b/custom_components/eebus/__init__.py
@@ -38,7 +38,7 @@ from .coordinator import EebusCoordinator
 from .providers import ProviderMappings
 from .runtime import BridgeRuntimeRegistry
 from .server_info import IncompatibleAPIMajorError
-from .ski import is_valid_ski, normalize_ski
+from .ski import is_valid_ski, normalize_ski, short_ski
 
 _LOGGER = logging.getLogger(__name__)
 _RUNTIME_REGISTRY = "runtime_registry"
@@ -83,7 +83,7 @@ async def async_migrate_entry(
             "valid 40-character hexadecimal fingerprint",
             config_entry.entry_id,
             config_entry.title,
-            config_entry.data[CONF_DEVICE_SKI],
+            "[redacted]",
         )
         return False
 
@@ -99,7 +99,7 @@ async def async_migrate_entry(
                 "SKI %s conflicts with older entry %s (%s)",
                 config_entry.entry_id,
                 config_entry.title,
-                canonical_ski,
+                short_ski(canonical_ski),
                 other_entry.entry_id,
                 other_entry.title,
             )

--- a/custom_components/eebus/device_session.py
+++ b/custom_components/eebus/device_session.py
@@ -12,6 +12,7 @@ import grpc.aio
 
 from . import proto_stubs
 from .grpc_client import RPC_TIMEOUT, WRITE_VALIDATION_CODES, is_unimplemented
+from .ski import short_ski
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -48,7 +49,7 @@ class DeviceSession:
         except grpc.aio.AioRpcError as err:
             if is_unimplemented(err):
                 _LOGGER.info(
-                    "%s unsupported for SKI %s: %s", label, self._ski, err.details()
+                    "%s unsupported for SKI %s: %s", label, short_ski(self._ski), err.details()
                 )
                 return WriteOutcome(
                     status_code=err.code(), unimplemented=True, error=err

--- a/custom_components/eebus/device_streams.py
+++ b/custom_components/eebus/device_streams.py
@@ -27,7 +27,7 @@ from .models import (
     _setpoint_to_dict,
 )
 from .session_diagnostics import DeviceStreamDiagnostics
-from .ski import normalize_ski
+from .ski import normalize_ski, short_ski
 from .snapshot import _capability_results_from_proto, _snapshot_observation_from_proto
 from .state import (
     CapabilityKey,
@@ -507,7 +507,7 @@ class DeviceStreams:
         if not self._matches(event.ski):
             return
         if event.event_type == proto_stubs.DeviceEventType.DEVICE_EVENT_TRUST_REMOVED:
-            _LOGGER.warning("EEBUS device %s removed trust with bridge", event.ski)
+            _LOGGER.warning("EEBUS device %s removed trust with bridge", short_ski(event.ski))
             connected = False
         elif event.event_type not in (
             proto_stubs.DeviceEventType.DEVICE_EVENT_CONNECTED,

--- a/custom_components/eebus/ski.py
+++ b/custom_components/eebus/ski.py
@@ -25,3 +25,9 @@ def normalize_ski(ski: str) -> str:
 def is_valid_ski(ski: str) -> bool:
     """Return whether an SKI is a 40-character hexadecimal fingerprint."""
     return len(ski) == 40 and all(character in string.hexdigits for character in ski)
+
+
+def short_ski(ski: str) -> str:
+    """Return a normalized, redacted SKI suitable for log messages."""
+    normalized = normalize_ski(ski)
+    return f"…{normalized[-6:]}"

--- a/custom_components/eebus/snapshot.py
+++ b/custom_components/eebus/snapshot.py
@@ -56,6 +56,7 @@ from .state import (
     StateField,
     StateObservation,
 )
+from .ski import short_ski
 
 _LOGGER = logging.getLogger(__name__)
 _LEGACY_CAPABILITY_WARNED: set[str] = set()
@@ -166,10 +167,10 @@ async def _async_read_capabilities(
                 _LEGACY_CAPABILITY_WARNED.add(ski)
                 _LOGGER.warning(
                     "Bridge lacks GetDeviceCapabilities; using legacy gRPC-status capability inference for SKI %s",
-                    ski,
+                    short_ski(ski),
                 )
             return None
-        _LOGGER.debug("Capability contract read failed for SKI %s: %s", ski, _rpc_error_text(err))
+        _LOGGER.debug("Capability contract read failed for SKI %s: %s", short_ski(ski), _rpc_error_text(err))
         return None
 
     return _capability_results_from_proto(response)
@@ -212,7 +213,7 @@ async def _poll_read[ResponseT](
         _LOGGER.debug(
             "EEBUS %s read failed for SKI %s: %s",
             label,
-            ski,
+            short_ski(ski),
             _rpc_error_text(err),
         )
         return _ReadResult(
@@ -226,7 +227,7 @@ async def _poll_read[ResponseT](
             None,
             status=grpc.StatusCode.UNKNOWN,
         )
-    _LOGGER.debug("EEBUS %s read for SKI %s succeeded", label, ski)
+    _LOGGER.debug("EEBUS %s read for SKI %s succeeded", label, short_ski(ski))
     return _ReadResult(response)
 
 
@@ -241,22 +242,22 @@ async def _async_register_remote_ski(
     try:
         await device_stub.RegisterRemoteSKI(proto_stubs.RegisterSKIRequest(ski=ski), timeout=RPC_TIMEOUT)
         if force:
-            _LOGGER.info("Forced re-registration of remote SKI %s with bridge", ski)
+            _LOGGER.info("Forced re-registration of remote SKI %s with bridge", short_ski(ski))
         else:
-            _LOGGER.info("Registered remote SKI %s with bridge", ski)
+            _LOGGER.info("Registered remote SKI %s with bridge", short_ski(ski))
         return True
     except grpc.aio.AioRpcError as err:
         if force:
             _LOGGER.warning(
                 "Forced remote SKI re-registration failed for %s: %s",
-                ski,
+                short_ski(ski),
                 _rpc_error_text(err),
             )
         else:
             # Retry in next polling cycle until the bridge accepts registration.
             _LOGGER.debug(
                 "Remote SKI registration pending for %s: %s",
-                ski,
+                short_ski(ski),
                 _rpc_error_text(err),
             )
         return registered
@@ -270,7 +271,7 @@ async def _async_fetch_device_info(device_stub: proto_stubs.DeviceServiceStub, s
         if not _is_unimplemented(err):
             _LOGGER.debug(
                 "ListPairedDevices failed for SKI %s: %s",
-                ski,
+                short_ski(ski),
                 _rpc_error_text(err),
             )
         return None
@@ -312,7 +313,7 @@ async def _async_read_compressor_flexibility(
         if not _is_unimplemented(err):
             _LOGGER.debug(
                 "EEBUS OHPCF read failed for SKI %s: %s",
-                ski,
+                short_ski(ski),
                 _rpc_error_text(err),
             )
         return _ReadResult(None, status=err.code())
@@ -346,7 +347,7 @@ async def _async_read_dhw_setpoint(
         if not _is_unimplemented(err):
             _LOGGER.debug(
                 "EEBUS DHW setpoint read failed for SKI %s: %s",
-                ski,
+                short_ski(ski),
                 _rpc_error_text(err),
             )
         return _ReadResult(None, status=err.code())
@@ -366,7 +367,7 @@ async def _async_read_dhw_system_function(
         if not _is_unimplemented(err):
             _LOGGER.debug(
                 "EEBUS DHW system function read failed for SKI %s: %s",
-                ski,
+                short_ski(ski),
                 _rpc_error_text(err),
             )
         return _ReadResult(None, status=err.code())
@@ -403,7 +404,7 @@ async def _async_read_device_diagnostics(
         if not (_is_unimplemented(err) or err.code() in (grpc.StatusCode.NOT_FOUND, grpc.StatusCode.UNAVAILABLE)):
             _LOGGER.debug(
                 "EEBUS device diagnosis read failed for SKI %s: %s",
-                ski,
+                short_ski(ski),
                 _rpc_error_text(err),
             )
         return _ReadResult(None, status=err.code())
@@ -528,7 +529,7 @@ async def async_build_snapshot(
     if ski == status.local_ski:
         _LOGGER.warning(
             "Configured remote SKI %s matches bridge local SKI; monitoring reads will stay empty",
-            ski,
+            short_ski(ski),
         )
 
     flat_measurements: dict[str, float | None] = {}
@@ -676,7 +677,7 @@ async def async_build_snapshot(
         _LOGGER.warning(
             "EEBUS reads returned NOT_FOUND for %s consecutive polls; forcing remote SKI re-registration for %s",
             updated_not_found_streak,
-            ski,
+            short_ski(ski),
         )
         registered = await _async_register_remote_ski(
             device_stub,
@@ -688,7 +689,7 @@ async def async_build_snapshot(
 
     _LOGGER.debug(
         "EEBUS poll summary for SKI %s: power=%s energy_total=%s energy_heating=%s energy_dhw=%s",
-        ski,
+        short_ski(ski),
         state.measurements.power_watts,
         state.measurements.energy_consumed_kwh,
         state.measurements.energy_consumed_heating_kwh,
@@ -843,7 +844,7 @@ async def async_build_device_snapshot(
             _LOGGER.warning(
                 "GetDeviceSnapshot returned NOT_FOUND for %s consecutive polls; forcing remote SKI re-registration for %s",
                 updated_not_found_streak,
-                ski,
+                short_ski(ski),
             )
             registered = await _async_register_remote_ski(
                 stub,

--- a/custom_components/eebus/snapshot.py
+++ b/custom_components/eebus/snapshot.py
@@ -42,6 +42,7 @@ from .models import (
     _room_heating_from_proto,
     _setpoint_to_dict,
 )
+from .ski import short_ski
 from .state import (
     CapabilityKey,
     CapabilityResult,
@@ -56,7 +57,6 @@ from .state import (
     StateField,
     StateObservation,
 )
-from .ski import short_ski
 
 _LOGGER = logging.getLogger(__name__)
 _LEGACY_CAPABILITY_WARNED: set[str] = set()

--- a/custom_components/eebus/tests/test_ski.py
+++ b/custom_components/eebus/tests/test_ski.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from custom_components.eebus.ski import is_valid_ski, normalize_ski
+from custom_components.eebus.ski import is_valid_ski, normalize_ski, short_ski
 
 
 @pytest.mark.parametrize(
@@ -34,6 +34,12 @@ def test_normalize_ski_does_not_expand_unicode_ligatures() -> None:
     normalized = normalize_ski(ligature_ski)
     assert normalized != "F" * 40
     assert not is_valid_ski(normalized)
+
+
+def test_short_ski_redacts_normalized_fingerprint() -> None:
+    ski = "AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD"
+    assert short_ski(ski) == "…BBCCDD"
+    assert "AABBCC" not in short_ski(ski)
 
 
 @pytest.mark.parametrize(

--- a/eebus-bridge/cmd/eebus-bridge/app.go
+++ b/eebus-bridge/cmd/eebus-bridge/app.go
@@ -261,7 +261,7 @@ func NewApplication(cfg *config.Config) (*Application, error) {
 	if err != nil {
 		return nil, fmt.Errorf("extracting SKI: %w", err)
 	}
-	log.Printf("Local SKI: %s", ski)
+	log.Printf("Local SKI: %s", eebus.ShortSKI(ski))
 
 	bus := eebus.NewEventBus()
 	registry := eebus.NewDeviceRegistry()
@@ -769,7 +769,7 @@ func (a *Application) startComponents(runtimeCtx context.Context, tx *lifecycleT
 	// the SHIP handshake without Home Assistant sending device.register_ski.
 	if a.cfg.Experimental.TrustSKI != "" {
 		a.bridgeSvc.RegisterRemoteSKI(a.cfg.Experimental.TrustSKI)
-		log.Printf("[EXP] auto-trusted remote SKI: %s", a.cfg.Experimental.TrustSKI)
+		log.Printf("[EXP] auto-trusted remote SKI: %s", eebus.ShortSKI(a.cfg.Experimental.TrustSKI))
 	}
 	if a.cfg.Logging.DebugEvents {
 		log.Println("[DEBUG] EEBUS event debug logging enabled; waiting for incoming callbacks")

--- a/eebus-bridge/internal/eebus/callbacks.go
+++ b/eebus-bridge/internal/eebus/callbacks.go
@@ -39,7 +39,7 @@ var _ api.ServiceReaderInterface = (*Callbacks)(nil)
 func (c *Callbacks) RemoteServiceConnected(_ api.ServiceInterface, identity shipapi.ServiceIdentity) {
 	ski := NormalizeSKI(identity.SKI)
 	if c.debugEvents {
-		log.Printf("[DEBUG] EEBUS callback: remote service connected: ski=%s", ski)
+		log.Printf("[DEBUG] EEBUS callback: remote service connected: ski=%s", ShortSKI(ski))
 	}
 
 	if c.registry != nil {
@@ -57,7 +57,7 @@ func (c *Callbacks) RemoteServiceConnected(_ api.ServiceInterface, identity ship
 func (c *Callbacks) RemoteServiceDisconnected(_ api.ServiceInterface, identity shipapi.ServiceIdentity) {
 	ski := NormalizeSKI(identity.SKI)
 	if c.debugEvents {
-		log.Printf("[DEBUG] EEBUS callback: remote service disconnected: ski=%s", ski)
+		log.Printf("[DEBUG] EEBUS callback: remote service disconnected: ski=%s", ShortSKI(ski))
 	}
 
 	// Drop cached entity references so a later re-pair re-populates them from
@@ -98,9 +98,9 @@ func (c *Callbacks) ServicePairingDetailUpdate(identity shipapi.ServiceIdentity,
 	ski := NormalizeSKI(identity.SKI)
 	if c.debugEvents {
 		if detail != nil {
-			log.Printf("[DEBUG] EEBUS callback: pairing detail updated: ski=%s state=%v", ski, detail.State())
+			log.Printf("[DEBUG] EEBUS callback: pairing detail updated: ski=%s state=%v", ShortSKI(ski), detail.State())
 		} else {
-			log.Printf("[DEBUG] EEBUS callback: pairing detail updated: ski=%s state=<nil>", ski)
+			log.Printf("[DEBUG] EEBUS callback: pairing detail updated: ski=%s state=<nil>", ShortSKI(ski))
 		}
 	}
 
@@ -113,7 +113,7 @@ func (c *Callbacks) ServicePairingDetailUpdate(identity shipapi.ServiceIdentity,
 // ServiceAutoTrusted is called when a device is automatically trusted via SHIP pairing.
 func (c *Callbacks) ServiceAutoTrusted(_ api.ServiceInterface, identity shipapi.ServiceIdentity) {
 	if c.debugEvents {
-		log.Printf("[DEBUG] EEBUS callback: service auto-trusted: ski=%s", NormalizeSKI(identity.SKI))
+		log.Printf("[DEBUG] EEBUS callback: service auto-trusted: ski=%s", ShortSKI(identity.SKI))
 	}
 	if c.registry != nil {
 		c.registry.MarkTrusted(identity.SKI)
@@ -123,7 +123,7 @@ func (c *Callbacks) ServiceAutoTrusted(_ api.ServiceInterface, identity shipapi.
 // ServiceAutoTrustFailed is called when SHIP pairing fails for a device.
 func (c *Callbacks) ServiceAutoTrustFailed(_ api.ServiceInterface, identity shipapi.ServiceIdentity, reason error) {
 	if c.debugEvents {
-		log.Printf("[DEBUG] EEBUS callback: service auto-trust failed: ski=%s reason=%v", NormalizeSKI(identity.SKI), reason)
+		log.Printf("[DEBUG] EEBUS callback: service auto-trust failed: ski=%s reason=%v", ShortSKI(identity.SKI), reason)
 	}
 	if c.registry != nil {
 		c.registry.MarkUntrusted(identity.SKI)
@@ -138,7 +138,7 @@ func (c *Callbacks) ServiceAutoTrustFailed(_ api.ServiceInterface, identity ship
 func (c *Callbacks) ServiceAutoTrustRemoved(_ api.ServiceInterface, identity shipapi.ServiceIdentity, reason string) {
 	ski := NormalizeSKI(identity.SKI)
 	if c.debugEvents {
-		log.Printf("[DEBUG] EEBUS callback: service auto-trust removed: ski=%s reason=%s", ski, reason)
+		log.Printf("[DEBUG] EEBUS callback: service auto-trust removed: ski=%s reason=%s", ShortSKI(ski), reason)
 	}
 
 	if c.registry != nil {

--- a/eebus-bridge/internal/eebus/callbacks_test.go
+++ b/eebus-bridge/internal/eebus/callbacks_test.go
@@ -1,7 +1,10 @@
 package eebus_test
 
 import (
+	"bytes"
 	"errors"
+	"log"
+	"strings"
 	"testing"
 	"time"
 
@@ -9,6 +12,32 @@ import (
 	spineapi "github.com/enbility/spine-go/api"
 	"github.com/volschin/eebus-bridge/internal/eebus"
 )
+
+func TestCallbacksDebugLogsRedactedSKI(t *testing.T) {
+	const fullSKI = "682f708ceba5df9adcb9e6787ea911d9fc3ac490"
+	var output bytes.Buffer
+	previousWriter := log.Writer()
+	previousFlags := log.Flags()
+	log.SetOutput(&output)
+	log.SetFlags(0)
+	t.Cleanup(func() {
+		log.SetOutput(previousWriter)
+		log.SetFlags(previousFlags)
+	})
+
+	callbacks := eebus.NewCallbacks(eebus.NewEventBus(), true)
+	identity := shipapi.ServiceIdentity{SKI: fullSKI}
+	callbacks.RemoteServiceConnected(nil, identity)
+	callbacks.RemoteServiceDisconnected(nil, identity)
+
+	got := output.String()
+	if strings.Contains(got, fullSKI) {
+		t.Fatalf("callback log leaked full SKI: %q", got)
+	}
+	if !strings.Contains(got, "…3AC490") {
+		t.Fatalf("callback log lacks redacted correlation suffix: %q", got)
+	}
+}
 
 func TestCallbacksDispatchConnect(t *testing.T) {
 	bus := eebus.NewEventBus()

--- a/eebus-bridge/internal/eebus/discovery.go
+++ b/eebus-bridge/internal/eebus/discovery.go
@@ -76,7 +76,7 @@ func FormatDeviceUseCases(ski string, device spineapi.DeviceRemoteInterface) str
 		deviceType = string(*dt)
 	}
 	entities := device.Entities()
-	fmt.Fprintf(&b, "[DISCOVERY] device ski=%s type=%s entities=%d\n", ski, deviceType, len(entities))
+	fmt.Fprintf(&b, "[DISCOVERY] device ski=%s type=%s entities=%d\n", ShortSKI(ski), deviceType, len(entities))
 
 	for _, e := range entities {
 		if e == nil {

--- a/eebus-bridge/internal/eebus/discovery_test.go
+++ b/eebus-bridge/internal/eebus/discovery_test.go
@@ -78,7 +78,7 @@ func TestFormatDeviceUseCases(t *testing.T) {
 	out := FormatDeviceUseCases("ABCD1234", device)
 
 	for _, want := range []string{
-		"[DISCOVERY] device ski=ABCD1234",
+		"[DISCOVERY] device ski=…CD1234",
 		string(model.DeviceTypeTypeHeatgenerationSystem),
 		string(model.UseCaseNameTypeMonitoringOfPowerConsumption),
 		"available=true",

--- a/eebus-bridge/internal/eebus/logging.go
+++ b/eebus-bridge/internal/eebus/logging.go
@@ -1,6 +1,22 @@
 package eebus
 
-import "log"
+import (
+	"fmt"
+	"log"
+	"regexp"
+)
+
+var (
+	logSKIPattern    = regexp.MustCompile(`(?i)\b[0-9a-f]{40}\b`)
+	logTokenPattern  = regexp.MustCompile(`(?i)token=[^\s,)]+`)
+	logBearerPattern = regexp.MustCompile(`(?i)bearer\s+[^\s,)]+`)
+)
+
+func redactLogText(message string) string {
+	message = logSKIPattern.ReplaceAllString(message, "[redacted-ski]")
+	message = logTokenPattern.ReplaceAllString(message, "token=[redacted]")
+	return logBearerPattern.ReplaceAllString(message, "Bearer [redacted]")
+}
 
 // shipLogger adapts the ship-go/eebus-go logging.LoggingInterface to the
 // bridge's stdlib logger. Trace output (raw per-message JSON) is gated behind
@@ -12,36 +28,36 @@ type shipLogger struct {
 
 func (l *shipLogger) Trace(args ...interface{}) {
 	if l.trace {
-		log.Print(append([]interface{}{"[SHIP TRACE] "}, args...)...)
+		log.Print("[SHIP TRACE] " + redactLogText(fmt.Sprint(args...)))
 	}
 }
 
 func (l *shipLogger) Tracef(format string, args ...interface{}) {
 	if l.trace {
-		log.Printf("[SHIP TRACE] "+format, args...)
+		log.Print("[SHIP TRACE] " + redactLogText(fmt.Sprintf(format, args...)))
 	}
 }
 
 func (l *shipLogger) Debug(args ...interface{}) {
-	log.Print(append([]interface{}{"[SHIP DEBUG] "}, args...)...)
+	log.Print("[SHIP DEBUG] " + redactLogText(fmt.Sprint(args...)))
 }
 
 func (l *shipLogger) Debugf(format string, args ...interface{}) {
-	log.Printf("[SHIP DEBUG] "+format, args...)
+	log.Print("[SHIP DEBUG] " + redactLogText(fmt.Sprintf(format, args...)))
 }
 
 func (l *shipLogger) Info(args ...interface{}) {
-	log.Print(append([]interface{}{"[SHIP INFO] "}, args...)...)
+	log.Print("[SHIP INFO] " + redactLogText(fmt.Sprint(args...)))
 }
 
 func (l *shipLogger) Infof(format string, args ...interface{}) {
-	log.Printf("[SHIP INFO] "+format, args...)
+	log.Print("[SHIP INFO] " + redactLogText(fmt.Sprintf(format, args...)))
 }
 
 func (l *shipLogger) Error(args ...interface{}) {
-	log.Print(append([]interface{}{"[SHIP ERROR] "}, args...)...)
+	log.Print("[SHIP ERROR] " + redactLogText(fmt.Sprint(args...)))
 }
 
 func (l *shipLogger) Errorf(format string, args ...interface{}) {
-	log.Printf("[SHIP ERROR] "+format, args...)
+	log.Print("[SHIP ERROR] " + redactLogText(fmt.Sprintf(format, args...)))
 }

--- a/eebus-bridge/internal/eebus/service_additional_test.go
+++ b/eebus-bridge/internal/eebus/service_additional_test.go
@@ -102,10 +102,14 @@ func TestShipLoggerForwardsEveryLevelAndTraceGate(t *testing.T) {
 	logger.Infof("info %d", 4)
 	logger.Error("error")
 	logger.Errorf("error %d", 5)
+	logger.Info("local ski=682f708ceba5df9adcb9e6787ea911d9fc3ac490 token=super-secret")
 	for _, marker := range []string{"[SHIP TRACE]", "[SHIP DEBUG]", "[SHIP INFO]", "[SHIP ERROR]"} {
 		if !strings.Contains(output.String(), marker) {
 			t.Fatalf("log output %q does not contain %q", output.String(), marker)
 		}
+	}
+	if strings.Contains(output.String(), "682f708ceba5df9adcb9e6787ea911d9fc3ac490") || strings.Contains(output.String(), "super-secret") {
+		t.Fatalf("SHIP logger leaked sensitive detail: %q", output.String())
 	}
 }
 

--- a/eebus-bridge/internal/grpc/errors.go
+++ b/eebus-bridge/internal/grpc/errors.go
@@ -43,7 +43,7 @@ type usecaseErrorClasses struct {
 }
 
 func mapUsecaseError(action string, err error, classes usecaseErrorClasses) error {
-	log.Printf("%s failed: %v", action, err)
+	log.Printf("%s failed: %s", action, redactSensitiveDetail(err.Error()))
 	switch {
 	case errorsIsAny(err, classes.invalidArgument):
 		return status.Error(codes.InvalidArgument, classifiedErrorMessage(action, "invalid request", err))

--- a/eebus-bridge/internal/grpc/errors_test.go
+++ b/eebus-bridge/internal/grpc/errors_test.go
@@ -1,9 +1,11 @@
 package grpc
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
+	"log"
 	"strings"
 	"testing"
 
@@ -81,6 +83,32 @@ func TestUnknownInternalErrorIsSanitized(t *testing.T) {
 	err := mapUsecaseError("reading data", errors.New("token=super-secret"), usecaseErrorClasses{})
 	if status.Code(err) != codes.Internal || strings.Contains(err.Error(), "super-secret") {
 		t.Fatalf("internal error was not sanitized: %v", err)
+	}
+}
+
+func TestUsecaseErrorLogIsSanitized(t *testing.T) {
+	var output bytes.Buffer
+	previousWriter := log.Writer()
+	previousFlags := log.Flags()
+	log.SetOutput(&output)
+	log.SetFlags(0)
+	t.Cleanup(func() {
+		log.SetOutput(previousWriter)
+		log.SetFlags(previousFlags)
+	})
+
+	mapUsecaseError(
+		"reading data",
+		fmt.Errorf("token=super-secret ski=%s: %w", testValidSKI, eebusapi.ErrEntityNotFound),
+		standardUsecaseErrorClasses,
+	)
+
+	got := output.String()
+	if strings.Contains(got, "super-secret") || strings.Contains(got, testValidSKI) {
+		t.Fatalf("usecase error log leaked sensitive detail: %q", got)
+	}
+	if !strings.Contains(got, "token=[redacted]") || !strings.Contains(got, "[redacted-ski]") {
+		t.Fatalf("usecase error log did not preserve redaction markers: %q", got)
 	}
 }
 

--- a/eebus-bridge/internal/usecases/dhwsysfn_adapter.go
+++ b/eebus-bridge/internal/usecases/dhwsysfn_adapter.go
@@ -58,7 +58,7 @@ func (w *DHWSystemFunctionMonitoring) HandleEvent(
 	event eebusapi.EventType,
 ) {
 	if w.debug {
-		log.Printf("[DEBUG] EEBUS DHW system function monitoring event received: ski=%s event=%s", ski, event)
+		log.Printf("[DEBUG] EEBUS DHW system function monitoring event received: ski=%s event=%s", eebus.ShortSKI(ski), event)
 	}
 
 	var eventType eebus.EventType

--- a/eebus-bridge/internal/usecases/lpc.go
+++ b/eebus-bridge/internal/usecases/lpc.go
@@ -49,7 +49,7 @@ func (w *LPCWrapper) HandleEvent(ski string, device spineapi.DeviceRemoteInterfa
 	if w.debug {
 		log.Printf(
 			"[DEBUG] EEBUS LPC event received: ski=%s event=%s has_device=%t has_entity=%t",
-			ski,
+			eebus.ShortSKI(ski),
 			event,
 			device != nil,
 			entity != nil,

--- a/eebus-bridge/internal/usecases/mgcp.go
+++ b/eebus-bridge/internal/usecases/mgcp.go
@@ -332,7 +332,7 @@ func (p *MGCPProvider) PublishEnergyConsumed(wh float64) error {
 // VR940 has discovered our grid-connection-point.
 func (p *MGCPProvider) handleEvent(ski string, _ spineapi.DeviceRemoteInterface, _ spineapi.EntityRemoteInterface, event eebusapi.EventType) {
 	if event == mgcpUseCaseSupportUpdate {
-		log.Printf("[MGCP] consumer support update from ski=%s", ski)
+		log.Printf("[MGCP] consumer support update from ski=%s", eebus.ShortSKI(ski))
 		if p.bus != nil {
 			p.bus.Publish(eebus.Event{SKI: ski, Type: eebus.EventTypeMGCPConsumerUpdated})
 		}

--- a/eebus-bridge/internal/usecases/monitoring.go
+++ b/eebus-bridge/internal/usecases/monitoring.go
@@ -61,7 +61,7 @@ func (w *MonitoringWrapper) HandleEvent(ski string, device spineapi.DeviceRemote
 	if w.debug {
 		log.Printf(
 			"[DEBUG] EEBUS monitoring event received: ski=%s event=%s has_device=%t has_entity=%t",
-			ski,
+			eebus.ShortSKI(ski),
 			event,
 			device != nil,
 			entity != nil,
@@ -194,7 +194,7 @@ func (w *MonitoringWrapper) GenericMeasurements(ski string) ([]GenericMeasuremen
 		measurements, err := w.measurementsForEntity(entityInfo)
 		if err != nil {
 			if w.debug {
-				log.Printf("[DEBUG] EEBUS generic measurement read failed: ski=%s entity=%s/%s err=%v", ski, entityInfo.Address, entityInfo.Type, err)
+				log.Printf("[DEBUG] EEBUS generic measurement read failed: ski=%s entity=%s/%s err=%v", eebus.ShortSKI(ski), entityInfo.Address, entityInfo.Type, err)
 			}
 			continue
 		}

--- a/eebus-bridge/internal/usecases/ohpcf.go
+++ b/eebus-bridge/internal/usecases/ohpcf.go
@@ -71,7 +71,7 @@ func (w *OHPCFWrapper) HandleEvent(ski string, device spineapi.DeviceRemoteInter
 	if w.debug {
 		log.Printf(
 			"[DEBUG] EEBUS ohpcf event received: ski=%s event=%s has_device=%t has_entity=%t",
-			ski,
+			eebus.ShortSKI(ski),
 			event,
 			device != nil,
 			entity != nil,

--- a/eebus-bridge/internal/usecases/roomheatingsysfn_adapter.go
+++ b/eebus-bridge/internal/usecases/roomheatingsysfn_adapter.go
@@ -56,7 +56,7 @@ func (w *RoomHeatingSystemFunctionMonitoring) HandleEvent(
 	event eebusapi.EventType,
 ) {
 	if w.debug {
-		log.Printf("[DEBUG] EEBUS room heating system function monitoring event received: ski=%s event=%s", ski, event)
+		log.Printf("[DEBUG] EEBUS room heating system function monitoring event received: ski=%s event=%s", eebus.ShortSKI(ski), event)
 	}
 
 	var eventType eebus.EventType

--- a/eebus-bridge/internal/usecases/roomheatingtemp_configuration.go
+++ b/eebus-bridge/internal/usecases/roomheatingtemp_configuration.go
@@ -136,7 +136,7 @@ func (f *CRHTConfigurationFacade) HandleEvent(
 		return
 	}
 	if f.debug {
-		log.Printf("[DEBUG] EEBUS room heating temperature event received: ski=%s event=%s", ski, event)
+		log.Printf("[DEBUG] EEBUS room heating temperature event received: ski=%s event=%s", eebus.ShortSKI(ski), event)
 	}
 
 	var eventType eebus.EventType

--- a/eebus-bridge/internal/usecases/temperaturemonitoring.go
+++ b/eebus-bridge/internal/usecases/temperaturemonitoring.go
@@ -126,7 +126,7 @@ func (w *TemperatureMonitoringWrapper) HandleEvent(
 	event eebusapi.EventType,
 ) {
 	if w.debug {
-		log.Printf("[DEBUG] EEBUS %s event received: ski=%s event=%s", w.logLabel, ski, event)
+		log.Printf("[DEBUG] EEBUS %s event received: ski=%s event=%s", w.logLabel, eebus.ShortSKI(ski), event)
 	}
 	if w.registry != nil {
 		w.registry.UpsertObservation(ski, device, entity, w.registryTag)

--- a/eebus-bridge/internal/usecases/vabd.go
+++ b/eebus-bridge/internal/usecases/vabd.go
@@ -348,7 +348,7 @@ func (p *VABDProvider) PublishStateOfCharge(pct float64) error {
 // remote VisualizationAppliance binds to the provider.
 func (p *VABDProvider) handleEvent(ski string, _ spineapi.DeviceRemoteInterface, _ spineapi.EntityRemoteInterface, event eebusapi.EventType) {
 	if event == vabdUseCaseSupportUpdate {
-		log.Printf("[VABD] consumer support update from ski=%s", ski)
+		log.Printf("[VABD] consumer support update from ski=%s", eebus.ShortSKI(ski))
 		if p.bus != nil {
 			p.bus.Publish(eebus.Event{SKI: ski, Type: eebus.EventTypeVABDConsumerUpdated})
 		}

--- a/eebus-bridge/internal/usecases/vapd.go
+++ b/eebus-bridge/internal/usecases/vapd.go
@@ -339,7 +339,7 @@ func (p *VAPDProvider) PublishPeakPower(watts float64) error {
 // remote VisualizationAppliance binds to the provider.
 func (p *VAPDProvider) handleEvent(ski string, _ spineapi.DeviceRemoteInterface, _ spineapi.EntityRemoteInterface, event eebusapi.EventType) {
 	if event == vapdUseCaseSupportUpdate {
-		log.Printf("[VAPD] consumer support update from ski=%s", ski)
+		log.Printf("[VAPD] consumer support update from ski=%s", eebus.ShortSKI(ski))
 		if p.bus != nil {
 			p.bus.Publish(eebus.Event{SKI: ski, Type: eebus.EventTypeVAPDConsumerUpdated})
 		}


### PR DESCRIPTION
## Summary

- redact full local and remote SKIs from Go and Home Assistant log messages while retaining the last six characters for correlation
- sanitize tokens, bearer credentials, and 40-character SKIs emitted by the optional SHIP upstream logger
- redact raw use-case errors before they are written to the Go log
- preserve full SKIs in RPC requests/responses, registry state, and configuration data

## TDD evidence

The new regression tests first failed with the original behavior:

- `TestUsecaseErrorLogIsSanitized` captured `token=super-secret` and the complete SKI
- `TestShipLoggerForwardsEveryLevelAndTraceGate` captured the complete SKI and token
- Python `test_short_ski_redacts_normalized_fingerprint` initially failed because no safe log helper existed

## Verification

- `PYTHONPATH=. .venv/bin/pytest` — 303 passed
- `ruff check custom_components/`
- `.venv/bin/mypy custom_components/eebus`
- `go vet ./...`
- `make test` — race-enabled full Go suite passed
- `make build`
- `PYTHON_BIN=.venv/bin/python bash generate_proto.sh`
- `PATH="../.cache/proto-tools/bin:$PATH" make proto`
- `uvx zizmor --offline .` — no findings
- `actionlint` — no findings
- `git diff --check`

## Summary by Sourcery

Redact sensitive identifiers and credentials from logging while preserving SKI usability for correlation.

New Features:
- Introduce helper utilities in Python and Go to produce shortened, log-safe SKI fingerprints.
- Add log text redaction for SHIP upstream logger messages, including SKIs, tokens, and bearer credentials.

Bug Fixes:
- Prevent use-case error logging from leaking raw tokens and full SKIs into Go logs.
- Ensure Home Assistant migration logs no longer print full device SKIs.

Enhancements:
- Update EEBUS bridge, discovery, monitoring, and device-related logs to use shortened SKIs instead of full fingerprints.
- Strengthen test coverage around log redaction behavior for SKIs and secrets in both Python and Go components.

Tests:
- Add regression tests verifying that short SKIs are redacted correctly and that sensitive details are not leaked by SHIP logger or use-case error logging.