### PR TITLE
feat: verify add-on bridge image provenance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,7 @@ jobs:
               - 'scripts/check_addon_version.py'
               - 'scripts/check_addon_tool_platforms.py'
               - 'scripts/tests/test_check_addon_tool_platforms.py'
+              - 'scripts/tests/test_ci_addon_paths_filter.py'
               - '.github/workflows/release.yml'
               - 'scripts/tests/test_release_addon_gate.py'
               - '.github/workflows/ci.yml'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,20 +38,27 @@ jobs:
               - 'eebus-bridge-addon/**'
               - 'repository.yaml'
               - 'custom_components/eebus/manifest.json'
+              - 'eebus-bridge-addon/config.yaml'
               - 'scripts/check_addon_version.py'
               - 'scripts/check_addon_tool_platforms.py'
+              - 'scripts/select_addon_ci_build_version.py'
               - 'scripts/tests/test_check_addon_tool_platforms.py'
               - 'scripts/tests/test_ci_addon_paths_filter.py'
               - 'scripts/tests/test_fetch_verified_bridge.py'
               - 'scripts/tests/test_addon_dockerfile_supply_chain.py'
               - '.github/workflows/release.yml'
               - 'scripts/tests/test_release_addon_gate.py'
+              - 'scripts/tests/test_select_addon_ci_build_version.py'
               - '.github/workflows/ci.yml'
             addon_build:
+              - 'custom_components/eebus/manifest.json'
               - 'eebus-bridge-addon/Dockerfile'
+              - 'eebus-bridge-addon/config.yaml'
               - 'eebus-bridge-addon/fetch-verified-bridge.sh'
               - 'eebus-bridge-addon/run.sh'
               - 'scripts/check_addon_tool_platforms.py'
+              - 'scripts/select_addon_ci_build_version.py'
+              - 'scripts/tests/test_select_addon_ci_build_version.py'
               - '.github/workflows/ci.yml'
               - '.github/workflows/release.yml'
             go:
@@ -234,6 +241,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          fetch-depth: 0
           persist-credentials: false
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0 # renovate: datasource=github-releases depName=docker/setup-buildx-action
@@ -258,16 +266,31 @@ jobs:
           python3 -m unittest scripts.tests.test_check_addon_tool_platforms -v
           python3 -m unittest scripts.tests.test_ci_addon_paths_filter -v
           python3 -m unittest scripts.tests.test_release_addon_gate -v
+          python3 -m unittest scripts.tests.test_select_addon_ci_build_version -v
       - name: Check verifier tool platforms
         run: python3 scripts/check_addon_tool_platforms.py eebus-bridge-addon/Dockerfile
+      - name: Select verified add-on build version
+        id: addon-build-version
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PUSH_BASE_SHA: ${{ github.event.before }}
+        run: |
+          set -euo pipefail
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+            base="$PR_BASE_SHA"
+          else
+            base="$PUSH_BASE_SHA"
+          fi
+          version="$(python3 scripts/select_addon_ci_build_version.py --base "$base")"
+          printf 'version=%s\n' "$version" >> "$GITHUB_OUTPUT"
       - name: Build verified add-on image
         if: needs.changes.outputs.addon_build == 'true'
         run: |
           set -euo pipefail
-          version="$(python3 -c 'import re; from pathlib import Path; text=Path("eebus-bridge-addon/config.yaml").read_text(); print(re.search(r"(?m)^version: \"([^\"]+)\"$", text).group(1))')"
           docker build \
             --platform linux/amd64 \
-            --build-arg "BUILD_VERSION=${version}" \
+            --build-arg "BUILD_VERSION=${{ steps.addon-build-version.outputs.version }}" \
             --tag eebus-bridge-addon:ci \
             eebus-bridge-addon
           docker run --rm --entrypoint /bin/sh eebus-bridge-addon:ci -c \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,8 @@ jobs:
               - 'repository.yaml'
               - 'custom_components/eebus/manifest.json'
               - 'scripts/check_addon_version.py'
+              - 'scripts/check_addon_tool_platforms.py'
+              - 'scripts/tests/test_check_addon_tool_platforms.py'
               - '.github/workflows/ci.yml'
             go:
               - 'eebus-bridge/**'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       addon: ${{ steps.filter.outputs.addon }}
+      addon_build: ${{ steps.filter.outputs.addon_build }}
       go: ${{ steps.filter.outputs.go }}
       proto: ${{ steps.filter.outputs.proto }}
       python: ${{ steps.filter.outputs.python }}
@@ -41,9 +42,18 @@ jobs:
               - 'scripts/check_addon_tool_platforms.py'
               - 'scripts/tests/test_check_addon_tool_platforms.py'
               - 'scripts/tests/test_ci_addon_paths_filter.py'
+              - 'scripts/tests/test_fetch_verified_bridge.py'
+              - 'scripts/tests/test_addon_dockerfile_supply_chain.py'
               - '.github/workflows/release.yml'
               - 'scripts/tests/test_release_addon_gate.py'
               - '.github/workflows/ci.yml'
+            addon_build:
+              - 'eebus-bridge-addon/Dockerfile'
+              - 'eebus-bridge-addon/fetch-verified-bridge.sh'
+              - 'eebus-bridge-addon/run.sh'
+              - 'scripts/check_addon_tool_platforms.py'
+              - '.github/workflows/ci.yml'
+              - '.github/workflows/release.yml'
             go:
               - 'eebus-bridge/**'
               - 'scripts/check_go_patch_coverage.py'
@@ -251,6 +261,7 @@ jobs:
       - name: Check verifier tool platforms
         run: python3 scripts/check_addon_tool_platforms.py eebus-bridge-addon/Dockerfile
       - name: Build verified add-on image
+        if: needs.changes.outputs.addon_build == 'true'
         run: |
           set -euo pipefail
           version="$(python3 -c 'import re; from pathlib import Path; text=Path("eebus-bridge-addon/config.yaml").read_text(); print(re.search(r"(?m)^version: \"([^\"]+)\"$", text).group(1))')"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,6 +220,8 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0 # renovate: datasource=github-releases depName=docker/setup-buildx-action
       - name: Lint add-on Dockerfile
         uses: hadolint/hadolint-action@06be81baf89a55ffd0e24b8f04a4185738dd3387 # v3.5.0 # renovate: datasource=github-releases depName=hadolint/hadolint-action
         with:
@@ -234,6 +236,27 @@ jobs:
           path: ./eebus-bridge-addon
       - name: Check add-on version matches the integration
         run: python3 scripts/check_addon_version.py
+      - name: Test verified bridge fetcher
+        run: |
+          python3 -m unittest scripts.tests.test_fetch_verified_bridge -v
+          python3 -m unittest scripts.tests.test_addon_dockerfile_supply_chain -v
+          python3 -m unittest scripts.tests.test_check_addon_tool_platforms -v
+      - name: Check verifier tool platforms
+        run: python3 scripts/check_addon_tool_platforms.py eebus-bridge-addon/Dockerfile
+      - name: Build verified add-on image
+        run: |
+          set -euo pipefail
+          version="$(python3 -c 'import re; from pathlib import Path; text=Path("eebus-bridge-addon/config.yaml").read_text(); print(re.search(r"(?m)^version: \"([^\"]+)\"$", text).group(1))')"
+          docker build \
+            --platform linux/amd64 \
+            --build-arg "BUILD_VERSION=${version}" \
+            --tag eebus-bridge-addon:ci \
+            eebus-bridge-addon
+          docker run --rm --entrypoint /bin/sh eebus-bridge-addon:ci -c \
+            'test -x /usr/local/bin/eebus-bridge &&
+             test ! -e /usr/local/bin/cosign &&
+             test ! -e /usr/local/bin/regctl &&
+             test ! -e /usr/local/bin/fetch-verified-bridge'
 
   test:
     # Gated like the go job: a Go- or Dockerfile-only PR cannot break ruff,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -243,6 +243,7 @@ jobs:
           python3 -m unittest scripts.tests.test_fetch_verified_bridge -v
           python3 -m unittest scripts.tests.test_addon_dockerfile_supply_chain -v
           python3 -m unittest scripts.tests.test_check_addon_tool_platforms -v
+          python3 -m unittest scripts.tests.test_ci_addon_paths_filter -v
       - name: Check verifier tool platforms
         run: python3 scripts/check_addon_tool_platforms.py eebus-bridge-addon/Dockerfile
       - name: Build verified add-on image

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -286,11 +286,13 @@ jobs:
           printf 'version=%s\n' "$version" >> "$GITHUB_OUTPUT"
       - name: Build verified add-on image
         if: needs.changes.outputs.addon_build == 'true'
+        env:
+          BUILD_VERSION: ${{ steps.addon-build-version.outputs.version }}
         run: |
           set -euo pipefail
           docker build \
             --platform linux/amd64 \
-            --build-arg "BUILD_VERSION=${{ steps.addon-build-version.outputs.version }}" \
+            --build-arg "BUILD_VERSION=${BUILD_VERSION}" \
             --tag eebus-bridge-addon:ci \
             eebus-bridge-addon
           docker run --rm --entrypoint /bin/sh eebus-bridge-addon:ci -c \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,8 @@ jobs:
               - 'scripts/check_addon_version.py'
               - 'scripts/check_addon_tool_platforms.py'
               - 'scripts/tests/test_check_addon_tool_platforms.py'
+              - '.github/workflows/release.yml'
+              - 'scripts/tests/test_release_addon_gate.py'
               - '.github/workflows/ci.yml'
             go:
               - 'eebus-bridge/**'
@@ -244,6 +246,7 @@ jobs:
           python3 -m unittest scripts.tests.test_addon_dockerfile_supply_chain -v
           python3 -m unittest scripts.tests.test_check_addon_tool_platforms -v
           python3 -m unittest scripts.tests.test_ci_addon_paths_filter -v
+          python3 -m unittest scripts.tests.test_release_addon_gate -v
       - name: Check verifier tool platforms
         run: python3 scripts/check_addon_tool_platforms.py eebus-bridge-addon/Dockerfile
       - name: Build verified add-on image

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     # Gated on the image so a failed or unhealthy build cannot produce a
     # published release. HACS updates users from published releases, so a
     # release without a working image strands everyone who upgrades on it.
-    needs: sign-image
+    needs: build-verified-addon
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -145,3 +145,31 @@ jobs:
             --certificate-identity "${CERTIFICATE_IDENTITY}" \
             --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
             "${IMAGE}"
+
+  build-verified-addon:
+    needs: sign-image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Build add-on from verified release image
+        env:
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          version="${RELEASE_TAG#v}"
+          docker build \
+            --platform linux/amd64 \
+            --build-arg "BUILD_VERSION=${version}" \
+            --tag eebus-bridge-addon:release-verify \
+            eebus-bridge-addon
+          docker run --rm --entrypoint /bin/sh \
+            eebus-bridge-addon:release-verify -c \
+            'test -x /usr/local/bin/eebus-bridge &&
+             test ! -e /usr/local/bin/cosign &&
+             test ! -e /usr/local/bin/regctl &&
+             test ! -e /usr/local/bin/fetch-verified-bridge'

