### PR TITLE
Rename add-on to app in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,14 +58,14 @@ Home Assistant                    eebus-bridge (Go)         Vaillant VR940f
 Der Go-basierte Bridge-Dienst laeuft als eigener Prozess neben Home Assistant.
 Welcher Weg passt, haengt von der HA-Installationsart ab.
 
-#### Home Assistant OS / Supervised: Add-on
+#### Home Assistant OS / Supervised: App (früher Add-on)
 
-1. **Settings** > **Add-ons** > **Add-on Store** > Drei-Punkte-Menue oben
+1. **Settings** > **Apps** > **App Store** > Drei-Punkte-Menue oben
    rechts > **Repositories**
 2. Repository-URL einfuegen: `https://github.com/volschin/eebus-ha-bridge` >
    **Add**
 3. Store schliessen und neu oeffnen, **EEBUS Bridge** auswaehlen > **Install**
-4. **Start**, danach im Add-on-Log die SKI der Bridge notieren (wird fuer das
+4. **Start**, danach im App-Log die SKI der Bridge notieren (wird fuer das
    Pairing gebraucht)
 
 Die Integration traegt anschliessend `localhost` und Port `50051` ein. Optionen

--- a/eebus-bridge-addon/README.md
+++ b/eebus-bridge-addon/README.md
@@ -1,10 +1,10 @@
-# EEBUS Bridge Add-on
+# EEBUS Bridge App (former Add-on)
 
-Runs the Go EEBUS bridge as a Home Assistant add-on, so Home Assistant OS and
+Runs the Go EEBUS bridge as a Home Assistant app, so Home Assistant OS and
 Supervised users get the `eebus` integration working without a separate Docker
 host.
 
-The add-on is **only** for HA OS / Supervised. HA Core and HA Container
+The app is **only** for HA OS / Supervised. HA Core and HA Container
 installations keep running the bridge via `docker-compose` — see the project
 [README](../README.md).
 


### PR DESCRIPTION
Updated the README to reflect the change from 'Add-on' to 'App' and clarified installation instructions.

## Summary by Sourcery

Update the documentation to reflect Home Assistant’s transition from Add-ons to Apps.

Enhancements:
- Update Home Assistant documentation to use the current “App” terminology and clarify installation and log references.
- Rename the bridge component documentation from Add-on to App while retaining compatibility context for the former name.

Documentation:
- Refresh README installation instructions for Home Assistant Apps and explain that the App was formerly called an Add-on.