### PR TITLE
chore: prepare v0.16.4 release

### DIFF
--- a/custom_components/eebus/manifest.json
+++ b/custom_components/eebus/manifest.json
@@ -10,6 +10,6 @@
   "quality_scale": "platinum",
   "requirements": ["grpcio>=1.78.0", "protobuf>=4.25.0"],
   "single_config_entry": false,
-  "version": "0.16.3",
+  "version": "0.16.4",
   "zeroconf": ["_ship._tcp.local."]
 }

--- a/eebus-bridge-addon/config.yaml
+++ b/eebus-bridge-addon/config.yaml
@@ -4,7 +4,7 @@ name: EEBUS Bridge
 # Dockerfile uses it as the tag of the published bridge image. Bumping it is
 # therefore the single action that both offers users an update and selects the
 # binary they get. scripts/check_addon_version.py enforces the equality.
-version: "0.16.3"
+version: "0.16.4"
 slug: eebus_bridge
 description: >-
   EEBUS SHIP/SPINE bridge for heat pumps. Serves the gRPC API that the EEBUS


### PR DESCRIPTION
## Summary

- bump Home Assistant integration version to 0.16.4
- bump Home Assistant add-on version to 0.16.4

## Verification

- `python3 scripts/check_addon_version.py`
- `PYTHONPATH=. uv run pytest -q`
- `uv run ruff check custom_components/`
- `uv run mypy custom_components/eebus`

## Summary by Sourcery

Chores:
- Bump the Home Assistant integration and add-on versions to 0.16.4.