### PR TITLE
chore: prepare v0.16.6 release

### DIFF
--- a/custom_components/eebus/manifest.json
+++ b/custom_components/eebus/manifest.json
@@ -10,6 +10,6 @@
   "quality_scale": "platinum",
   "requirements": ["grpcio>=1.78.0", "protobuf>=4.25.0"],
   "single_config_entry": false,
-  "version": "0.16.5",
+  "version": "0.16.6",
   "zeroconf": ["_ship._tcp.local."]
 }

--- a/eebus-bridge-addon/config.yaml
+++ b/eebus-bridge-addon/config.yaml
@@ -4,7 +4,7 @@ name: EEBUS Bridge
 # Dockerfile uses it as the tag of the published bridge image. Bumping it is
 # therefore the single action that both offers users an update and selects the
 # binary they get. scripts/check_addon_version.py enforces the equality.
-version: "0.16.5"
+version: "0.16.6"
 slug: eebus_bridge
 description: >-
   EEBUS SHIP/SPINE bridge for heat pumps. Serves the gRPC API that the EEBUS


### PR DESCRIPTION
Prepare v0.16.6 as the signed bootstrap image required by add-on source verification.

## Summary by Sourcery

Chores:
- Update the Home Assistant integration and EEBUS Bridge add-on to version 0.16.6.