### PR TITLE
ci: sign release images with Cosign

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     # Gated on the image so a failed or unhealthy build cannot produce a
     # published release. HACS updates users from published releases, so a
     # release without a working image strands everyone who upgrades on it.
-    needs: publish-image
+    needs: sign-image
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -30,6 +30,8 @@ jobs:
     permissions:
       contents: read
       packages: write
+    outputs:
+      digest: ${{ steps.push.outputs.digest }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -92,6 +94,7 @@ jobs:
         run: bash scripts/smoke-image.sh eebus-bridge:smoke
 
       - name: Build and push multi-arch image
+        id: push
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0 # renovate: datasource=github-releases depName=docker/build-push-action
         with:
           context: ./eebus-bridge
@@ -110,3 +113,35 @@ jobs:
             BUILD_VERSION=${{ github.ref_name }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  sign-image:
+    needs: publish-image
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      packages: write
+    steps:
+      - name: Log in to GHCR
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0 # renovate: datasource=github-releases depName=docker/login-action
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2 # renovate: datasource=github-releases depName=sigstore/cosign-installer
+
+      - name: Sign image digest
+        env:
+          IMAGE: ghcr.io/${{ github.repository_owner }}/eebus-bridge@${{ needs.publish-image.outputs.digest }}
+        run: cosign sign --yes "${IMAGE}"
+
+      - name: Verify image signature
+        env:
+          CERTIFICATE_IDENTITY: ${{ github.server_url }}/${{ github.repository }}/.github/workflows/release.yml@${{ github.ref }}
+          IMAGE: ghcr.io/${{ github.repository_owner }}/eebus-bridge@${{ needs.publish-image.outputs.digest }}
+        run: |
+          cosign verify \
+            --certificate-identity "${CERTIFICATE_IDENTITY}" \
+            --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+            "${IMAGE}"


### PR DESCRIPTION
## Summary

- export the pushed multi-architecture image digest from the release job
- sign the immutable GHCR digest keylessly with Cosign in a least-privilege job
- verify the Fulcio identity and GitHub OIDC issuer before publishing the GitHub release

## Verification

- `actionlint v1.7.12 .github/workflows/release.yml`
- static release-gate, permission, digest-flow, and action-pinning assertions
- focused functional and security reviews

## Summary by Sourcery

Secure release publishing by signing the immutable container image digest and validating its provenance before creating the GitHub release.

New Features:
- Sign published GHCR image digests keylessly with Cosign and verify their GitHub OIDC identity before release publication.

Enhancements:
- Gate GitHub release creation on successful image signing and verification.
- Export the multi-architecture image digest from the image publishing job for downstream signing.

CI:
- Add a least-privilege release signing job with pinned Cosign installation and GHCR package access.