--- a/docs/superpowers/plans/2026-08-27-addon-cosign-verification.md
+++ b/docs/superpowers/plans/2026-08-27-addon-cosign-verification.md
@@ -1,0 +1,1273 @@
+# Verified Add-on Source Image Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Supervisor-built EEBUS add-ons package the bridge binary only after exact Cosign identity verification of the immutable signed release digest.
+
+**Architecture:** A digest-pinned Cosign stage and digest-pinned regctl stage feed an ephemeral verifier stage. A tested shell script resolves the configured version tag once, verifies the resulting multi-platform index digest, extracts the native bridge binary from that same digest, and passes only that binary to the final Home Assistant image. CI builds this path against an already-signed bootstrap release, and release publication is gated on a post-sign add-on build.
+
+**Tech Stack:** Docker BuildKit multi-stage builds, Cosign v3.1.3, regctl v0.11.5, POSIX shell, Python `unittest`, GitHub Actions, Home Assistant Supervisor app devcontainer
+
+**Spec:** `docs/superpowers/specs/2026-08-27-addon-cosign-verification-design.md`
+
+## Global Constraints
+
+- Bootstrap v0.16.6 must be built and signed before fail-closed add-on verification reaches `main`.
+- Version changes and release tags remain separate from feature commits.
+- `manifest.json` and `eebus-bridge-addon/config.yaml` versions must always match.
+- Accept only certificate identity `https://github.com/volschin/eebus-ha-bridge/.github/workflows/release.yml@refs/tags/vX.Y.Z` and issuer `https://token.actions.githubusercontent.com`.
+- Verification and extraction must use the same validated `sha256:` digest reference.
+- No unsigned fallback, identity regex, transparency-log bypass, or runtime verification.
+- Cosign and regctl must remain outside the final add-on image.
+- Preserve `amd64`, `aarch64`, and `armv7` support.
+- Keep `ghcr.io/home-assistant/base:latest` unchanged in this feature.
+- Do not change `run.sh`, EEBUS runtime configuration, host networking, or persistent data.
+- Use real external commands only in integration gates; unit tests fake unavoidable registry CLIs through `PATH`.
+
+---
+
+### Task 1: Publish signed bootstrap release v0.16.6
+
+**Files:**
+- Modify: `custom_components/eebus/manifest.json:13`
+- Modify: `eebus-bridge-addon/config.yaml:7`
+
+**Interfaces:**
+- Consumes: merged keyless signing workflow in `.github/workflows/release.yml`
+- Produces: public signed image `ghcr.io/volschin/eebus-bridge:0.16.6`
+
+- [ ] **Step 1: Start from current `main` in a clean release branch**
+
+```bash
+git switch main
+git pull --ff-only origin main
+git switch -c release/v0.16.6
+```
+
+Expected: clean branch based on `main`; no feature files included.
+
+- [ ] **Step 2: Update both version declarations**
+
+Change `custom_components/eebus/manifest.json`:
+
+```json
+"version": "0.16.6",
+```
+
+Change `eebus-bridge-addon/config.yaml`:
+
+```yaml
+version: "0.16.6"
+```
+
+- [ ] **Step 3: Run version-policy gates**
+
+```bash
+python3 -m unittest scripts.tests.test_check_addon_version -v
+python3 scripts/check_addon_version.py
+python3 scripts/check_addon_version.py v0.16.6
+```
+
+Expected: all commands exit 0.
+
+- [ ] **Step 4: Commit the isolated release change**
+
+```bash
+git add custom_components/eebus/manifest.json eebus-bridge-addon/config.yaml
+git commit -m "chore: prepare v0.16.6 release"
+```
+
+- [ ] **Step 5: Push, open, verify, and merge the release PR**
+
+```bash
+git push -u origin release/v0.16.6
+gh pr create --base main --head release/v0.16.6 \
+  --title "chore: prepare v0.16.6 release" \
+  --body "Prepare v0.16.6 as the signed bootstrap image required by add-on source verification."
+gh pr checks --watch --interval 30
+```
+
+Before merge, confirm all checks pass and no unresolved review threads exist, then run:
+
+```bash
+gh pr merge --squash --delete-branch
+```
+
+- [ ] **Step 6: Tag merged release commit**
+
+```bash
+git switch main
+git pull --ff-only origin main
+git tag -a v0.16.6 -m "v0.16.6"
+git push origin v0.16.6
+```
+
+- [ ] **Step 7: Watch release workflow through image signing and publication**
+
+```bash
+run_id="$(gh run list \
+  --workflow Release \
+  --commit "$(git rev-list -n 1 v0.16.6)" \
+  --limit 1 \
+  --json databaseId \
+  --jq '.[0].databaseId')"
+test -n "${run_id}"
+gh run watch "${run_id}" --exit-status
+```
+
+Expected: `publish-image`, `sign-image`, and `create-release` succeed; GitHub Release v0.16.6 is published.
+
+- [ ] **Step 8: Verify the bootstrap image independently**
+
+```bash
+image="ghcr.io/volschin/eebus-bridge:0.16.6"
+digest="$(docker buildx imagetools inspect "${image}" | awk '/^Digest:/ {print $2; exit}')"
+test -n "${digest}"
+docker run --rm \
+  ghcr.io/sigstore/cosign/cosign:v3.1.3@sha256:9e5c2f2edc34351160407ca3416c61855bdf9403c3c5936e0f0be7fc261611b8 \
+  verify \
+  --certificate-identity \
+  "https://github.com/volschin/eebus-ha-bridge/.github/workflows/release.yml@refs/tags/v0.16.6" \
+  --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+  "ghcr.io/volschin/eebus-bridge@${digest}"
+```
+
+Expected: Cosign exits 0 and reports a verified signature.
+
+---
+
+### Task 2: Implement fail-closed bridge fetch script with TDD
+
+**Files:**
+- Create: `eebus-bridge-addon/fetch-verified-bridge.sh`
+- Create: `scripts/tests/test_fetch_verified_bridge.py`
+- Include in commit: `docs/superpowers/specs/2026-08-27-addon-cosign-verification-design.md`
+- Include in commit: `docs/superpowers/plans/2026-08-27-addon-cosign-verification.md`
+
+**Interfaces:**
+- Consumes: `cosign` and `regctl` available on `PATH`
+- Produces: `fetch-verified-bridge.sh <version> <output-path>`, exiting 0 only with a non-empty executable verified binary
+
+- [ ] **Step 1: Rebase feature branch onto signed v0.16.6 `main`**
+
+```bash
+git switch feat/addon-image-verification
+git rebase main
+```
+
+Expected: `manifest.json` and add-on `config.yaml` both contain `0.16.6`.
+
+- [ ] **Step 2: Write failing script tests**
+
+Create `scripts/tests/test_fetch_verified_bridge.py` with a `unittest.TestCase` that:
+
+```python
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import stat
+import subprocess
+import tempfile
+import textwrap
+import unittest
+
+
+ROOT = Path(__file__).parents[2]
+SCRIPT = ROOT / "eebus-bridge-addon" / "fetch-verified-bridge.sh"
+VALID_DIGEST = "sha256:" + "a" * 64
+EXPECTED_IMAGE = f"ghcr.io/volschin/eebus-bridge@{VALID_DIGEST}"
+EXPECTED_IDENTITY = (
+    "https://github.com/volschin/eebus-ha-bridge/.github/workflows/"
+    "release.yml@refs/tags/v0.16.6"
+)
+
+
+class FetchVerifiedBridgeTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp_dir.name)
+        self.bin_dir = self.root / "bin"
+        self.bin_dir.mkdir()
+        self.log = self.root / "calls.log"
+        self.output = self.root / "eebus-bridge"
+        self._write_fake(
+            "regctl",
+            r"""
+            printf 'regctl %s\n' "$*" >>"${CALL_LOG}"
+            if [ "$1 $2" = "image digest" ]; then
+                [ "${FAKE_DIGEST_EXIT:-0}" -eq 0 ] || exit "${FAKE_DIGEST_EXIT}"
+                printf '%s\n' "${FAKE_DIGEST:-sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa}"
+                exit 0
+            fi
+            if [ "$1 $2" = "image get-file" ]; then
+                [ "${FAKE_GET_FILE_EXIT:-0}" -eq 0 ] || exit "${FAKE_GET_FILE_EXIT}"
+                if [ "${FAKE_EMPTY_OUTPUT:-0}" -eq 0 ]; then
+                    printf 'verified-binary' >"$7"
+                else
+                    : >"$7"
+                fi
+                exit 0
+            fi
+            exit 90
+            """,
+        )
+        self._write_fake(
+            "cosign",
+            r"""
+            printf 'cosign %s\n' "$*" >>"${CALL_LOG}"
+            exit "${FAKE_COSIGN_EXIT:-0}"
+            """,
+        )
+
+    def tearDown(self) -> None:
+        self.temp_dir.cleanup()
+
+    def _write_fake(self, name: str, body: str) -> None:
+        path = self.bin_dir / name
+        path.write_text("#!/bin/sh\nset -eu\n" + textwrap.dedent(body))
+        path.chmod(0o755)
+
+    def _run(self, version: str = "0.16.6", **extra_env: str) -> subprocess.CompletedProcess[str]:
+        env = os.environ.copy()
+        env.update(
+            {
+                "PATH": f"{self.bin_dir}:/usr/bin:/bin",
+                "CALL_LOG": str(self.log),
+                **extra_env,
+            }
+        )
+        return subprocess.run(
+            [str(SCRIPT), version, str(self.output)],
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+```
+
+Add focused test methods asserting:
+
+```python
+def test_rejects_non_semver_before_registry_access(self) -> None:
+    result = self._run("v0.16.6")
+    self.assertNotEqual(result.returncode, 0)
+    self.assertFalse(self.log.exists())
+
+
+def test_rejects_malformed_digest_before_cosign(self) -> None:
+    result = self._run(FAKE_DIGEST="sha256:bad")
+    self.assertNotEqual(result.returncode, 0)
+    calls = self.log.read_text()
+    self.assertIn("regctl image digest", calls)
+    self.assertNotIn("cosign", calls)
+
+
+def test_cosign_failure_prevents_extraction(self) -> None:
+    result = self._run(FAKE_COSIGN_EXIT="17")
+    self.assertEqual(result.returncode, 17)
+    calls = self.log.read_text()
+    self.assertIn("cosign verify", calls)
+    self.assertNotIn("get-file", calls)
+
+
+def test_success_verifies_and_extracts_same_digest(self) -> None:
+    result = self._run()
+    self.assertEqual(result.returncode, 0, result.stderr)
+    calls = self.log.read_text()
+    self.assertEqual(calls.count(EXPECTED_IMAGE), 2)
+    self.assertIn(EXPECTED_IDENTITY, calls)
+    self.assertIn("https://token.actions.githubusercontent.com", calls)
+    self.assertIn("regctl image get-file --platform local", calls)
+    self.assertEqual(self.output.read_text(), "verified-binary")
+    self.assertTrue(self.output.stat().st_mode & stat.S_IXUSR)
+
+
+def test_empty_extracted_file_fails_closed(self) -> None:
+    result = self._run(FAKE_EMPTY_OUTPUT="1")
+    self.assertNotEqual(result.returncode, 0)
+```
+
+Add failure-propagation methods in the same class:
+
+```python
+def test_digest_resolution_failure_propagates(self) -> None:
+    result = self._run(FAKE_DIGEST_EXIT="23")
+    self.assertEqual(result.returncode, 23)
+    calls = self.log.read_text()
+    self.assertIn("regctl image digest", calls)
+    self.assertNotIn("cosign", calls)
+    self.assertNotIn("get-file", calls)
+
+
+def test_extraction_failure_propagates(self) -> None:
+    result = self._run(FAKE_GET_FILE_EXIT="29")
+    self.assertEqual(result.returncode, 29)
+    calls = self.log.read_text()
+    self.assertIn("cosign verify", calls)
+    self.assertIn("regctl image get-file", calls)
+    self.assertFalse(self.output.exists())
+```
+
+Add `if __name__ == "__main__": unittest.main()` after the class.
+
+- [ ] **Step 3: Run tests and verify RED**
+
+```bash
+python3 -m unittest scripts.tests.test_fetch_verified_bridge -v
+```
+
+Expected: FAIL because `eebus-bridge-addon/fetch-verified-bridge.sh` does not exist.
+
+- [ ] **Step 4: Implement minimal production script**
+
+Create `eebus-bridge-addon/fetch-verified-bridge.sh`:
+
+```sh
+#!/bin/sh
+set -eu
+
+if [ "$#" -ne 2 ]; then
+    echo "usage: $0 <version> <output-path>" >&2
+    exit 64
+fi
+
+version="$1"
+output="$2"
+repository="ghcr.io/volschin/eebus-bridge"
+issuer="https://token.actions.githubusercontent.com"
+
+if ! printf '%s\n' "${version}" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+    echo "invalid bridge version: ${version}" >&2
+    exit 65
+fi
+
+tag_ref="${repository}:${version}"
+digest="$(regctl image digest "${tag_ref}")"
+if ! printf '%s\n' "${digest}" | grep -Eq '^sha256:[0-9a-f]{64}$'; then
+    echo "invalid bridge image digest: ${digest}" >&2
+    exit 66
+fi
+
+image="${repository}@${digest}"
+identity="https://github.com/volschin/eebus-ha-bridge/.github/workflows/release.yml@refs/tags/v${version}"
+
+echo "Verifying ${image} from ${identity}"
+cosign verify \
+    --certificate-identity "${identity}" \
+    --certificate-oidc-issuer "${issuer}" \
+    "${image}" >/dev/null
+
+mkdir -p "$(dirname "${output}")"
+rm -f "${output}"
+regctl image get-file --platform local \
+    "${image}" \
+    /usr/local/bin/eebus-bridge \
+    "${output}"
+chmod 0755 "${output}"
+
+if [ ! -s "${output}" ] || [ ! -x "${output}" ]; then
+    echo "verified bridge output is missing or not executable" >&2
+    exit 67
+fi
+```
+
+Mark it executable:
+
+```bash
+chmod 0755 eebus-bridge-addon/fetch-verified-bridge.sh
+```
+
+- [ ] **Step 5: Run tests and verify GREEN**
+
+```bash
+python3 -m unittest scripts.tests.test_fetch_verified_bridge -v
+```
+
+Expected: all tests pass with no warnings.
+
+- [ ] **Step 6: Commit script, tests, spec, and plan**
+
+```bash
+git add \
+  eebus-bridge-addon/fetch-verified-bridge.sh \
+  scripts/tests/test_fetch_verified_bridge.py \
+  docs/superpowers/specs/2026-08-27-addon-cosign-verification-design.md \
+  docs/superpowers/plans/2026-08-27-addon-cosign-verification.md
+git commit -m "feat: add verified bridge image fetcher"
+```
+
+---
+
+### Task 3: Replace bridge `FROM` with verified extraction stage
+
+**Files:**
+- Modify: `eebus-bridge-addon/Dockerfile:1-31`
+- Create: `scripts/tests/test_addon_dockerfile_supply_chain.py`
+
+**Interfaces:**
+- Consumes: `fetch-verified-bridge.sh <version> <output-path>` from Task 2
+- Produces: final add-on image containing only `/usr/local/bin/eebus-bridge` from verified source digest
+
+- [ ] **Step 1: Write failing Dockerfile contract tests**
+
+Create `scripts/tests/test_addon_dockerfile_supply_chain.py`:
+
+```python
+from pathlib import Path
+import re
+import unittest
+
+
+DOCKERFILE = Path(__file__).parents[2] / "eebus-bridge-addon" / "Dockerfile"
+COSIGN_REF = (
+    "ghcr.io/sigstore/cosign/cosign:v3.1.3@sha256:"
+    "9e5c2f2edc34351160407ca3416c61855bdf9403c3c5936e0f0be7fc261611b8"
+)
+REGCTL_REF = (
+    "ghcr.io/regclient/regctl:v0.11.5@sha256:"
+    "dbe356c6cf9f8f85e302b9e47fed481ef3f1b04807350e99b02ab2cadee0a993"
+)
+
+
+class AddonDockerfileSupplyChainTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.text = DOCKERFILE.read_text()
+
+    def test_bridge_registry_is_not_a_from_source(self) -> None:
+        self.assertNotRegex(
+            self.text,
+            r"(?m)^FROM\s+ghcr\.io/volschin/eebus-bridge",
+        )
+
+    def test_verifier_tools_are_tagged_and_digest_pinned(self) -> None:
+        self.assertIn(f"FROM {COSIGN_REF} AS cosign", self.text)
+        self.assertIn(f"FROM {REGCTL_REF} AS regctl", self.text)
+
+    def test_final_stage_copies_only_verified_bridge(self) -> None:
+        final_stage = self.text.rsplit("FROM ${BUILD_FROM}", 1)[1]
+        self.assertIn(
+            "COPY --from=verified-bridge /verified/eebus-bridge "
+            "/usr/local/bin/eebus-bridge",
+            final_stage,
+        )
+        self.assertNotIn("cosign", final_stage)
+        self.assertNotIn("regctl", final_stage)
+        self.assertNotIn("fetch-verified-bridge", final_stage)
+
+
+if __name__ == "__main__":
+    unittest.main()
+```
+
+- [ ] **Step 2: Run tests and verify RED**
+
+```bash
+python3 -m unittest scripts.tests.test_addon_dockerfile_supply_chain -v
+```
+
+Expected: failures show the bridge registry is still a `FROM` source and pinned tool stages are absent.
+
+- [ ] **Step 3: Replace Dockerfile stages**
+
+Rewrite `eebus-bridge-addon/Dockerfile` to preserve existing comments where still accurate and use this structure:
+
+```dockerfile
+ARG BUILD_VERSION
+ARG BUILD_FROM=ghcr.io/home-assistant/base:latest
+
+FROM ghcr.io/sigstore/cosign/cosign:v3.1.3@sha256:9e5c2f2edc34351160407ca3416c61855bdf9403c3c5936e0f0be7fc261611b8 AS cosign
+FROM ghcr.io/regclient/regctl:v0.11.5@sha256:dbe356c6cf9f8f85e302b9e47fed481ef3f1b04807350e99b02ab2cadee0a993 AS regctl
+
+# hadolint ignore=DL3006
+FROM ${BUILD_FROM} AS verified-bridge
+ARG BUILD_VERSION
+# Resolve the mutable version tag once; verification and extraction then use one digest.
+COPY --from=cosign /ko-app/cosign /usr/local/bin/cosign
+COPY --from=regctl /regctl /usr/local/bin/regctl
+COPY fetch-verified-bridge.sh /usr/local/bin/fetch-verified-bridge
+RUN chmod 0755 /usr/local/bin/fetch-verified-bridge \
+    && /usr/local/bin/fetch-verified-bridge \
+        "${BUILD_VERSION}" /verified/eebus-bridge
+
+# Tool binaries stay in the verifier stage; only verified output enters runtime.
+# hadolint ignore=DL3006
+FROM ${BUILD_FROM}
+COPY --from=verified-bridge /verified/eebus-bridge /usr/local/bin/eebus-bridge
+COPY run.sh /run.sh
+RUN chmod a+x /run.sh
+CMD [ "/run.sh" ]
+```
+
+This exact structure documents both properties: tag resolution happens once inside the script, and tool binaries never reach the final stage.
+
+- [ ] **Step 4: Run contract tests and Hadolint**
+
+```bash
+python3 -m unittest scripts.tests.test_addon_dockerfile_supply_chain -v
+docker run --rm -i hadolint/hadolint:v2.14.0-alpine \
+  hadolint - < eebus-bridge-addon/Dockerfile
+```
+
+Expected: all tests and Hadolint pass.
+
+- [ ] **Step 5: Build against signed v0.16.6 on amd64**
+
+```bash
+docker build \
+  --platform linux/amd64 \
+  --build-arg BUILD_VERSION=0.16.6 \
+  --tag eebus-bridge-addon:verified-test \
+  eebus-bridge-addon
+
+docker run --rm --entrypoint /bin/sh eebus-bridge-addon:verified-test -c \
+  'test -x /usr/local/bin/eebus-bridge &&
+   test ! -e /usr/local/bin/cosign &&
+   test ! -e /usr/local/bin/regctl &&
+   test ! -e /usr/local/bin/fetch-verified-bridge'
+```
+
+Expected: build log shows exact v0.16.6 digest and successful Cosign verification; final-image assertions pass.
+
+- [ ] **Step 6: Commit Dockerfile integration**
+
+```bash
+git add eebus-bridge-addon/Dockerfile scripts/tests/test_addon_dockerfile_supply_chain.py
+git commit -m "feat: verify add-on bridge image during build"
+```
+
+---
+
+### Task 4: Add recurring tool-platform and PR integration gates
+
+**Files:**
+- Create: `scripts/check_addon_tool_platforms.py`
+- Create: `scripts/tests/test_check_addon_tool_platforms.py`
+- Modify: `.github/workflows/ci.yml:215-236`
+
+**Interfaces:**
+- Consumes: digest-pinned Dockerfile `FROM` references with stage aliases `cosign` and `regctl`
+- Produces: CLI `python3 scripts/check_addon_tool_platforms.py eebus-bridge-addon/Dockerfile`
+
+- [ ] **Step 1: Write failing pure-function tests for platform validation**
+
+Create `scripts/tests/test_check_addon_tool_platforms.py`:
+
+```python
+from __future__ import annotations
+
+import unittest
+
+from scripts.check_addon_tool_platforms import (
+    manifest_platforms,
+    missing_platforms,
+    tool_images,
+)
+
+
+COSIGN = "ghcr.io/sigstore/cosign/cosign:v3.1.3@sha256:" + "a" * 64
+REGCTL = "ghcr.io/regclient/regctl:v0.11.5@sha256:" + "b" * 64
+DOCKERFILE = f"""\
+FROM {COSIGN} AS cosign
+FROM {REGCTL} AS regctl
+FROM base AS final
+"""
+INDEX = {
+    "manifests": [
+        {"platform": {"os": "linux", "architecture": "amd64"}},
+        {"platform": {"os": "linux", "architecture": "arm64"}},
+        {
+            "platform": {
+                "os": "linux",
+                "architecture": "arm",
+                "variant": "v7",
+            }
+        },
+    ]
+}
+
+
+class AddonToolPlatformsTest(unittest.TestCase):
+    def test_extracts_digest_pinned_tool_stages(self) -> None:
+        self.assertEqual(tool_images(DOCKERFILE), [COSIGN, REGCTL])
+
+    def test_rejects_missing_tool_stage(self) -> None:
+        with self.assertRaisesRegex(ValueError, "missing tool stage: regctl"):
+            tool_images(f"FROM {COSIGN} AS cosign\n")
+
+    def test_rejects_tool_without_full_digest(self) -> None:
+        dockerfile = DOCKERFILE.replace(
+            COSIGN,
+            "ghcr.io/sigstore/cosign/cosign:v3.1.3",
+        )
+        with self.assertRaisesRegex(ValueError, "not digest-pinned"):
+            tool_images(dockerfile)
+
+    def test_normalizes_manifest_platforms(self) -> None:
+        self.assertEqual(
+            manifest_platforms(INDEX),
+            {"linux/amd64", "linux/arm64", "linux/arm/v7"},
+        )
+
+    def test_reports_missing_arm_v7(self) -> None:
+        self.assertEqual(
+            missing_platforms({"linux/amd64", "linux/arm64"}),
+            {"linux/arm/v7"},
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()
+```
+
+- [ ] **Step 2: Run tests and verify RED**
+
+```bash
+python3 -m unittest scripts.tests.test_check_addon_tool_platforms -v
+```
+
+Expected: import failure because checker does not exist.
+
+- [ ] **Step 3: Implement platform checker**
+
+Create `scripts/check_addon_tool_platforms.py`:
+
+```python
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import re
+import subprocess
+import sys
+from typing import Any
+
+
+REQUIRED_PLATFORMS = {"linux/amd64", "linux/arm64", "linux/arm/v7"}
+TOOL_STAGES = ("cosign", "regctl")
+FROM_RE = re.compile(
+    r"(?mi)^FROM\s+(?P<image>\S+)\s+AS\s+(?P<stage>cosign|regctl)\s*$"
+)
+DIGEST_RE = re.compile(r"@sha256:[0-9a-f]{64}$")
+
+
+def tool_images(dockerfile: str) -> list[str]:
+    images = {match.group("stage"): match.group("image") for match in FROM_RE.finditer(dockerfile)}
+    for stage in TOOL_STAGES:
+        if stage not in images:
+            raise ValueError(f"missing tool stage: {stage}")
+        if DIGEST_RE.search(images[stage]) is None:
+            raise ValueError(f"tool stage {stage} is not digest-pinned: {images[stage]}")
+    return [images[stage] for stage in TOOL_STAGES]
+
+
+def manifest_platforms(index: dict[str, Any]) -> set[str]:
+    manifests = index.get("manifests")
+    if not isinstance(manifests, list):
+        raise ValueError("image reference did not resolve to an OCI index")
+
+    platforms: set[str] = set()
+    for descriptor in manifests:
+        if not isinstance(descriptor, dict):
+            continue
+        platform = descriptor.get("platform")
+        if not isinstance(platform, dict):
+            continue
+        os_name = platform.get("os")
+        architecture = platform.get("architecture")
+        variant = platform.get("variant")
+        if not isinstance(os_name, str) or not isinstance(architecture, str):
+            continue
+        value = f"{os_name}/{architecture}"
+        if isinstance(variant, str) and variant:
+            value = f"{value}/{variant}"
+        platforms.add(value)
+    return platforms
+
+
+def missing_platforms(platforms: set[str]) -> set[str]:
+    return REQUIRED_PLATFORMS - platforms
+
+
+def inspect_index(image: str) -> dict[str, Any]:
+    result = subprocess.run(
+        ["docker", "buildx", "imagetools", "inspect", "--raw", image],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    value = json.loads(result.stdout)
+    if not isinstance(value, dict):
+        raise ValueError(f"invalid OCI index for {image}")
+    return value
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("dockerfile", type=Path)
+    args = parser.parse_args()
+
+    try:
+        images = tool_images(args.dockerfile.read_text())
+        for image in images:
+            missing = missing_platforms(manifest_platforms(inspect_index(image)))
+            if missing:
+                names = ", ".join(sorted(missing))
+                raise ValueError(f"{image} is missing platforms: {names}")
+            print(f"{image}: required platforms present")
+    except (OSError, ValueError, json.JSONDecodeError, subprocess.CalledProcessError) as error:
+        print(error, file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+```
+
+Mark it executable:
+
+```bash
+chmod 0755 scripts/check_addon_tool_platforms.py
+```
+
+- [ ] **Step 4: Run tests and verify GREEN**
+
+```bash
+python3 -m unittest scripts.tests.test_check_addon_tool_platforms -v
+python3 scripts/check_addon_tool_platforms.py eebus-bridge-addon/Dockerfile
+```
+
+Expected: tests pass; both pinned tool images report all required platforms.
+
+- [ ] **Step 5: Extend add-on CI job**
+
+After checkout, add the existing SHA-pinned Buildx setup action:
+
+```yaml
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0 # renovate: datasource=github-releases depName=docker/setup-buildx-action
+```
+
+After version synchronization, add:
+
+```yaml
+      - name: Test verified bridge fetcher
+        run: |
+          python3 -m unittest scripts.tests.test_fetch_verified_bridge -v
+          python3 -m unittest scripts.tests.test_addon_dockerfile_supply_chain -v
+          python3 -m unittest scripts.tests.test_check_addon_tool_platforms -v
+
+      - name: Check verifier tool platforms
+        run: python3 scripts/check_addon_tool_platforms.py eebus-bridge-addon/Dockerfile
+
+      - name: Build verified add-on image
+        run: |
+          set -euo pipefail
+          version="$(python3 -c 'import re; from pathlib import Path; text=Path("eebus-bridge-addon/config.yaml").read_text(); print(re.search(r"(?m)^version: \"([^\"]+)\"$", text).group(1))')"
+          docker build \
+            --platform linux/amd64 \
+            --build-arg "BUILD_VERSION=${version}" \
+            --tag eebus-bridge-addon:ci \
+            eebus-bridge-addon
+          docker run --rm --entrypoint /bin/sh eebus-bridge-addon:ci -c \
+            'test -x /usr/local/bin/eebus-bridge &&
+             test ! -e /usr/local/bin/cosign &&
+             test ! -e /usr/local/bin/regctl &&
+             test ! -e /usr/local/bin/fetch-verified-bridge'
+```
+
+- [ ] **Step 6: Validate workflow and full add-on gate locally**
+
+```bash
+go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 .github/workflows/ci.yml
+python3 -m unittest \
+  scripts.tests.test_fetch_verified_bridge \
+  scripts.tests.test_addon_dockerfile_supply_chain \
+  scripts.tests.test_check_addon_tool_platforms -v
+python3 scripts/check_addon_tool_platforms.py eebus-bridge-addon/Dockerfile
+```
+
+Expected: every command exits 0.
+
+- [ ] **Step 7: Commit CI gates**
+
+```bash
+git add \
+  scripts/check_addon_tool_platforms.py \
+  scripts/tests/test_check_addon_tool_platforms.py \
+  .github/workflows/ci.yml
+git commit -m "ci: test verified add-on image builds"
+```
+
+---
+
+### Task 5: Gate future releases on verified add-on build
+
+**Files:**
+- Modify: `.github/workflows/release.yml:12-26,117-end`
+- Create: `scripts/tests/test_release_addon_gate.py`
+
+**Interfaces:**
+- Consumes: signed version tag image produced by `sign-image`
+- Produces: `build-verified-addon` release job required before `create-release`
+
+- [ ] **Step 1: Write failing workflow contract test**
+
+Create `scripts/tests/test_release_addon_gate.py`:
+
+```python
+from __future__ import annotations
+
+from pathlib import Path
+import re
+import unittest
+
+
+WORKFLOW = Path(__file__).parents[2] / ".github" / "workflows" / "release.yml"
+
+
+def job_block(workflow: str, name: str) -> str:
+    match = re.search(
+        rf"(?ms)^  {re.escape(name)}:\n.*?(?=^  [a-z][a-z0-9-]*:\n|\Z)",
+        workflow,
+    )
+    if match is None:
+        raise AssertionError(f"job not found: {name}")
+    return match.group(0)
+
+
+class ReleaseAddonGateTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.workflow = WORKFLOW.read_text()
+
+    def test_release_waits_for_verified_addon_build(self) -> None:
+        create_release = job_block(self.workflow, "create-release")
+        self.assertIn("needs: build-verified-addon", create_release)
+
+    def test_verified_addon_build_waits_for_signing(self) -> None:
+        build_job = job_block(self.workflow, "build-verified-addon")
+        self.assertIn("needs: sign-image", build_job)
+        self.assertIn('version="${RELEASE_TAG#v}"', build_job)
+        self.assertIn('--build-arg "BUILD_VERSION=${version}"', build_job)
+        self.assertIn("eebus-bridge-addon", build_job)
+
+    def test_verified_addon_build_has_read_only_permissions(self) -> None:
+        build_job = job_block(self.workflow, "build-verified-addon")
+        permissions = build_job.split("    steps:", 1)[0]
+        self.assertIn("contents: read", permissions)
+        self.assertNotIn("id-token: write", permissions)
+        self.assertNotIn("packages: write", permissions)
+
+
+if __name__ == "__main__":
+    unittest.main()
+```
+
+The test locates two-space workflow job blocks directly and requires no PyYAML dependency.
+
+- [ ] **Step 2: Run test and verify RED**
+
+```bash
+python3 -m unittest scripts.tests.test_release_addon_gate -v
+```
+
+Expected: failures show `create-release` still depends on `sign-image` and no verified add-on job exists.
+
+- [ ] **Step 3: Add release job and dependency**
+
+Change `create-release` to:
+
+```yaml
+    needs: build-verified-addon
+```
+
+Append after `sign-image`:
+
+```yaml
+  build-verified-addon:
+    needs: sign-image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Build add-on from verified release image
+        env:
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          version="${RELEASE_TAG#v}"
+          docker build \
+            --platform linux/amd64 \
+            --build-arg "BUILD_VERSION=${version}" \
+            --tag eebus-bridge-addon:release-verify \
+            eebus-bridge-addon
+          docker run --rm --entrypoint /bin/sh \
+            eebus-bridge-addon:release-verify -c \
+            'test -x /usr/local/bin/eebus-bridge &&
+             test ! -e /usr/local/bin/cosign &&
+             test ! -e /usr/local/bin/regctl &&
+             test ! -e /usr/local/bin/fetch-verified-bridge'
+```
+
+The environment indirection prevents direct GitHub-expression interpolation inside shell code and preserves command-injection hardening.
+
+- [ ] **Step 4: Run workflow tests and actionlint**
+
+```bash
+python3 -m unittest scripts.tests.test_release_addon_gate -v
+go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 \
+  .github/workflows/release.yml
+```
+
+Expected: tests and actionlint pass.
+
+- [ ] **Step 5: Run complete relevant verification set**
+
+```bash
+git diff --check
+python3 -m unittest \
+  scripts.tests.test_check_addon_version \
+  scripts.tests.test_fetch_verified_bridge \
+  scripts.tests.test_addon_dockerfile_supply_chain \
+  scripts.tests.test_check_addon_tool_platforms \
+  scripts.tests.test_release_addon_gate -v
+python3 scripts/check_addon_version.py
+python3 scripts/check_addon_tool_platforms.py eebus-bridge-addon/Dockerfile
+```
+
+Expected: all checks pass.
+
+- [ ] **Step 6: Commit release gate**
+
+```bash
+git add .github/workflows/release.yml scripts/tests/test_release_addon_gate.py
+git commit -m "ci: gate releases on verified add-on build"
+```
+
+---
+
+### Task 6: Validate real Supervisor install, rebuild, and startup
+
+**Files:**
+- No committed file changes
+
+**Interfaces:**
+- Consumes: feature branch with signed v0.16.6 source image
+- Produces: recorded acceptance evidence for PR description
+
+- [ ] **Step 1: Configure official Home Assistant app devcontainer in an isolated test clone**
+
+Create a disposable clone from the fully committed feature branch, then copy official devcontainer files into that clone:
+
+```bash
+test_root="$(mktemp -d /tmp/eebus-supervisor-cosign.XXXXXX)"
+printf '%s\n' "${test_root}" > /tmp/eebus-supervisor-cosign.path
+git clone --local . "${test_root}"
+mkdir -p "${test_root}/.devcontainer" "${test_root}/.vscode"
+curl -fsSL \
+  https://github.com/home-assistant/devcontainer/raw/main/apps/devcontainer.json \
+  -o "${test_root}/.devcontainer/devcontainer.json"
+curl -fsSL \
+  https://github.com/home-assistant/devcontainer/raw/main/apps/tasks.json \
+  -o "${test_root}/.vscode/tasks.json"
+code "${test_root}"
+```
+
+In VS Code, run `Dev Containers: Reopen in Container`, then task `Start Home Assistant`. All later Task 6 commands run inside this disposable devcontainer.
+
+- [ ] **Step 2: Install local app through real Supervisor**
+
+```bash
+ha apps install local_eebus_bridge
+ha apps info local_eebus_bridge
+ha apps logs --follow local_eebus_bridge
+```
+
+Expected: Supervisor builds the local Dockerfile, verification succeeds, and app reaches started/running state.
+
+- [ ] **Step 3: Verify restart has no registry dependency**
+
+```bash
+ha apps restart local_eebus_bridge
+ha apps info local_eebus_bridge
+```
+
+Expected: restart does not rebuild and logs contain no Cosign/regctl operation.
+
+- [ ] **Step 4: Verify forced rebuild succeeds**
+
+```bash
+ha apps rebuild --force local_eebus_bridge
+ha apps start local_eebus_bridge
+ha apps info local_eebus_bridge
+```
+
+Expected: rebuild logs show v0.16.6 digest resolution and exact identity verification.
+
+- [ ] **Step 5: Verify wrong identity fails closed**
+
+Temporarily change repository name in the disposable clone's expected certificate identity:
+
+```bash
+python3 - <<'PY'
+from pathlib import Path
+
+path = Path("eebus-bridge-addon/fetch-verified-bridge.sh")
+old = "github.com/volschin/eebus-ha-bridge/.github/workflows"
+new = "github.com/volschin/eebus-ha-bridge-invalid/.github/workflows"
+text = path.read_text()
+if text.count(old) != 1:
+    raise SystemExit(f"expected one identity occurrence, found {text.count(old)}")
+path.write_text(text.replace(old, new))
+PY
+ha apps rebuild --force local_eebus_bridge
+```
+
+Expected: nonzero rebuild result; logs show Cosign identity mismatch; no unverified replacement image is produced.
+
+Restore production identity and prove recovery:
+
+```bash
+git restore eebus-bridge-addon/fetch-verified-bridge.sh
+ha apps rebuild --force local_eebus_bridge
+ha apps start local_eebus_bridge
+ha apps info local_eebus_bridge
+```
+
+Expected: rebuild, start, and info commands succeed.
+
+- [ ] **Step 6: Remove isolated test clone**
+
+Close devcontainer and VS Code window. From original checkout:
+
+```bash
+test_root="$(tr -d '\n' < /tmp/eebus-supervisor-cosign.path)"
+test -n "${test_root}"
+rm -rf "${test_root}"
+rm -f /tmp/eebus-supervisor-cosign.path
+git status --short
+```
+
+Expected: original feature checkout contains no devcontainer files or acceptance-test edits.
+
+---
+
+### Task 7: Review and merge feature PR
+
+**Files:**
+- Review all feature changes
+
+**Interfaces:**
+- Consumes: Tasks 2-6
+- Produces: merged fail-closed verifier on `main`
+
+- [ ] **Step 1: Run fresh final verification**
+
+```bash
+git diff --check
+python3 -m unittest \
+  scripts.tests.test_check_addon_version \
+  scripts.tests.test_fetch_verified_bridge \
+  scripts.tests.test_addon_dockerfile_supply_chain \
+  scripts.tests.test_check_addon_tool_platforms \
+  scripts.tests.test_release_addon_gate -v
+python3 scripts/check_addon_version.py
+python3 scripts/check_addon_tool_platforms.py eebus-bridge-addon/Dockerfile
+go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 \
+  .github/workflows/ci.yml .github/workflows/release.yml
+docker build \
+  --platform linux/amd64 \
+  --build-arg BUILD_VERSION=0.16.6 \
+  --tag eebus-bridge-addon:final-verify \
+  eebus-bridge-addon
+```
+
+Expected: all commands exit 0.
+
+- [ ] **Step 2: Request independent functional and security reviews**
+
+Review requirements:
+
+- same digest reaches Cosign and regctl extraction;
+- no fail-open path;
+- exact identity and issuer;
+- no tool binary in final image;
+- job permissions remain least privilege;
+- release publication waits for verified add-on build;
+- all three architectures remain covered.
+
+Fix every Critical or Important finding and rerun Step 1.
+
+- [ ] **Step 3: Push feature branch and create PR**
+
+```bash
+python3 - <<'PY'
+from pathlib import Path
+
+Path("/tmp/addon-verification-pr.md").write_text("""\
+## Summary
+
+- replace unsigned bridge `FROM` stage with digest resolution, exact Cosign identity verification, and same-digest binary extraction
+- keep Cosign, regctl, and verifier script outside final add-on image
+- gate pull requests and releases with verified add-on builds
+
+## Security boundary
+
+This rejects registry tag substitution and unsigned or differently signed images. It does not protect against compromise of authorized `release.yml` workflow.
+
+## Verification
+
+- signed bootstrap image v0.16.6 verified against exact workflow identity and GitHub OIDC issuer
+- shell, Dockerfile contract, platform manifest, version, and release workflow tests pass
+- amd64 add-on build passes and final image contains no verifier tools
+- Supervisor devcontainer install, restart, forced rebuild, negative identity, and recovery checks pass
+
+## Rollout
+
+After merge, separate v0.16.7 release delivers verified build path to existing installations.
+""")
+PY
+git push -u origin feat/addon-image-verification
+gh pr create --base main --head feat/addon-image-verification \
+  --title "feat: verify add-on bridge image provenance" \
+  --body-file /tmp/addon-verification-pr.md
+```
+
+Expected: PR body records architecture, v0.16.6 bootstrap evidence, automated checks, Supervisor result, threat-model boundary, and v0.16.7 rollout.
+
+- [ ] **Step 4: Babysit CI and review threads**
+
+Wait until all checks complete. Read comments and unresolved threads, verify each finding, apply focused fixes with tests, and push. Repeat until checks are green and unresolved actionable thread count is zero.
+
+- [ ] **Step 5: Merge feature PR**
+
+After all checks pass and unresolved actionable thread count is zero:
+
+```bash
+gh pr merge --squash --delete-branch
+git switch main
+git pull --ff-only origin main
+git status --short --branch
+```
+
+Expected: PR merged, remote feature branch deleted, local `main` clean and synchronized.
+
+---
+
+### Task 8: Release v0.16.7 and verify end-to-end gate
+
+**Files:**
+- Modify: `custom_components/eebus/manifest.json:13`
+- Modify: `eebus-bridge-addon/config.yaml:7`
+
+**Interfaces:**
+- Consumes: merged verifier and release gate
+- Produces: v0.16.7 update delivered to existing add-on installations
+
+- [ ] **Step 1: Create isolated release branch and bump both versions**
+
+```bash
+git switch main
+git pull --ff-only origin main
+git switch -c release/v0.16.7
+```
+
+Set `custom_components/eebus/manifest.json` to:
+
+```json
+"version": "0.16.7",
+```
+
+Set `eebus-bridge-addon/config.yaml` to:
+
+```yaml
+version: "0.16.7"
+```
+
+Run and commit:
+
+```bash
+python3 -m unittest scripts.tests.test_check_addon_version -v
+python3 scripts/check_addon_version.py
+python3 scripts/check_addon_version.py v0.16.7
+git add custom_components/eebus/manifest.json eebus-bridge-addon/config.yaml
+git commit -m "chore: prepare v0.16.7 release"
+```
+
+- [ ] **Step 2: Open and merge release PR after green CI**
+
+```bash
+git push -u origin release/v0.16.7
+gh pr create --base main --head release/v0.16.7 \
+  --title "chore: prepare v0.16.7 release" \
+  --body "Prepare v0.16.7 to deliver verified add-on source image builds."
+gh pr checks --watch --interval 30
+```
+
+Confirm all checks pass, changed files are only two version declarations, and no unresolved review threads exist. Then run:
+
+```bash
+gh pr merge --squash --delete-branch
+```
+
+- [ ] **Step 3: Tag v0.16.7 and watch full gated release**
+
+```bash
+git switch main
+git pull --ff-only origin main
+git tag -a v0.16.7 -m "v0.16.7"
+git push origin v0.16.7
+run_id="$(gh run list \
+  --workflow Release \
+  --commit "$(git rev-list -n 1 v0.16.7)" \
+  --limit 1 \
+  --json databaseId \
+  --jq '.[0].databaseId')"
+test -n "${run_id}"
+gh run watch "${run_id}" --exit-status
+```
+
+Expected job order and result:
+
+```text
+publish-image: success
+sign-image: success
+build-verified-addon: success
+create-release: success
+```
+
+- [ ] **Step 4: Verify published image identity independently**
+
+```bash
+image="ghcr.io/volschin/eebus-bridge:0.16.7"
+digest="$(docker buildx imagetools inspect "${image}" | awk '/^Digest:/ {print $2; exit}')"
+test -n "${digest}"
+docker run --rm \
+  ghcr.io/sigstore/cosign/cosign:v3.1.3@sha256:9e5c2f2edc34351160407ca3416c61855bdf9403c3c5936e0f0be7fc261611b8 \
+  verify \
+  --certificate-identity \
+  "https://github.com/volschin/eebus-ha-bridge/.github/workflows/release.yml@refs/tags/v0.16.7" \
+  --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+  "ghcr.io/volschin/eebus-bridge@${digest}"
+```
+
+Expected: Cosign exits 0 and reports signature from exact v0.16.7 release workflow identity.
+
+- [ ] **Step 5: Confirm final repository and release state**
+
+```bash
+python3 scripts/check_addon_version.py
+gh release view v0.16.7
+git status --short --branch
+```
+
+Expected: versions match, release is published, local `main` is clean and synchronized with `origin/main`.

