### PR TITLE
refactor: modernize code for Go 1.27

### DIFF
--- a/eebus-bridge/cmd/eebus-bridge/app.go
+++ b/eebus-bridge/cmd/eebus-bridge/app.go
@@ -5,8 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"log"
-	"os"
-	"os/signal"
 	"reflect"
 	"strings"
 	"sync"
@@ -196,12 +194,6 @@ type controlledShutdownError struct {
 
 func (e *controlledShutdownError) Error() string { return e.err.Error() }
 func (e *controlledShutdownError) Unwrap() error { return e.err }
-
-type signalShutdown struct {
-	signal os.Signal
-}
-
-func (s *signalShutdown) Error() string { return "received signal " + s.signal.String() }
 
 // Application owns the daemon's EEBUS, use-case, gRPC, watchdog, and shutdown
 // lifecycle. The small lifecycle interfaces keep failure fan-out and teardown
@@ -681,9 +673,8 @@ func (a *Application) Start(ctx context.Context) error {
 
 	select {
 	case <-runtimeCtx.Done():
-		var sig *signalShutdown
-		if errors.As(context.Cause(ctx), &sig) {
-			log.Printf("Received signal %s", sig.signal)
+		if cause := context.Cause(ctx); cause != nil && !errors.Is(cause, context.Canceled) {
+			log.Printf("Shutdown requested: %v", cause)
 		}
 		return nil
 	case failure := <-a.backgroundFailures:
@@ -910,32 +901,7 @@ func (a *Application) Stop() {
 }
 
 func logRunError(err error) {
-	var controlled *controlledShutdownError
-	if !errors.As(err, &controlled) {
+	if _, ok := errors.AsType[*controlledShutdownError](err); !ok {
 		log.Print(err)
-	}
-}
-
-func notifySignalContext(parent context.Context, signals ...os.Signal) (context.Context, func()) {
-	ctx, cancel := context.WithCancelCause(parent)
-	signalCh := make(chan os.Signal, 1)
-	signal.Notify(signalCh, signals...)
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		select {
-		case sig := <-signalCh:
-			cancel(&signalShutdown{signal: sig})
-		case <-ctx.Done():
-		}
-	}()
-
-	var stopOnce sync.Once
-	return ctx, func() {
-		stopOnce.Do(func() {
-			signal.Stop(signalCh)
-			cancel(context.Canceled)
-		})
-		<-done
 	}
 }

--- a/eebus-bridge/cmd/eebus-bridge/app.go
+++ b/eebus-bridge/cmd/eebus-bridge/app.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"os"
+	"os/signal"
 	"reflect"
 	"strings"
 	"sync"
@@ -904,4 +906,8 @@ func logRunError(err error) {
 	if _, ok := errors.AsType[*controlledShutdownError](err); !ok {
 		log.Print(err)
 	}
+}
+
+func notifySignalContext(parent context.Context, signals ...os.Signal) (context.Context, context.CancelFunc) {
+	return signal.NotifyContext(parent, signals...)
 }

--- a/eebus-bridge/cmd/eebus-bridge/app_test.go
+++ b/eebus-bridge/cmd/eebus-bridge/app_test.go
@@ -3,10 +3,12 @@ package main
 import (
 	"context"
 	"errors"
+	"fmt"
+	"log"
 	"net"
+	"strings"
 	"sync"
 	"sync/atomic"
-	"syscall"
 	"testing"
 	"time"
 
@@ -282,38 +284,17 @@ func TestApplicationErrorWrappersAndLogging(t *testing.T) {
 	if controlled.Error() != want.Error() || !errors.Is(controlled, want) {
 		t.Fatalf("controlled error = %v", controlled)
 	}
-	signalErr := &signalShutdown{signal: syscall.SIGTERM}
-	if signalErr.Error() != "received signal terminated" {
-		t.Fatalf("signal error = %q", signalErr.Error())
-	}
-	logRunError(controlled)
+
+	var output strings.Builder
+	oldOutput := log.Writer()
+	log.SetOutput(&output)
+	t.Cleanup(func() { log.SetOutput(oldOutput) })
+
+	logRunError(fmt.Errorf("wrapped: %w", controlled))
+	assert.Empty(t, output.String())
+
 	logRunError(want)
-}
-
-func TestNotifySignalContextStopsAndCapturesSignal(t *testing.T) {
-	t.Run("explicit stop", func(t *testing.T) {
-		ctx, stop := notifySignalContext(context.Background(), syscall.SIGUSR1)
-		stop()
-		stop()
-		if !errors.Is(context.Cause(ctx), context.Canceled) {
-			t.Fatalf("context cause = %v", context.Cause(ctx))
-		}
-	})
-
-	t.Run("signal", func(t *testing.T) {
-		ctx, stop := notifySignalContext(context.Background(), syscall.SIGUSR1)
-		defer stop()
-		require.NoError(t, syscall.Kill(syscall.Getpid(), syscall.SIGUSR1))
-		select {
-		case <-ctx.Done():
-			var signalCause *signalShutdown
-			if !errors.As(context.Cause(ctx), &signalCause) || signalCause.signal != syscall.SIGUSR1 {
-				t.Fatalf("context cause = %v", context.Cause(ctx))
-			}
-		case <-time.After(time.Second):
-			t.Fatal("timeout waiting for signal context")
-		}
-	})
+	assert.Contains(t, output.String(), "runtime failure")
 }
 
 type fakeHeartbeatLifecycle struct {
@@ -798,13 +779,17 @@ func TestMonitoringWatchdogHealthTracksTrustedDisconnectedDevice(t *testing.T) {
 	assert.Equal(t, []bool{false}, grpcServer.deviceHealthValues())
 }
 
-func TestApplicationStartSignalTriggersShutdown(t *testing.T) {
+func TestApplicationStartCancellationCauseTriggersShutdown(t *testing.T) {
 	bridge := &fakeBridgeLifecycle{started: make(chan struct{})}
 	grpcServer := &fakeGRPCLifecycle{release: make(chan struct{}), serving: make(chan struct{})}
 	heartbeat := &fakeHeartbeatLifecycle{}
 	app := newTestApplication(bridge, grpcServer, heartbeat, nil)
 	ctx, cancel := context.WithCancelCause(context.Background())
 	result := make(chan error, 1)
+	var output strings.Builder
+	oldOutput := log.Writer()
+	log.SetOutput(&output)
+	t.Cleanup(func() { log.SetOutput(oldOutput) })
 	go func() { result <- app.Start(ctx) }()
 
 	select {
@@ -812,14 +797,15 @@ func TestApplicationStartSignalTriggersShutdown(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("application did not become ready")
 	}
-	cancel(&signalShutdown{signal: syscall.SIGTERM})
+	cancel(errors.New("terminated signal received"))
 
 	select {
 	case err := <-result:
 		require.NoError(t, err)
 	case <-time.After(time.Second):
-		t.Fatal("application did not stop after signal cancellation")
+		t.Fatal("application did not stop after cancellation")
 	}
+	assert.Contains(t, output.String(), "Shutdown requested: terminated signal received")
 	assert.Equal(t, int32(1), bridge.stops.Load())
 	assert.Equal(t, int32(1), grpcServer.stops.Load())
 	assert.Equal(t, int32(1), heartbeat.stops.Load())

--- a/eebus-bridge/cmd/eebus-bridge/app_test.go
+++ b/eebus-bridge/cmd/eebus-bridge/app_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"syscall"
 	"testing"
 	"time"
 
@@ -295,6 +296,14 @@ func TestApplicationErrorWrappersAndLogging(t *testing.T) {
 
 	logRunError(want)
 	assert.Contains(t, output.String(), "runtime failure")
+}
+
+func TestNotifySignalContextStopCancelsContext(t *testing.T) {
+	ctx, stop := notifySignalContext(context.Background(), syscall.SIGUSR1)
+	stop()
+	stop()
+
+	assert.ErrorIs(t, context.Cause(ctx), context.Canceled)
 }
 
 type fakeHeartbeatLifecycle struct {

--- a/eebus-bridge/cmd/eebus-bridge/app_test.go
+++ b/eebus-bridge/cmd/eebus-bridge/app_test.go
@@ -788,6 +788,23 @@ func TestMonitoringWatchdogHealthTracksTrustedDisconnectedDevice(t *testing.T) {
 	assert.Equal(t, []bool{false}, grpcServer.deviceHealthValues())
 }
 
+type synchronizedLogOutput struct {
+	mu      sync.Mutex
+	builder strings.Builder
+}
+
+func (o *synchronizedLogOutput) Write(data []byte) (int, error) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	return o.builder.Write(data)
+}
+
+func (o *synchronizedLogOutput) String() string {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	return o.builder.String()
+}
+
 func TestApplicationStartCancellationCauseTriggersShutdown(t *testing.T) {
 	bridge := &fakeBridgeLifecycle{started: make(chan struct{})}
 	grpcServer := &fakeGRPCLifecycle{release: make(chan struct{}), serving: make(chan struct{})}
@@ -795,7 +812,7 @@ func TestApplicationStartCancellationCauseTriggersShutdown(t *testing.T) {
 	app := newTestApplication(bridge, grpcServer, heartbeat, nil)
 	ctx, cancel := context.WithCancelCause(context.Background())
 	result := make(chan error, 1)
-	var output strings.Builder
+	var output synchronizedLogOutput
 	oldOutput := log.Writer()
 	log.SetOutput(&output)
 	t.Cleanup(func() { log.SetOutput(oldOutput) })

--- a/eebus-bridge/cmd/eebus-bridge/main.go
+++ b/eebus-bridge/cmd/eebus-bridge/main.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"log"
 	"os"
+	"os/signal"
 	"syscall"
 
 	"github.com/volschin/eebus-bridge/internal/config"
@@ -27,7 +28,7 @@ func main() {
 		log.Fatalf("loading config: %v", err)
 	}
 
-	ctx, stopSignals := notifySignalContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	ctx, stopSignals := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stopSignals()
 	if err := run(ctx, cfg); err != nil {
 		logRunError(err)

--- a/eebus-bridge/cmd/eebus-bridge/main.go
+++ b/eebus-bridge/cmd/eebus-bridge/main.go
@@ -5,7 +5,6 @@ import (
 	"flag"
 	"log"
 	"os"
-	"os/signal"
 	"syscall"
 
 	"github.com/volschin/eebus-bridge/internal/config"
@@ -28,7 +27,7 @@ func main() {
 		log.Fatalf("loading config: %v", err)
 	}
 
-	ctx, stopSignals := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	ctx, stopSignals := notifySignalContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stopSignals()
 	if err := run(ctx, cfg); err != nil {
 		logRunError(err)

--- a/eebus-bridge/cmd/eebus-contract-testserver/main.go
+++ b/eebus-bridge/cmd/eebus-contract-testserver/main.go
@@ -105,18 +105,16 @@ func (fakePayloadSource) AttachDHWSystemFunctionPayload(event *pb.DHWSystemFunct
 }
 
 func (fakePayloadSource) AttachRoomHeatingPayload(event *pb.RoomHeatingEvent, _ string) bool {
-	current := 20.5
 	event.State = &pb.RoomHeatingState{
-		CurrentTemperatureCelsius: &current,
+		CurrentTemperatureCelsius: new(20.5),
 		Setpoint:                  &pb.RoomHeatingSetpoint{ValueCelsius: 21, Writable: true},
 	}
 	return true
 }
 
 func (fakePayloadSource) AttachOHPCFPayload(event *pb.OHPCFEvent, _ string, _ eebus.EventType) bool {
-	estimate := 1500.0
 	event.Flexibility = &pb.CompressorFlexibility{
-		Available: true, RequestedPowerEstimateW: &estimate,
+		Available: true, RequestedPowerEstimateW: new(1500.0),
 		State: pb.CompressorPowerConsumptionState_COMPRESSOR_STATE_AVAILABLE,
 	}
 	return true

--- a/eebus-bridge/go.mod
+++ b/eebus-bridge/go.mod
@@ -1,6 +1,6 @@
 module github.com/volschin/eebus-bridge
 
-go 1.25.0
+go 1.27.0
 
 require (
 	github.com/enbility/eebus-go v0.7.1-0.20260731142702-0aa83d264add

--- a/eebus-bridge/internal/config/config.go
+++ b/eebus-bridge/internal/config/config.go
@@ -137,7 +137,6 @@ func LoadFromFile(path string) (*Config, error) {
 }
 
 func defaultConfig() *Config {
-	ohpcfEnabled := true
 	return &Config{
 		GRPC: GRPCConfig{
 			Port: 50051,
@@ -156,15 +155,16 @@ func defaultConfig() *Config {
 			StoragePath: "/data/certs",
 		},
 		OHPCF: OHPCFConfig{
-			Enabled: &ohpcfEnabled,
+			Enabled: new(true),
 		},
 	}
 }
 
 func applyPostLoadDefaults(cfg *Config) {
 	if cfg.Certificates.AutoGenerate == nil {
-		autoGenerate := cfg.Certificates.CertFile == "" && cfg.Certificates.KeyFile == ""
-		cfg.Certificates.AutoGenerate = &autoGenerate
+		cfg.Certificates.AutoGenerate = new(
+			cfg.Certificates.CertFile == "" && cfg.Certificates.KeyFile == "",
+		)
 	}
 }
 

--- a/eebus-bridge/internal/eebus/announcement.go
+++ b/eebus-bridge/internal/eebus/announcement.go
@@ -100,8 +100,7 @@ func setLocalVendorName(entity spineapi.EntityLocalInterface, vendor string) err
 	if !ok || data == nil {
 		return errNoManufacturerData
 	}
-	name := model.DeviceClassificationStringType(vendor)
-	data.VendorName = &name
+	data.VendorName = new(model.DeviceClassificationStringType(vendor))
 	feature.SetData(model.FunctionTypeDeviceClassificationManufacturerData, data)
 	return nil
 }

--- a/eebus-bridge/internal/grpc/device_service.go
+++ b/eebus-bridge/internal/grpc/device_service.go
@@ -231,12 +231,10 @@ func (s *DeviceService) GetDeviceDiagnostics(_ context.Context, req *pb.DeviceRe
 		}
 	}
 	if age, ok := s.registry.MonitoringLastSuccessAge(ski); ok {
-		seconds := uint64(max(age/time.Second, 0))
-		result.MonitoringLastSuccessAgeSeconds = &seconds
+		result.MonitoringLastSuccessAgeSeconds = new(uint64(max(age/time.Second, 0)))
 	}
 	if health, ok := s.registry.DeviceHealth(ski); ok && health.Connected && !health.ConnectedAt.IsZero() {
-		seconds := uint64(max(now.Sub(health.ConnectedAt)/time.Second, 0))
-		result.ConnectionAgeSeconds = &seconds
+		result.ConnectionAgeSeconds = new(uint64(max(now.Sub(health.ConnectedAt)/time.Second, 0)))
 	}
 	if s.snapshot != nil {
 		metrics := s.snapshot.Metrics(ski)

--- a/eebus-bridge/internal/grpc/device_service_test.go
+++ b/eebus-bridge/internal/grpc/device_service_test.go
@@ -262,6 +262,7 @@ func TestGetDeviceDiagnosticsIsRedactedAndDeviceScoped(t *testing.T) {
 	registry.AddDevice(skiB, eebus.DeviceInfo{})
 	registry.MarkConnected(skiA)
 	registry.MarkConnected(skiB)
+	registry.RecordMonitoringSuccess(skiA)
 	bus.Publish(eebus.Event{SKI: skiA, Type: eebus.EventTypeMonitoringPowerUpdated})
 	bus.Publish(eebus.Event{SKI: skiB, Type: eebus.EventTypeMonitoringPowerUpdated})
 	bus.Publish(eebus.Event{SKI: skiB, Type: eebus.EventTypeMonitoringPowerUpdated})
@@ -291,6 +292,9 @@ func TestGetDeviceDiagnosticsIsRedactedAndDeviceScoped(t *testing.T) {
 	}
 	if diagnosticsA.ConnectionAgeSeconds == nil {
 		t.Fatal("connected device diagnostics omitted connection age")
+	}
+	if diagnosticsA.MonitoringLastSuccessAgeSeconds == nil {
+		t.Fatal("device diagnostics omitted monitoring success age")
 	}
 	if diagnosticsB.Readiness != pb.DeviceReadinessState_DEVICE_READINESS_EXHAUSTED || diagnosticsB.Recovery.Attempts != 3 || diagnosticsB.Events.Revision != 2 {
 		t.Fatalf("device B diagnostics = %+v", diagnosticsB)

--- a/eebus-bridge/internal/grpc/hvac_service.go
+++ b/eebus-bridge/internal/grpc/hvac_service.go
@@ -67,7 +67,7 @@ func (s *HVACService) snapshotRoomHeating(ski string) (*pb.RoomHeatingState, err
 	// its own must never make an otherwise unavailable aggregate look readable.
 	if s.registry != nil {
 		if label := s.registry.ZoneLabel(ski); label != "" {
-			state.ZoneLabel = &label
+			state.ZoneLabel = new(label)
 		}
 	}
 	if s.room != nil {

--- a/eebus-bridge/internal/usecases/provider_snapshot.go
+++ b/eebus-bridge/internal/usecases/provider_snapshot.go
@@ -301,8 +301,7 @@ func cloneFloat64Ptr(value *float64) *float64 {
 	if value == nil {
 		return nil
 	}
-	cloned := *value
-	return &cloned
+	return new(*value)
 }
 
 func measurementDataForID(id model.MeasurementIdType, value *float64) eebusapi.MeasurementDataForID {


### PR DESCRIPTION
## Summary

- raise the bridge module baseline to Go 1.27
- use the standard signal.NotifyContext shutdown path
- replace temporary pointer variables with Go 1.26 new(expr)
- use errors.AsType for controlled shutdown errors

## Verification

- gofmt on changed Go files
- git diff --check
- go vet ./...
- make test
- make build
- go test -tags=integration -v ./internal/grpc/ -run TestIntegration
- PYTHONPATH=. uv run pytest -m cross_language -v custom_components/eebus/tests/test_cross_language_contract.py

## Hardware follow-up

Live VR940 reconnect remains the hardware gate for Go 1.27 TLS defaults.

## Summary by Sourcery

Modernize the bridge for Go 1.27 and streamline application shutdown and diagnostics behavior.

Enhancements:
- Modernize the bridge codebase for Go 1.27, including standard signal-based shutdown handling and current language idioms for pointer creation.
- Simplify shutdown error handling and logging while preserving controlled shutdown behavior.
- Strengthen diagnostics coverage for monitoring success age and cancellation-driven application shutdown.

Build:
- Raise the bridge module’s minimum Go version to 1.27.

Tests:
- Update application and device diagnostics tests for the revised shutdown and monitoring behavior.