--- a/docs/superpowers/specs/2026-08-27-addon-cosign-verification-design.md
+++ b/docs/superpowers/specs/2026-08-27-addon-cosign-verification-design.md
@@ -1,0 +1,195 @@
+# Verified Home Assistant Add-on Source Image Design
+
+**Date:** 2026-08-27
+
+## Goal
+
+The Home Assistant Supervisor must only package `/usr/local/bin/eebus-bridge` from a bridge image whose immutable multi-platform manifest digest was signed by this repository's release workflow. Verification must happen while Supervisor builds the add-on, fail closed, and add no registry or Sigstore dependency to normal add-on startup.
+
+## Context
+
+The add-on currently uses `ghcr.io/volschin/eebus-bridge:${BUILD_VERSION}` as a Dockerfile stage and copies one static binary from it. `BUILD_VERSION` comes from `config.yaml`; Supervisor builds the add-on locally on the user's machine. The release workflow now signs the pushed multi-platform digest keylessly with Cosign and verifies the signature before publishing the GitHub release.
+
+A digest cannot be committed alongside the version that creates it: the digest is only known after the tagged commit has built and pushed the image. Runtime verification in `run.sh` would happen after the image was built, would not prove which digest supplied the copied binary unless that digest were already embedded, and would make every start depend on registry availability.
+
+## Non-goals
+
+- Do not add Cosign or registry tools to the final add-on image.
+- Do not verify signatures during each add-on start.
+- Do not replace or digest-pin the existing Home Assistant base image in this change.
+- Do not protect against a compromised authorized release workflow. A correctly signed malicious release remains valid under this model.
+- Do not add fallback behavior for unsigned bridge images.
+- Do not change EEBUS runtime behavior, configuration, networking, or persistent data.
+
+## Architecture
+
+### Tool stages
+
+Use official multi-platform tool images pinned by tag and index digest:
+
+- `ghcr.io/sigstore/cosign/cosign:v3.1.3@sha256:9e5c2f2edc34351160407ca3416c61855bdf9403c3c5936e0f0be7fc261611b8`
+  - binary: `/ko-app/cosign`
+  - supports `linux/amd64`, `linux/arm64`, and `linux/arm/v7`
+- `ghcr.io/regclient/regctl:v0.11.5@sha256:dbe356c6cf9f8f85e302b9e47fed481ef3f1b04807350e99b02ab2cadee0a993`
+  - binary: `/regctl`
+  - supports `linux/amd64`, `linux/arm64`, and `linux/arm/v7`
+
+The tag documents the tool version. The digest determines immutable content and lets Renovate propose reviewed digest updates. Crane is not used because its official v0.22.0 image lacks `linux/arm/v7`.
+
+### Verification stage
+
+The Dockerfile no longer declares the bridge image as `FROM`. A `verified-bridge` stage based on the existing Home Assistant base image receives the two static tool binaries and the verification script.
+
+The script interface is:
+
+```text
+fetch-verified-bridge.sh <version> <output-path>
+```
+
+For version `X.Y.Z`, it performs these operations in order:
+
+1. Validate that the version exactly matches `^[0-9]+\.[0-9]+\.[0-9]+$`.
+2. Resolve `ghcr.io/volschin/eebus-bridge:X.Y.Z` to its multi-platform index digest with `regctl image digest` and no platform selection.
+3. Validate that the result exactly matches `sha256:` followed by 64 lowercase hexadecimal characters.
+4. Construct `ghcr.io/volschin/eebus-bridge@sha256:...`.
+5. Verify that digest with Cosign using:
+   - certificate identity `https://github.com/volschin/eebus-ha-bridge/.github/workflows/release.yml@refs/tags/vX.Y.Z`
+   - OIDC issuer `https://token.actions.githubusercontent.com`
+6. Only after successful verification, extract `/usr/local/bin/eebus-bridge` from the same digest with `regctl image get-file --platform local`.
+7. Require a non-empty executable output file.
+
+The final add-on stage copies only that output file, `run.sh`, and existing runtime content. Cosign, regctl, and the verification script remain in intermediate stages.
+
+### Data flow
+
+```text
+BUILD_VERSION
+    |
+    v
+mutable version tag --resolve once--> immutable index digest
+                                         |
+                                         +--> exact Cosign identity verification
+                                         |
+                                         +--> platform-local binary extraction
+                                                   |
+                                                   v
+                                         final Home Assistant add-on image
+```
+
+The signed index commits to every referenced platform manifest. `--platform local` chooses the native Supervisor platform from that signed index.
+
+## Security properties
+
+- The version tag is only used to discover one digest. All security-sensitive operations after discovery use the digest.
+- A tag change after discovery cannot alter either the verified subject or downloaded binary.
+- Verification uses an exact certificate identity and issuer, not regular expressions.
+- No transparency-log or certificate checks are disabled.
+- Registry, DNS, Sigstore, malformed version, malformed digest, missing signature, wrong identity, extraction, and output validation failures all terminate the build.
+- No unsigned fallback exists.
+- A failed install or update cannot produce a new add-on image. An already-built add-on has no Cosign, registry, or network dependency when it starts.
+- Tool images are immutable digest-pinned bootstrap dependencies. Updating either digest requires the normal dependency PR and CI path.
+- BuildKit may reuse a previously successful verification layer for an unchanged version and unchanged tools. Such a cache hit can only preserve the old verified binary; it cannot substitute content from a subsequently moved tag.
+
+## Automated tests
+
+### Verification script tests
+
+Add focused tests that place fake `cosign` and `regctl` executables first on `PATH` while exercising the real shell script. They must prove:
+
+- malformed versions fail before any registry command;
+- digest-resolution failure propagates;
+- malformed digest output fails before Cosign;
+- Cosign failure prevents `image get-file`;
+- success passes the exact same digest reference to Cosign and `image get-file`;
+- success passes the exact workflow identity and GitHub OIDC issuer;
+- success creates a non-empty executable output;
+- extraction failure or empty output fails closed.
+
+Mocks are limited to unavoidable external registry CLIs. Assertions target command order, arguments, output, and exit status of the production script.
+
+### Static Dockerfile tests
+
+Assert that:
+
+- the bridge repository is no longer used by a `FROM` instruction;
+- Cosign and regctl references include the approved full index digests;
+- only the verified output is copied into the final image;
+- the final stage does not contain Cosign, regctl, or the verification script.
+
+### Pull-request CI
+
+The existing add-on job continues to run Hadolint, the Supervisor add-on linter, and version synchronization. It additionally:
+
+1. runs verification-script and Dockerfile contract tests;
+2. confirms the pinned Cosign and regctl indexes contain `linux/amd64`, `linux/arm64`, and `linux/arm/v7`;
+3. builds the add-on on `linux/amd64` against the current already-signed release version.
+
+### Release CI
+
+Extend release ordering to:
+
+```text
+publish-image -> sign-image -> build-verified-addon -> create-release
+```
+
+`build-verified-addon` checks out the tagged source and builds the add-on on `linux/amd64` with `BUILD_VERSION` derived from the tag. It has only `contents: read`; the source image and signature are public. A failed verification or extraction prevents GitHub Release publication.
+
+The release build does not emulate other architectures. Platform availability is checked from the pinned tool indexes in PR CI, while users build natively on their Supervisor hardware.
+
+## Supervisor acceptance test
+
+Use Home Assistant's official app development devcontainer, which starts a real Supervisor and Home Assistant instance and maps the repository as a local app.
+
+After the bootstrap release and implementation:
+
+1. Start Home Assistant through the devcontainer task.
+2. Install the local EEBUS Bridge app through Supervisor.
+3. Confirm Supervisor build logs show digest resolution, successful identity verification, and extraction.
+4. Start the app and confirm the bridge reaches its normal running state.
+5. Stop and restart the app; confirm startup performs no Cosign or registry access.
+6. Force a Supervisor rebuild and confirm success.
+7. Temporarily alter the expected certificate identity in the local test checkout.
+8. Force another rebuild and confirm Supervisor reports build failure and no unverified image is produced.
+9. Restore the identity and confirm a subsequent forced rebuild and start succeed.
+
+Run the same install/build/start flow once on a real Home Assistant OS or Supervised system when available. Native ARM/v7 execution cannot be fully proven by an amd64 hosted runner without QEMU; the pinned manifest check preserves coverage until hardware validation is possible.
+
+## Rollout
+
+The currently referenced v0.16.5 bridge image predates Cosign signing. Enabling fail-closed verification against it would break new local builds.
+
+Rollout therefore uses separate release operations:
+
+1. Create a version-only v0.16.6 release from current `main` before merging implementation. The already-merged release workflow builds and signs its bridge image.
+2. Verify the v0.16.6 image signature explicitly against the exact workflow identity and issuer.
+3. Rebase the feature branch onto the v0.16.6 version commit.
+4. Implement and test the verifier against signed v0.16.6.
+5. Merge the feature PR after automated and Supervisor acceptance gates pass.
+6. Create a separate v0.16.7 release so existing add-on installations receive an update that contains the verified build path.
+7. Confirm v0.16.7 passes `build-verified-addon`, publishes its GitHub release, and verifies with Cosign.
+
+Version changes and release tags remain separate from the feature commit, preserving repository release policy.
+
+There is an unavoidable short interval after a future version commit reaches `main` and before its tag workflow has signed the image. A Supervisor build attempted in that interval fails closed and can be retried after the release completes.
+
+## Acceptance criteria
+
+- No `FROM ghcr.io/volschin/eebus-bridge:*` remains in the add-on Dockerfile.
+- Tag resolution occurs once; verification and extraction use the same validated digest.
+- Only the expected release workflow identity and GitHub OIDC issuer are accepted.
+- Cosign/regctl support all three add-on architectures and are digest-pinned.
+- Verification tools do not exist in the final add-on image.
+- Unit, static, amd64 integration, release-gate, and Supervisor devcontainer tests pass.
+- Negative identity testing proves Supervisor rebuild fails closed.
+- v0.16.6 is signed before implementation is merged.
+- v0.16.7 delivers the verifier to existing installations after feature merge.
+
+## References
+
+- [Sigstore image verification](https://docs.sigstore.dev/cosign/verifying/verify/)
+- [Sigstore Cosign installation and image identity](https://docs.sigstore.dev/cosign/system_config/installation/)
+- [regctl image get-file](https://regclient.org/cli/regctl/image/get-file/)
+- [regctl image export](https://regclient.org/cli/regctl/image/export/)
+- [Home Assistant local app testing](https://developers.home-assistant.io/docs/apps/testing/)
+- [Home Assistant app configuration](https://developers.home-assistant.io/docs/apps/configuration/)
+- [Home Assistant app publishing](https://developers.home-assistant.io/docs/add-ons/publishing/)

--- a/eebus-bridge-addon/Dockerfile
+++ b/eebus-bridge-addon/Dockerfile
@@ -11,21 +11,24 @@ ARG BUILD_VERSION
 # pin it later if that becomes worth the churn.
 ARG BUILD_FROM=ghcr.io/home-assistant/base:latest
 
-# The release workflow already publishes this binary for linux/amd64,
-# linux/arm64 and linux/arm/v7 — the same three platforms `arch:` lists — so
-# the add-on copies it out instead of rebuilding. The Supervisor builds add-ons
-# on the user's own hardware, where a Go toolchain run costs minutes of CPU and
-# can plausibly OOM on a Pi.
-FROM ghcr.io/volschin/eebus-bridge:${BUILD_VERSION} AS bridge
+FROM ghcr.io/sigstore/cosign/cosign:v3.1.3@sha256:9e5c2f2edc34351160407ca3416c61855bdf9403c3c5936e0f0be7fc261611b8 AS cosign
+FROM ghcr.io/regclient/regctl:v0.11.5@sha256:dbe356c6cf9f8f85e302b9e47fed481ef3f1b04807350e99b02ab2cadee0a993 AS regctl
 
 # hadolint ignore=DL3006
-FROM ${BUILD_FROM}
+FROM ${BUILD_FROM} AS verified-bridge
+ARG BUILD_VERSION
+# Resolve the mutable version tag once; verification and extraction then use one digest.
+COPY --from=cosign /ko-app/cosign /usr/local/bin/cosign
+COPY --from=regctl /regctl /usr/local/bin/regctl
+COPY fetch-verified-bridge.sh /usr/local/bin/fetch-verified-bridge
+RUN chmod 0755 /usr/local/bin/fetch-verified-bridge \
+    && /usr/local/bin/fetch-verified-bridge \
+        "${BUILD_VERSION}" /verified/eebus-bridge
 
-# The bridge is a static CGO_ENABLED=0 binary that never shells out, so nothing
-# else from the release image is needed and the HA base's userland (s6, bashio)
-# is only here to read the add-on options.
-COPY --from=bridge /usr/local/bin/eebus-bridge /usr/local/bin/eebus-bridge
+# Tool binaries stay in the verifier stage; only verified output enters runtime.
+# hadolint ignore=DL3006
+FROM ${BUILD_FROM}
+COPY --from=verified-bridge /verified/eebus-bridge /usr/local/bin/eebus-bridge
 COPY run.sh /run.sh
 RUN chmod a+x /run.sh
-
 CMD [ "/run.sh" ]

--- a/eebus-bridge-addon/fetch-verified-bridge.sh
+++ b/eebus-bridge-addon/fetch-verified-bridge.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+set -eu
+
+if [ "$#" -ne 2 ]; then
+    echo "usage: $0 <version> <output-path>" >&2
+    exit 64
+fi
+
+version="$1"
+output="$2"
+repository="ghcr.io/volschin/eebus-bridge"
+issuer="https://token.actions.githubusercontent.com"
+
+if ! printf '%s\n' "${version}" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+    echo "invalid bridge version: ${version}" >&2
+    exit 65
+fi
+
+tag_ref="${repository}:${version}"
+digest="$(regctl image digest "${tag_ref}")"
+if ! printf '%s\n' "${digest}" | grep -Eq '^sha256:[0-9a-f]{64}$'; then
+    echo "invalid bridge image digest: ${digest}" >&2
+    exit 66
+fi
+
+image="${repository}@${digest}"
+identity="https://github.com/volschin/eebus-ha-bridge/.github/workflows/release.yml@refs/tags/v${version}"
+
+echo "Verifying ${image} from ${identity}"
+cosign verify \
+    --certificate-identity "${identity}" \
+    --certificate-oidc-issuer "${issuer}" \
+    "${image}" >/dev/null
+
+mkdir -p "$(dirname "${output}")"
+rm -f "${output}"
+regctl image get-file --platform local \
+    "${image}" \
+    /usr/local/bin/eebus-bridge \
+    "${output}"
+chmod 0755 "${output}"
+
+if [ ! -s "${output}" ] || [ ! -x "${output}" ]; then
+    echo "verified bridge output is missing or not executable" >&2
+    exit 67
+fi

--- a/eebus-bridge-addon/fetch-verified-bridge.sh
+++ b/eebus-bridge-addon/fetch-verified-bridge.sh
@@ -34,19 +34,25 @@ cosign verify \
 
 mkdir -p "$(dirname "${output}")"
 rm -f "${output}"
-temp_output="${output}.tmp.$$"
+temp_dir="$(mktemp -d "$(dirname "${output}")/.eebus-bridge.XXXXXX")"
+temp_output="${temp_dir}/eebus-bridge"
 cleanup() {
-    rm -f "${temp_output}"
+    rm -rf "${temp_dir}"
 }
 trap cleanup EXIT HUP INT TERM
 regctl image get-file --platform local \
     "${image}" \
     /usr/local/bin/eebus-bridge \
     "${temp_output}"
+
+if [ ! -f "${temp_output}" ] || [ -L "${temp_output}" ] || [ ! -s "${temp_output}" ]; then
+    echo "verified bridge output is missing, not regular, or empty" >&2
+    exit 67
+fi
 chmod 0755 "${temp_output}"
 
-if [ ! -s "${temp_output}" ] || [ ! -x "${temp_output}" ]; then
-    echo "verified bridge output is missing or not executable" >&2
+if [ ! -x "${temp_output}" ]; then
+    echo "verified bridge output is not executable" >&2
     exit 67
 fi
 

--- a/eebus-bridge-addon/fetch-verified-bridge.sh
+++ b/eebus-bridge-addon/fetch-verified-bridge.sh
@@ -34,13 +34,20 @@ cosign verify \
 
 mkdir -p "$(dirname "${output}")"
 rm -f "${output}"
+temp_output="${output}.tmp.$$"
+cleanup() {
+    rm -f "${temp_output}"
+}
+trap cleanup EXIT HUP INT TERM
 regctl image get-file --platform local \
     "${image}" \
     /usr/local/bin/eebus-bridge \
-    "${output}"
-chmod 0755 "${output}"
+    "${temp_output}"
+chmod 0755 "${temp_output}"
 
-if [ ! -s "${output}" ] || [ ! -x "${output}" ]; then
+if [ ! -s "${temp_output}" ] || [ ! -x "${temp_output}" ]; then
     echo "verified bridge output is missing or not executable" >&2
     exit 67
 fi
+
+mv -f "${temp_output}" "${output}"

--- a/scripts/check_addon_tool_platforms.py
+++ b/scripts/check_addon_tool_platforms.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import re
+import subprocess
+import sys
+from typing import Any
+
+
+REQUIRED_PLATFORMS = {"linux/amd64", "linux/arm64", "linux/arm/v7"}
+TOOL_STAGES = ("cosign", "regctl")
+FROM_RE = re.compile(
+    r"(?mi)^FROM\s+(?P<image>\S+)\s+AS\s+(?P<stage>cosign|regctl)\s*$"
+)
+DIGEST_RE = re.compile(r"@sha256:[0-9a-f]{64}$")
+
+
+def tool_images(dockerfile: str) -> list[str]:
+    images = {
+        match.group("stage"): match.group("image") for match in FROM_RE.finditer(dockerfile)
+    }
+    for stage in TOOL_STAGES:
+        if stage not in images:
+            raise ValueError(f"missing tool stage: {stage}")
+        if DIGEST_RE.search(images[stage]) is None:
+            raise ValueError(f"tool stage {stage} is not digest-pinned: {images[stage]}")
+    return [images[stage] for stage in TOOL_STAGES]
+
+
+def manifest_platforms(index: dict[str, Any]) -> set[str]:
+    manifests = index.get("manifests")
+    if not isinstance(manifests, list):
+        raise ValueError("image reference did not resolve to an OCI index")
+
+    platforms: set[str] = set()
+    for descriptor in manifests:
+        if not isinstance(descriptor, dict):
+            continue
+        platform = descriptor.get("platform")
+        if not isinstance(platform, dict):
+            continue
+        os_name = platform.get("os")
+        architecture = platform.get("architecture")
+        variant = platform.get("variant")
+        if not isinstance(os_name, str) or not isinstance(architecture, str):
+            continue
+        value = f"{os_name}/{architecture}"
+        if isinstance(variant, str) and variant and (architecture, variant) != ("arm64", "v8"):
+            value = f"{value}/{variant}"
+        platforms.add(value)
+    return platforms
+
+
+def missing_platforms(platforms: set[str]) -> set[str]:
+    return REQUIRED_PLATFORMS - platforms
+
+
+def inspect_index(image: str) -> dict[str, Any]:
+    result = subprocess.run(
+        ["docker", "buildx", "imagetools", "inspect", "--raw", image],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    value = json.loads(result.stdout)
+    if not isinstance(value, dict):
+        raise ValueError(f"invalid OCI index for {image}")
+    return value
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("dockerfile", type=Path)
+    args = parser.parse_args()
+
+    try:
+        images = tool_images(args.dockerfile.read_text())
+        for image in images:
+            missing = missing_platforms(manifest_platforms(inspect_index(image)))
+            if missing:
+                names = ", ".join(sorted(missing))
+                raise ValueError(f"{image} is missing platforms: {names}")
+            print(f"{image}: required platforms present")
+    except (OSError, ValueError, json.JSONDecodeError, subprocess.CalledProcessError) as error:
+        print(error, file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/select_addon_ci_build_version.py
+++ b/scripts/select_addon_ci_build_version.py
@@ -19,14 +19,19 @@ VERSION_PATHS = frozenset(
 _MANIFEST_PATH = "custom_components/eebus/manifest.json"
 _ADDON_CONFIG_PATH = "eebus-bridge-addon/config.yaml"
 _ADDON_VERSION_RE = re.compile(r'(?m)^version: "([^"\n]+)"[ \t]*$')
+_VERSION_RE = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+$")
+
+
+def _validate_version(path: str, version: object) -> str:
+    if not isinstance(version, str) or not _VERSION_RE.fullmatch(version):
+        raise ValueError(f"{path} has an invalid version")
+    return version
 
 
 def _parse_version(path: str, content: str) -> tuple[str, str]:
     if path == _MANIFEST_PATH:
         document = json.loads(content)
-        version = document.get("version")
-        if not isinstance(version, str) or not version:
-            raise ValueError(f"{path} has no version")
+        version = _validate_version(path, document.get("version"))
         document["version"] = "__VERSION__"
         return version, json.dumps(document, sort_keys=True, separators=(",", ":"))
 
@@ -34,7 +39,8 @@ def _parse_version(path: str, content: str) -> tuple[str, str]:
         matches = list(_ADDON_VERSION_RE.finditer(content))
         if len(matches) != 1:
             raise ValueError(f"{path} must contain exactly one quoted version")
-        return matches[0].group(1), _ADDON_VERSION_RE.sub('version: "__VERSION__"', content)
+        version = _validate_version(path, matches[0].group(1))
+        return version, _ADDON_VERSION_RE.sub('version: "__VERSION__"', content)
 
     raise ValueError(f"unsupported version declaration: {path}")
 
@@ -66,7 +72,7 @@ def select_build_version(
 
     try:
         base_version, base_normalized = _version_and_normalized_files(base_files)
-    except (KeyError, ValueError, json.JSONDecodeError):
+    except KeyError:
         return current_version
 
     if base_normalized != current_normalized:

--- a/scripts/select_addon_ci_build_version.py
+++ b/scripts/select_addon_ci_build_version.py
@@ -81,7 +81,7 @@ def select_build_version(
 
 
 def _git_output(*args: str) -> str:
-    return subprocess.check_output(("git", *args), text=True).strip()
+    return subprocess.check_output(("git", *args), text=True)
 
 
 def _current_files() -> dict[str, str]:

--- a/scripts/select_addon_ci_build_version.py
+++ b/scripts/select_addon_ci_build_version.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Select the bridge version for a verified add-on CI build."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import re
+import subprocess
+from collections.abc import Collection, Mapping
+
+VERSION_PATHS = frozenset(
+    {
+        "custom_components/eebus/manifest.json",
+        "eebus-bridge-addon/config.yaml",
+    }
+)
+_MANIFEST_PATH = "custom_components/eebus/manifest.json"
+_ADDON_CONFIG_PATH = "eebus-bridge-addon/config.yaml"
+_ADDON_VERSION_RE = re.compile(r'(?m)^version: "([^"\n]+)"[ \t]*$')
+
+
+def _parse_version(path: str, content: str) -> tuple[str, str]:
+    if path == _MANIFEST_PATH:
+        document = json.loads(content)
+        version = document.get("version")
+        if not isinstance(version, str) or not version:
+            raise ValueError(f"{path} has no version")
+        document["version"] = "__VERSION__"
+        return version, json.dumps(document, sort_keys=True, separators=(",", ":"))
+
+    if path == _ADDON_CONFIG_PATH:
+        matches = list(_ADDON_VERSION_RE.finditer(content))
+        if len(matches) != 1:
+            raise ValueError(f"{path} must contain exactly one quoted version")
+        return matches[0].group(1), _ADDON_VERSION_RE.sub('version: "__VERSION__"', content)
+
+    raise ValueError(f"unsupported version declaration: {path}")
+
+
+def _version_and_normalized_files(
+    files: Mapping[str, str],
+) -> tuple[str, dict[str, str]]:
+    versions: set[str] = set()
+    normalized: dict[str, str] = {}
+    for path in VERSION_PATHS:
+        version, normalized_content = _parse_version(path, files[path])
+        versions.add(version)
+        normalized[path] = normalized_content
+
+    if len(versions) != 1:
+        raise ValueError("version declarations are not synchronized")
+    return versions.pop(), normalized
+
+
+def select_build_version(
+    changed_paths: Collection[str],
+    base_files: Mapping[str, str],
+    current_files: Mapping[str, str],
+) -> str:
+    """Use the signed base version only for a semantic version-only change."""
+    current_version, current_normalized = _version_and_normalized_files(current_files)
+    if set(changed_paths) != VERSION_PATHS:
+        return current_version
+
+    try:
+        base_version, base_normalized = _version_and_normalized_files(base_files)
+    except (KeyError, ValueError, json.JSONDecodeError):
+        return current_version
+
+    if base_normalized != current_normalized:
+        return current_version
+    return base_version
+
+
+def _git_output(*args: str) -> str:
+    return subprocess.check_output(("git", *args), text=True).strip()
+
+
+def _current_files() -> dict[str, str]:
+    return {path: Path(path).read_text() for path in VERSION_PATHS}
+
+
+def _base_files(base: str) -> dict[str, str]:
+    return {path: _git_output("show", f"{base}:{path}") for path in VERSION_PATHS}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--base", required=True, help="trusted event base commit")
+    args = parser.parse_args()
+
+    changed_paths = _git_output("diff", "--name-only", args.base, "HEAD").splitlines()
+    current_files = _current_files()
+    try:
+        base_files = _base_files(args.base)
+    except subprocess.CalledProcessError:
+        base_files = {}
+
+    print(select_build_version(changed_paths, base_files, current_files))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tests/test_addon_dockerfile_supply_chain.py
+++ b/scripts/tests/test_addon_dockerfile_supply_chain.py
@@ -1,0 +1,45 @@
+from pathlib import Path
+import re
+import unittest
+
+
+DOCKERFILE = Path(__file__).parents[2] / "eebus-bridge-addon" / "Dockerfile"
+COSIGN_REF = (
+    "ghcr.io/sigstore/cosign/cosign:v3.1.3@sha256:"
+    "9e5c2f2edc34351160407ca3416c61855bdf9403c3c5936e0f0be7fc261611b8"
+)
+REGCTL_REF = (
+    "ghcr.io/regclient/regctl:v0.11.5@sha256:"
+    "dbe356c6cf9f8f85e302b9e47fed481ef3f1b04807350e99b02ab2cadee0a993"
+)
+
+
+class AddonDockerfileSupplyChainTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.text = DOCKERFILE.read_text()
+
+    def test_bridge_registry_is_not_a_from_source(self) -> None:
+        self.assertNotRegex(
+            self.text,
+            r"(?m)^FROM\s+ghcr\.io/volschin/eebus-bridge",
+        )
+
+    def test_verifier_tools_are_tagged_and_digest_pinned(self) -> None:
+        self.assertIn(f"FROM {COSIGN_REF} AS cosign", self.text)
+        self.assertIn(f"FROM {REGCTL_REF} AS regctl", self.text)
+
+    def test_final_stage_copies_only_verified_bridge(self) -> None:
+        final_stage = self.text.rsplit("FROM ${BUILD_FROM}", 1)[1]
+        self.assertIn(
+            "COPY --from=verified-bridge /verified/eebus-bridge "
+            "/usr/local/bin/eebus-bridge",
+            final_stage,
+        )
+        self.assertNotIn("cosign", final_stage)
+        self.assertNotIn("regctl", final_stage)
+        self.assertNotIn("fetch-verified-bridge", final_stage)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_check_addon_tool_platforms.py
+++ b/scripts/tests/test_check_addon_tool_platforms.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import unittest
+
+from scripts.check_addon_tool_platforms import (
+    manifest_platforms,
+    missing_platforms,
+    tool_images,
+)
+
+
+COSIGN = "ghcr.io/sigstore/cosign/cosign:v3.1.3@sha256:" + "a" * 64
+REGCTL = "ghcr.io/regclient/regctl:v0.11.5@sha256:" + "b" * 64
+DOCKERFILE = f"""\
+FROM {COSIGN} AS cosign
+FROM {REGCTL} AS regctl
+FROM base AS final
+"""
+INDEX = {
+    "manifests": [
+        {"platform": {"os": "linux", "architecture": "amd64"}},
+        {"platform": {"os": "linux", "architecture": "arm64"}},
+        {
+            "platform": {
+                "os": "linux",
+                "architecture": "arm",
+                "variant": "v7",
+            }
+        },
+    ]
+}
+
+
+class AddonToolPlatformsTest(unittest.TestCase):
+    def test_extracts_digest_pinned_tool_stages(self) -> None:
+        self.assertEqual(tool_images(DOCKERFILE), [COSIGN, REGCTL])
+
+    def test_rejects_missing_tool_stage(self) -> None:
+        with self.assertRaisesRegex(ValueError, "missing tool stage: regctl"):
+            tool_images(f"FROM {COSIGN} AS cosign\n")
+
+    def test_rejects_tool_without_full_digest(self) -> None:
+        dockerfile = DOCKERFILE.replace(
+            COSIGN,
+            "ghcr.io/sigstore/cosign/cosign:v3.1.3",
+        )
+        with self.assertRaisesRegex(ValueError, "not digest-pinned"):
+            tool_images(dockerfile)
+
+    def test_normalizes_manifest_platforms(self) -> None:
+        self.assertEqual(
+            manifest_platforms(INDEX),
+            {"linux/amd64", "linux/arm64", "linux/arm/v7"},
+        )
+
+    def test_normalizes_arm64_v8_manifest_variant(self) -> None:
+        self.assertEqual(
+            manifest_platforms(
+                {
+                    "manifests": [
+                        {
+                            "platform": {
+                                "os": "linux",
+                                "architecture": "arm64",
+                                "variant": "v8",
+                            }
+                        }
+                    ]
+                }
+            ),
+            {"linux/arm64"},
+        )
+
+    def test_reports_missing_arm_v7(self) -> None:
+        self.assertEqual(
+            missing_platforms({"linux/amd64", "linux/arm64"}),
+            {"linux/arm/v7"},
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_ci_addon_paths_filter.py
+++ b/scripts/tests/test_ci_addon_paths_filter.py
@@ -10,6 +10,7 @@ REQUIRED_ADDON_PATHS = {
     ".github/workflows/release.yml",
     "scripts/check_addon_tool_platforms.py",
     "scripts/tests/test_check_addon_tool_platforms.py",
+    "scripts/tests/test_ci_addon_paths_filter.py",
     "scripts/tests/test_release_addon_gate.py",
 }
 

--- a/scripts/tests/test_ci_addon_paths_filter.py
+++ b/scripts/tests/test_ci_addon_paths_filter.py
@@ -7,8 +7,10 @@ import unittest
 
 WORKFLOW = Path(__file__).parents[2] / ".github/workflows/ci.yml"
 REQUIRED_ADDON_PATHS = {
+    ".github/workflows/release.yml",
     "scripts/check_addon_tool_platforms.py",
     "scripts/tests/test_check_addon_tool_platforms.py",
+    "scripts/tests/test_release_addon_gate.py",
 }
 
 
@@ -30,6 +32,10 @@ class AddonPathsFilterTest(unittest.TestCase):
 
         self.assertIn(
             "python3 -m unittest scripts.tests.test_ci_addon_paths_filter -v",
+            addon_job,
+        )
+        self.assertIn(
+            "python3 -m unittest scripts.tests.test_release_addon_gate -v",
             addon_job,
         )
 

--- a/scripts/tests/test_ci_addon_paths_filter.py
+++ b/scripts/tests/test_ci_addon_paths_filter.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from pathlib import Path
+import unittest
+
+
+WORKFLOW = Path(__file__).parents[2] / ".github/workflows/ci.yml"
+REQUIRED_ADDON_PATHS = {
+    "scripts/check_addon_tool_platforms.py",
+    "scripts/tests/test_check_addon_tool_platforms.py",
+}
+
+
+class AddonPathsFilterTest(unittest.TestCase):
+    def test_addon_filter_triggers_for_platform_checker_changes(self) -> None:
+        workflow = WORKFLOW.read_text()
+        addon_filter = workflow.split("            addon:\n", 1)[1].split(
+            "            go:\n", 1
+        )[0]
+
+        for path in REQUIRED_ADDON_PATHS:
+            self.assertIn(f"              - '{path}'", addon_filter)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_ci_addon_paths_filter.py
+++ b/scripts/tests/test_ci_addon_paths_filter.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+import re
 import unittest
 
 
@@ -20,6 +21,17 @@ class AddonPathsFilterTest(unittest.TestCase):
 
         for path in REQUIRED_ADDON_PATHS:
             self.assertIn(f"              - '{path}'", addon_filter)
+
+    def test_addon_job_runs_filter_contract_test(self) -> None:
+        workflow = WORKFLOW.read_text()
+        addon_job = re.search(
+            r"(?ms)^  addon:\n(?P<body>.*?)(?=^  \w+:|\Z)", workflow
+        ).group("body")
+
+        self.assertIn(
+            "python3 -m unittest scripts.tests.test_ci_addon_paths_filter -v",
+            addon_job,
+        )
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_ci_addon_paths_filter.py
+++ b/scripts/tests/test_ci_addon_paths_filter.py
@@ -8,20 +8,28 @@ import unittest
 WORKFLOW = Path(__file__).parents[2] / ".github/workflows/ci.yml"
 REQUIRED_ADDON_PATHS = {
     ".github/workflows/release.yml",
+    "custom_components/eebus/manifest.json",
+    "eebus-bridge-addon/config.yaml",
     "scripts/check_addon_tool_platforms.py",
+    "scripts/select_addon_ci_build_version.py",
     "scripts/tests/test_addon_dockerfile_supply_chain.py",
     "scripts/tests/test_check_addon_tool_platforms.py",
     "scripts/tests/test_ci_addon_paths_filter.py",
     "scripts/tests/test_fetch_verified_bridge.py",
     "scripts/tests/test_release_addon_gate.py",
+    "scripts/tests/test_select_addon_ci_build_version.py",
 }
 REQUIRED_ADDON_BUILD_PATHS = {
     ".github/workflows/ci.yml",
     ".github/workflows/release.yml",
+    "custom_components/eebus/manifest.json",
     "eebus-bridge-addon/Dockerfile",
+    "eebus-bridge-addon/config.yaml",
     "eebus-bridge-addon/fetch-verified-bridge.sh",
     "eebus-bridge-addon/run.sh",
     "scripts/check_addon_tool_platforms.py",
+    "scripts/select_addon_ci_build_version.py",
+    "scripts/tests/test_select_addon_ci_build_version.py",
 }
 VERSION_DECLARATION_PATHS = {
     "custom_components/eebus/manifest.json",
@@ -39,7 +47,7 @@ class AddonPathsFilterTest(unittest.TestCase):
         for path in REQUIRED_ADDON_PATHS:
             self.assertIn(f"              - '{path}'", addon_filter)
 
-    def test_addon_build_filter_skips_version_only_changes(self) -> None:
+    def test_addon_build_filter_covers_version_declarations(self) -> None:
         workflow = WORKFLOW.read_text()
         changes_job = workflow.split("  changes:\n", 1)[1].split("  policy:\n", 1)[0]
         addon_build_filter = workflow.split("            addon_build:\n", 1)[1].split(
@@ -52,7 +60,7 @@ class AddonPathsFilterTest(unittest.TestCase):
         for path in REQUIRED_ADDON_BUILD_PATHS:
             self.assertIn(f"              - '{path}'", addon_build_filter)
         for path in VERSION_DECLARATION_PATHS:
-            self.assertNotIn(f"              - '{path}'", addon_build_filter)
+            self.assertIn(f"              - '{path}'", addon_build_filter)
 
     def test_addon_job_runs_filter_contract_test(self) -> None:
         workflow = WORKFLOW.read_text()
@@ -71,6 +79,18 @@ class AddonPathsFilterTest(unittest.TestCase):
         build_step = addon_job.split("      - name: Build verified add-on image\n", 1)[1]
         self.assertIn(
             "        if: needs.changes.outputs.addon_build == 'true'\n",
+            build_step,
+        )
+        self.assertIn("          fetch-depth: 0", addon_job)
+        selection_step = addon_job.split(
+            "      - name: Select verified add-on build version\n", 1
+        )[1].split("      - name: Build verified add-on image\n", 1)[0]
+        self.assertIn(
+            'python3 scripts/select_addon_ci_build_version.py --base "$base"',
+            selection_step,
+        )
+        self.assertIn(
+            '--build-arg "BUILD_VERSION=${{ steps.addon-build-version.outputs.version }}"',
             build_step,
         )
 

--- a/scripts/tests/test_ci_addon_paths_filter.py
+++ b/scripts/tests/test_ci_addon_paths_filter.py
@@ -9,9 +9,23 @@ WORKFLOW = Path(__file__).parents[2] / ".github/workflows/ci.yml"
 REQUIRED_ADDON_PATHS = {
     ".github/workflows/release.yml",
     "scripts/check_addon_tool_platforms.py",
+    "scripts/tests/test_addon_dockerfile_supply_chain.py",
     "scripts/tests/test_check_addon_tool_platforms.py",
     "scripts/tests/test_ci_addon_paths_filter.py",
+    "scripts/tests/test_fetch_verified_bridge.py",
     "scripts/tests/test_release_addon_gate.py",
+}
+REQUIRED_ADDON_BUILD_PATHS = {
+    ".github/workflows/ci.yml",
+    ".github/workflows/release.yml",
+    "eebus-bridge-addon/Dockerfile",
+    "eebus-bridge-addon/fetch-verified-bridge.sh",
+    "eebus-bridge-addon/run.sh",
+    "scripts/check_addon_tool_platforms.py",
+}
+VERSION_DECLARATION_PATHS = {
+    "custom_components/eebus/manifest.json",
+    "eebus-bridge-addon/config.yaml",
 }
 
 
@@ -24,6 +38,21 @@ class AddonPathsFilterTest(unittest.TestCase):
 
         for path in REQUIRED_ADDON_PATHS:
             self.assertIn(f"              - '{path}'", addon_filter)
+
+    def test_addon_build_filter_skips_version_only_changes(self) -> None:
+        workflow = WORKFLOW.read_text()
+        changes_job = workflow.split("  changes:\n", 1)[1].split("  policy:\n", 1)[0]
+        addon_build_filter = workflow.split("            addon_build:\n", 1)[1].split(
+            "            go:\n", 1
+        )[0]
+
+        self.assertIn(
+            "      addon_build: ${{ steps.filter.outputs.addon_build }}", changes_job
+        )
+        for path in REQUIRED_ADDON_BUILD_PATHS:
+            self.assertIn(f"              - '{path}'", addon_build_filter)
+        for path in VERSION_DECLARATION_PATHS:
+            self.assertNotIn(f"              - '{path}'", addon_build_filter)
 
     def test_addon_job_runs_filter_contract_test(self) -> None:
         workflow = WORKFLOW.read_text()
@@ -38,6 +67,11 @@ class AddonPathsFilterTest(unittest.TestCase):
         self.assertIn(
             "python3 -m unittest scripts.tests.test_release_addon_gate -v",
             addon_job,
+        )
+        build_step = addon_job.split("      - name: Build verified add-on image\n", 1)[1]
+        self.assertIn(
+            "        if: needs.changes.outputs.addon_build == 'true'\n",
+            build_step,
         )
 
 

--- a/scripts/tests/test_ci_addon_paths_filter.py
+++ b/scripts/tests/test_ci_addon_paths_filter.py
@@ -90,9 +90,13 @@ class AddonPathsFilterTest(unittest.TestCase):
             selection_step,
         )
         self.assertIn(
-            '--build-arg "BUILD_VERSION=${{ steps.addon-build-version.outputs.version }}"',
+            "        env:\n"
+            "          BUILD_VERSION: ${{ steps.addon-build-version.outputs.version }}\n",
             build_step,
         )
+        build_run = build_step.split("        run: |\n", 1)[1]
+        self.assertIn('--build-arg "BUILD_VERSION=${BUILD_VERSION}"', build_run)
+        self.assertNotIn("${{ steps.addon-build-version.outputs.version }}", build_run)
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_fetch_verified_bridge.py
+++ b/scripts/tests/test_fetch_verified_bridge.py
@@ -37,7 +37,10 @@ class FetchVerifiedBridgeTest(unittest.TestCase):
                 exit 0
             fi
             if [ "$1 $2" = "image get-file" ]; then
-                [ "${FAKE_GET_FILE_EXIT:-0}" -eq 0 ] || exit "${FAKE_GET_FILE_EXIT}"
+                if [ "${FAKE_GET_FILE_EXIT:-0}" -ne 0 ]; then
+                    printf 'partial-binary' >"$7"
+                    exit "${FAKE_GET_FILE_EXIT}"
+                fi
                 if [ "${FAKE_EMPTY_OUTPUT:-0}" -eq 0 ]; then
                     printf 'verified-binary' >"$7"
                 else

--- a/scripts/tests/test_fetch_verified_bridge.py
+++ b/scripts/tests/test_fetch_verified_bridge.py
@@ -41,6 +41,10 @@ class FetchVerifiedBridgeTest(unittest.TestCase):
                     printf 'partial-binary' >"$7"
                     exit "${FAKE_GET_FILE_EXIT}"
                 fi
+                if [ "${FAKE_SYMLINK_OUTPUT:-0}" -eq 1 ]; then
+                    ln -s "${CALL_LOG}" "$7"
+                    exit 0
+                fi
                 if [ "${FAKE_EMPTY_OUTPUT:-0}" -eq 0 ]; then
                     printf 'verified-binary' >"$7"
                 else
@@ -113,10 +117,17 @@ class FetchVerifiedBridgeTest(unittest.TestCase):
         self.assertIn("regctl image get-file --platform local", calls)
         self.assertEqual(self.output.read_text(), "verified-binary")
         self.assertTrue(self.output.stat().st_mode & stat.S_IXUSR)
+        self.assertEqual(list(self.root.glob(".eebus-bridge.*")), [])
 
     def test_empty_extracted_file_fails_closed(self) -> None:
         result = self._run(FAKE_EMPTY_OUTPUT="1")
         self.assertNotEqual(result.returncode, 0)
+
+    def test_symlink_extracted_file_fails_closed(self) -> None:
+        result = self._run(FAKE_SYMLINK_OUTPUT="1")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertFalse(self.output.exists())
+        self.assertEqual(list(self.root.glob(".eebus-bridge.*")), [])
 
     def test_digest_resolution_failure_propagates(self) -> None:
         result = self._run(FAKE_DIGEST_EXIT="23")
@@ -133,6 +144,7 @@ class FetchVerifiedBridgeTest(unittest.TestCase):
         self.assertIn("cosign verify", calls)
         self.assertIn("regctl image get-file", calls)
         self.assertFalse(self.output.exists())
+        self.assertEqual(list(self.root.glob(".eebus-bridge.*")), [])
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_fetch_verified_bridge.py
+++ b/scripts/tests/test_fetch_verified_bridge.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import stat
+import subprocess
+import tempfile
+import textwrap
+import unittest
+
+
+ROOT = Path(__file__).parents[2]
+SCRIPT = ROOT / "eebus-bridge-addon" / "fetch-verified-bridge.sh"
+VALID_DIGEST = "sha256:" + "a" * 64
+EXPECTED_IMAGE = f"ghcr.io/volschin/eebus-bridge@{VALID_DIGEST}"
+EXPECTED_IDENTITY = (
+    "https://github.com/volschin/eebus-ha-bridge/.github/workflows/"
+    "release.yml@refs/tags/v0.16.6"
+)
+
+
+class FetchVerifiedBridgeTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp_dir.name)
+        self.bin_dir = self.root / "bin"
+        self.bin_dir.mkdir()
+        self.log = self.root / "calls.log"
+        self.output = self.root / "eebus-bridge"
+        self._write_fake(
+            "regctl",
+            r"""
+            printf 'regctl %s\n' "$*" >>"${CALL_LOG}"
+            if [ "$1 $2" = "image digest" ]; then
+                [ "${FAKE_DIGEST_EXIT:-0}" -eq 0 ] || exit "${FAKE_DIGEST_EXIT}"
+                printf '%s\n' "${FAKE_DIGEST:-sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa}"
+                exit 0
+            fi
+            if [ "$1 $2" = "image get-file" ]; then
+                [ "${FAKE_GET_FILE_EXIT:-0}" -eq 0 ] || exit "${FAKE_GET_FILE_EXIT}"
+                if [ "${FAKE_EMPTY_OUTPUT:-0}" -eq 0 ]; then
+                    printf 'verified-binary' >"$7"
+                else
+                    : >"$7"
+                fi
+                exit 0
+            fi
+            exit 90
+            """,
+        )
+        self._write_fake(
+            "cosign",
+            r"""
+            printf 'cosign %s\n' "$*" >>"${CALL_LOG}"
+            exit "${FAKE_COSIGN_EXIT:-0}"
+            """,
+        )
+
+    def tearDown(self) -> None:
+        self.temp_dir.cleanup()
+
+    def _write_fake(self, name: str, body: str) -> None:
+        path = self.bin_dir / name
+        path.write_text("#!/bin/sh\nset -eu\n" + textwrap.dedent(body))
+        path.chmod(0o755)
+
+    def _run(self, version: str = "0.16.6", **extra_env: str) -> subprocess.CompletedProcess[str]:
+        env = os.environ.copy()
+        env.update(
+            {
+                "PATH": f"{self.bin_dir}:/usr/bin:/bin",
+                "CALL_LOG": str(self.log),
+                **extra_env,
+            }
+        )
+        return subprocess.run(
+            [str(SCRIPT), version, str(self.output)],
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    def test_rejects_non_semver_before_registry_access(self) -> None:
+        result = self._run("v0.16.6")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertFalse(self.log.exists())
+
+    def test_rejects_malformed_digest_before_cosign(self) -> None:
+        result = self._run(FAKE_DIGEST="sha256:bad")
+        self.assertNotEqual(result.returncode, 0)
+        calls = self.log.read_text()
+        self.assertIn("regctl image digest", calls)
+        self.assertNotIn("cosign", calls)
+
+    def test_cosign_failure_prevents_extraction(self) -> None:
+        result = self._run(FAKE_COSIGN_EXIT="17")
+        self.assertEqual(result.returncode, 17)
+        calls = self.log.read_text()
+        self.assertIn("cosign verify", calls)
+        self.assertNotIn("get-file", calls)
+
+    def test_success_verifies_and_extracts_same_digest(self) -> None:
+        result = self._run()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        calls = self.log.read_text()
+        self.assertEqual(calls.count(EXPECTED_IMAGE), 2)
+        self.assertIn(EXPECTED_IDENTITY, calls)
+        self.assertIn("https://token.actions.githubusercontent.com", calls)
+        self.assertIn("regctl image get-file --platform local", calls)
+        self.assertEqual(self.output.read_text(), "verified-binary")
+        self.assertTrue(self.output.stat().st_mode & stat.S_IXUSR)
+
+    def test_empty_extracted_file_fails_closed(self) -> None:
+        result = self._run(FAKE_EMPTY_OUTPUT="1")
+        self.assertNotEqual(result.returncode, 0)
+
+    def test_digest_resolution_failure_propagates(self) -> None:
+        result = self._run(FAKE_DIGEST_EXIT="23")
+        self.assertEqual(result.returncode, 23)
+        calls = self.log.read_text()
+        self.assertIn("regctl image digest", calls)
+        self.assertNotIn("cosign", calls)
+        self.assertNotIn("get-file", calls)
+
+    def test_extraction_failure_propagates(self) -> None:
+        result = self._run(FAKE_GET_FILE_EXIT="29")
+        self.assertEqual(result.returncode, 29)
+        calls = self.log.read_text()
+        self.assertIn("cosign verify", calls)
+        self.assertIn("regctl image get-file", calls)
+        self.assertFalse(self.output.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_release_addon_gate.py
+++ b/scripts/tests/test_release_addon_gate.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from pathlib import Path
+import re
+import unittest
+
+
+WORKFLOW = Path(__file__).parents[2] / ".github" / "workflows" / "release.yml"
+
+
+def job_block(workflow: str, name: str) -> str:
+    match = re.search(
+        rf"(?ms)^  {re.escape(name)}:\n.*?(?=^  [a-z][a-z0-9-]*:\n|\Z)",
+        workflow,
+    )
+    if match is None:
+        raise AssertionError(f"job not found: {name}")
+    return match.group(0)
+
+
+class ReleaseAddonGateTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.workflow = WORKFLOW.read_text()
+
+    def test_release_waits_for_verified_addon_build(self) -> None:
+        create_release = job_block(self.workflow, "create-release")
+        self.assertIn("needs: build-verified-addon", create_release)
+
+    def test_verified_addon_build_waits_for_signing(self) -> None:
+        build_job = job_block(self.workflow, "build-verified-addon")
+        self.assertIn("needs: sign-image", build_job)
+        self.assertIn('version="${RELEASE_TAG#v}"', build_job)
+        self.assertIn('--build-arg "BUILD_VERSION=${version}"', build_job)
+        self.assertIn("eebus-bridge-addon", build_job)
+
+    def test_verified_addon_build_has_read_only_permissions(self) -> None:
+        build_job = job_block(self.workflow, "build-verified-addon")
+        permissions = build_job.split("    steps:", 1)[0]
+        self.assertIn("contents: read", permissions)
+        self.assertNotIn("id-token: write", permissions)
+        self.assertNotIn("packages: write", permissions)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_select_addon_ci_build_version.py
+++ b/scripts/tests/test_select_addon_ci_build_version.py
@@ -49,6 +49,28 @@ class SelectAddonCiBuildVersionTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             select_build_version(VERSION_PATHS, BASE_FILES, head_files)
 
+    def test_rejects_current_shell_payload(self) -> None:
+        head_files = {
+            "custom_components/eebus/manifest.json": (
+                '{"domain":"eebus","version":"0.16.7;$(touch /tmp/pwned)"}\n'
+            ),
+            "eebus-bridge-addon/config.yaml": (
+                'name: EEBUS\nversion: "0.16.7;$(touch /tmp/pwned)"\n'
+            ),
+        }
+
+        with self.assertRaises(ValueError):
+            select_build_version(VERSION_PATHS, BASE_FILES, head_files)
+
+    def test_rejects_base_newline_payload(self) -> None:
+        base_files = dict(BASE_FILES)
+        base_files["eebus-bridge-addon/config.yaml"] = (
+            'name: EEBUS\nversion: "0.16.6\nmalicious"\n'
+        )
+
+        with self.assertRaises(ValueError):
+            select_build_version(VERSION_PATHS, base_files, HEAD_FILES)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/tests/test_select_addon_ci_build_version.py
+++ b/scripts/tests/test_select_addon_ci_build_version.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import unittest
+
+from scripts.select_addon_ci_build_version import (
+    VERSION_PATHS,
+    select_build_version,
+)
+
+
+BASE_FILES = {
+    "custom_components/eebus/manifest.json": '{"domain":"eebus","version":"0.16.6"}\n',
+    "eebus-bridge-addon/config.yaml": 'name: EEBUS\nversion: "0.16.6"\n',
+}
+HEAD_FILES = {
+    "custom_components/eebus/manifest.json": '{"domain":"eebus","version":"0.16.7"}\n',
+    "eebus-bridge-addon/config.yaml": 'name: EEBUS\nversion: "0.16.7"\n',
+}
+
+
+class SelectAddonCiBuildVersionTest(unittest.TestCase):
+    def test_uses_signed_base_for_exact_version_only_change(self) -> None:
+        self.assertEqual(
+            select_build_version(VERSION_PATHS, BASE_FILES, HEAD_FILES), "0.16.6"
+        )
+
+    def test_uses_current_version_for_config_change(self) -> None:
+        head_files = dict(HEAD_FILES)
+        head_files["eebus-bridge-addon/config.yaml"] += "arch:\n  - amd64\n"
+
+        self.assertEqual(
+            select_build_version(VERSION_PATHS, BASE_FILES, head_files), "0.16.7"
+        )
+
+    def test_uses_current_version_when_only_one_version_file_changes(self) -> None:
+        self.assertEqual(
+            select_build_version(
+                {"eebus-bridge-addon/config.yaml"}, BASE_FILES, HEAD_FILES
+            ),
+            "0.16.7",
+        )
+
+    def test_rejects_unsynchronized_current_version_declarations(self) -> None:
+        head_files = dict(HEAD_FILES)
+        head_files["eebus-bridge-addon/config.yaml"] = (
+            'name: EEBUS\nversion: "0.16.8"\n'
+        )
+
+        with self.assertRaises(ValueError):
+            select_build_version(VERSION_PATHS, BASE_FILES, head_files)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_select_addon_ci_build_version.py
+++ b/scripts/tests/test_select_addon_ci_build_version.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
+import subprocess
+import sys
+import tempfile
 import unittest
+from pathlib import Path
 
 from scripts.select_addon_ci_build_version import (
     VERSION_PATHS,
@@ -70,6 +74,69 @@ class SelectAddonCiBuildVersionTest(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             select_build_version(VERSION_PATHS, base_files, HEAD_FILES)
+
+    def _git(self, directory: Path, *args: str) -> str:
+        return subprocess.check_output(
+            ("git", *args), cwd=directory, text=True
+        ).strip()
+
+    def _write_version_files(self, directory: Path, version: str, config_suffix: str = "") -> None:
+        manifest = directory / "custom_components/eebus/manifest.json"
+        config = directory / "eebus-bridge-addon/config.yaml"
+        manifest.parent.mkdir(parents=True, exist_ok=True)
+        config.parent.mkdir(parents=True, exist_ok=True)
+        manifest.write_text(f'{{"domain":"eebus","version":"{version}"}}\n')
+        config.write_text(f'name: EEBUS\nversion: "{version}"\n{config_suffix}')
+
+    def _select_from_git_repository(
+        self, directory: Path, base: str
+    ) -> subprocess.CompletedProcess[str]:
+        selector = Path(__file__).parents[1] / "select_addon_ci_build_version.py"
+        return subprocess.run(
+            (sys.executable, str(selector), "--base", base),
+            cwd=directory,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+    def test_cli_uses_base_for_exact_version_only_git_commit(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            directory = Path(temporary_directory)
+            self._git(directory, "init", "--quiet")
+            self._git(directory, "config", "user.email", "test@example.invalid")
+            self._git(directory, "config", "user.name", "Test User")
+            self._write_version_files(directory, "0.16.6")
+            self._git(directory, "add", ".")
+            self._git(directory, "commit", "--quiet", "-m", "base")
+            base = self._git(directory, "rev-parse", "HEAD")
+            self._write_version_files(directory, "0.16.7")
+            self._git(directory, "add", ".")
+            self._git(directory, "commit", "--quiet", "-m", "version")
+
+            result = self._select_from_git_repository(directory, base)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout, "0.16.6\n")
+
+    def test_cli_uses_current_for_mixed_git_commit(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            directory = Path(temporary_directory)
+            self._git(directory, "init", "--quiet")
+            self._git(directory, "config", "user.email", "test@example.invalid")
+            self._git(directory, "config", "user.name", "Test User")
+            self._write_version_files(directory, "0.16.6")
+            self._git(directory, "add", ".")
+            self._git(directory, "commit", "--quiet", "-m", "base")
+            base = self._git(directory, "rev-parse", "HEAD")
+            self._write_version_files(directory, "0.16.7", "arch:\n  - amd64\n")
+            self._git(directory, "add", ".")
+            self._git(directory, "commit", "--quiet", "-m", "mixed")
+
+            result = self._select_from_git_repository(directory, base)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout, "0.16.7\n")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Resolve the released bridge image tag to a digest, verify that exact digest with Cosign, and extract the bridge binary from that same digest.
- Keep Cosign, regctl, and the verifier script in build-only stages; the final add-on image receives only `/usr/local/bin/eebus-bridge`.
- Gate pull requests and releases with the verified add-on build, retaining least-privilege workflow permissions and coverage for amd64, aarch64, and armv7.

## Architecture and security boundary

The Docker build copies digest-pinned Cosign and regctl into a `verified-bridge` stage. `fetch-verified-bridge.sh` resolves `ghcr.io/volschin/eebus-bridge:v<BUILD_VERSION>` once, verifies that resolved digest with the exact release workflow certificate identity and GitHub Actions OIDC issuer, then uses regctl to extract the binary from that exact digest. The final stage copies only the verified binary.

This rejects registry tag substitution and unsigned or differently signed bridge images. It intentionally does not protect against compromise of the authorized `release.yml` workflow, which is the signing authority.

## Bootstrap and Supervisor acceptance

- Bootstrap `v0.16.6` resolved to `ghcr.io/volschin/eebus-bridge@sha256:67967d35ce24b42a97a503968237c9aaeda15ac320589a8eb579b6caaf134b92` and passed Cosign verification against `https://github.com/volschin/eebus-ha-bridge/.github/workflows/release.yml@refs/tags/v0.16.6` and `https://token.actions.githubusercontent.com`.
- An official Home Assistant apps devcontainer ran a real Supervisor local-app install, explicit start, restart, forced rebuild, negative exact-identity rebuild, restore, and recovery. The negative rebuild failed in the verifier before runtime copy/export; recovery restored a started, host-networked app.
- Unchanged forced/recovery rebuilds may reuse an already successful verifier layer. That cache can preserve only previously verified bytes; the uncached initial install and identity-changing negative rebuild executed Cosign verification.

## Verification

- `git diff --check`
- 23 targeted add-on/version/workflow tests
- version and verifier-tool platform checks
- actionlint on CI and release workflows
- fresh `linux/amd64` add-on Docker build for `BUILD_VERSION=0.16.6`; final image confirmed bridge/runtime entrypoint present and Cosign/regctl absent

## Rollout

After merge, a separate `v0.16.7` release will deliver the verified build path to existing installations.

## Summary by Sourcery

Verify the bridge binary’s signed provenance during add-on builds and gate CI and releases on the resulting image.

New Features:
- Verify released bridge images by immutable digest and exact Cosign GitHub Actions identity before extracting the binary into the add-on.
- Add automated verified add-on image builds for pull requests and releases, including final-image checks and multi-architecture tool coverage.

Bug Fixes:
- Prevent tag substitution, unsigned images, identity mismatches, failed extraction, and invalid outputs from producing an add-on image.

Enhancements:
- Keep Cosign, regctl, and the verifier confined to intermediate build stages while preserving the existing runtime image and supported architectures.
- Select a trusted signed base version for CI builds when version-only changes are under review.

CI:
- Gate release publication on a successful post-signing verified add-on build while retaining least-privilege permissions.

Documentation:
- Document the verified add-on image supply-chain design, security boundary, rollout, and Supervisor acceptance procedure.

Tests:
- Add shell, Dockerfile, platform, CI path, version-selection, and release-gate tests covering success and fail-closed behavior.